### PR TITLE
Codify the structural-change checklist: catch silently orphaned rows

### DIFF
--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -398,6 +398,69 @@ set converges to empty.
 
 ---
 
+## Structural-change checklist (split / merge / retire / re-date / create)
+
+A **structural change** is any edit that changes which polities exist or when
+they exist: creating a polity, splitting a chain into periods, merging two rows,
+retiring/superseding a row, or moving a start/end year. It silently re-routes
+data, because the matcher resolves a label by alias → iso3 family + year
+containment → name, and none of that is visible in the wiki diff. Four real
+failures from one session:
+
+| what happened | which step catches it |
+|---|---|
+| the Indonesia merge renamed a row to "Dutch East Indies" and **orphaned 23 rows** that had resolved by NAME | 7 |
+| the India split typed the new rows `colonial`, so Hyderabad **outranked them and took 36 rows** | 9 |
+| the Newfoundland fix put 54 rows of 1948 Canadian data on the wrong side of a boundary — **the total was unchanged** | 6 |
+| `ETH-1936-1941` shipped `polygon_area_km2: 1000000`, a rounded placeholder | 3 |
+
+Run the snapshot **before** touching anything — after the edit there is nothing
+left to compare against:
+
+```bash
+python3 scripts/structural_change_check.py --snapshot   # BEFORE the edit
+#   ... make the change (steps 1-4 below) ...
+python3 scripts/structural_change_check.py --compare    # AFTER
+```
+
+### The eleven steps
+
+| # | step | who |
+|---|---|---|
+| 0 | `scripts/structural_change_check.py --snapshot` — per-polity matched-row counts, total, resolving labels, areas | script |
+| 1 | Write/edit the wiki page(s): frontmatter **and** body, which can contradict each other; say what changed and why | **human/agent** |
+| 2 | `python3 scripts/build_database.py` — rebuilds CSV+GPKG and asserts the row count | mechanical |
+| 3 | Verify the attached geometry measures what the page claims (equal-area `ESRI:54034`); never write a round placeholder area | mechanical (step 10 checks it) |
+| 4 | Mark superseded rows `wiki_status: superseded` **and** `polygon_status: unassigned` | **human/agent** |
+| 5 | Re-run the matcher; confirm the **total match count did not drop** | `--compare` §1 |
+| 6 | Confirm per-polity counts moved **as intended**, not merely that the total held | `--compare` §2/§3 — reported as REVIEW; only a human can say the movement was the intended one |
+| 7 | If the entity's **name** changed, confirm labels that resolved by name still resolve — otherwise add an alias | `--compare` §4 |
+| 8 | If a FAOSTAT-era alias targeted a changed code, re-run `pipelines/faostat-era-matching/match.R --accept-diff` | **human/agent** (needs R + FAOSTAT bulk data) |
+| 9 | `scripts/audit_family_shadowing.py` — a new row can tie with an existing one on type rank | `--compare` §6 |
+| 10 | `scripts/validate_polygons.py`, `scripts/validate_citations.py`, placeholder-area scan | `--compare` §5/§6 (+ CI for the first two) |
+| 11 | A `wiki/log.md` entry of kind `decision`, **naming the human who signed off** | **human only** — never an agent's call |
+
+Steps 1, 4, 8 and 11 stay human. Everything else the script does, and it exits
+non-zero on: a dropped total, a polity that went from data to zero rows, a label
+that stopped resolving, a round `polygon_area_km2` this change introduced, or a
+non-zero exit from the shadowing/polygon validators. Per-polity movement and
+pre-existing round areas are reported as `REVIEW`, not `FAIL` — they need a
+judgement the script cannot make.
+
+### Why it is not in CI
+
+`--compare` needs matched-row counts, which need `01_match_and_findings.py`,
+which reads the consolidated layer-B dataset (`WHEP_LAYERB`, ~190k rows) from
+personal Nextcloud — not redistributable, so CI cannot see it. It is therefore a
+**local** pre/post-change tool and is deliberately absent from
+`.github/workflows/validate.yml`; CI keeps running the data-free validators
+(`validate_citations`, `build_database --check`, `validate_polygons`,
+`audit_family_shadowing`). Issue #17 tracks the CI limitation. The snapshot
+lands in `state/structural_snapshot.json`, gitignored like the other per-run
+artefacts.
+
+---
+
 ## Status / provenance
 
 Methodology authored 2026-06-23. The deterministic detectors and the

--- a/pipelines/polity-autoimprove/state/.gitignore
+++ b/pipelines/polity-autoimprove/state/.gitignore
@@ -5,6 +5,7 @@ territorial_flagged.json
 run_report.md
 assertions.json
 verdicts_pending*.json
+structural_snapshot.json
 # Persistent state below is committed: review_ledger.csv, applied_aliases.csv
 match_confidence.csv
 audit_sample.csv

--- a/scripts/structural_change_check.py
+++ b/scripts/structural_change_check.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Guard a STRUCTURAL change to the polity set: prove no data row was lost.
+
+Creating, splitting, merging, retiring or re-dating a polity re-routes the data
+that matches it. The matcher resolves a label by alias, then by iso3 family +
+year containment, then by name; a structural edit can therefore move rows that
+were never mentioned on the page being edited. Every failure below is real, from
+one session, and every one was invisible in the wiki diff:
+
+  * The Indonesia merge renamed a row to "Dutch East Indies" and silently
+    ORPHANED 23 rows whose label had resolved by NAME. Nothing pointed at the
+    old name any more, so those rows simply stopped matching.
+  * The India split typed the new rows `colonial`, so HYD-1724-1948 (Hyderabad,
+    a princely state) outranked them on the family preference and took 36 rows
+    of plainly national "india" data.
+  * The Newfoundland fix moved 54 rows of 1948 Canadian data to the wrong side
+    of a boundary. The TOTAL matched count was unchanged — only a PER-POLITY
+    diff exposed it.
+  * ETH-1936-1941 shipped with `polygon_area_km2: 1000000`, a rounded
+    placeholder that no equal-area measurement would ever produce.
+
+So a total-count check is not enough, and a wiki review is not enough. This
+script is the mechanical half of the structural-change checklist (the checklist
+itself, including the human steps, is in
+pipelines/polity-autoimprove/README.md, "Structural-change checklist").
+
+Workflow — snapshot BEFORE the edit, compare AFTER:
+
+    python3 scripts/structural_change_check.py --snapshot
+    ... edit the wiki page(s), run scripts/build_database.py ...
+    python3 scripts/structural_change_check.py --compare
+
+`--snapshot` re-runs the matcher and records per-polity matched-row counts, the
+total, and which labels currently match. `--compare` re-runs the matcher and
+reports:
+
+  1. TOTAL matched rows, before vs after — a DROP is a FAILURE (rows orphaned).
+  2. PER-POLITY movement, biggest first — the Newfoundland case. Not auto-
+     judgeable: a human confirms each movement was the intended one.
+  3. Polities that received rows before and now receive ZERO — a row was
+     superseded without its data being re-routed.
+  4. Labels that became UNMATCHED — the rename-orphans-a-label case.
+
+then runs the mechanical checks that must follow any structural change:
+`scripts/audit_family_shadowing.py`, `scripts/validate_polygons.py`, and a scan
+for placeholder-looking `polygon_area_km2` values (exact multiples of 100,000 —
+a measured equal-area figure is never that round). The snapshot records areas
+too, so a round value THIS change introduced or altered blocks, while one that
+already sat in the database is reported as pre-existing cleanup.
+
+NOT IN CI, deliberately. Getting matched-row counts requires the matcher, which
+reads the consolidated layer-B dataset from personal Nextcloud
+(`WHEP_LAYERB`, ~190k rows, not redistributable). CI has no access to it, so
+this is a LOCAL pre/post-change tool and is intentionally absent from
+.github/workflows/validate.yml. Issue #17 tracks that CI limitation.
+
+Usage:
+  python3 scripts/structural_change_check.py --snapshot [--no-rematch]
+  python3 scripts/structural_change_check.py --compare  [--no-rematch] [--top N]
+                                                        [--skip-checks]
+Exit 1 if the comparison fails (or, with --snapshot, if the snapshot could not
+be taken).
+"""
+import argparse, json, os, subprocess, sys, time
+import pandas as pd
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATE = os.path.join(REPO, "pipelines/polity-autoimprove/state")
+MATCHER = os.path.join(REPO, "pipelines/polity-autoimprove/01_match_and_findings.py")
+MATCHED = os.path.join(STATE, "matched_rows.parquet")
+SNAPSHOT = os.path.join(STATE, "structural_snapshot.json")   # gitignored per-run artefact
+POLDB = os.path.join(REPO, "data/final/polities_database.csv")
+DEAD = ("retired", "superseded")
+
+ap = argparse.ArgumentParser()
+g = ap.add_mutually_exclusive_group(required=True)
+g.add_argument("--snapshot", action="store_true",
+               help="record the pre-change per-polity matched-row counts")
+g.add_argument("--compare", action="store_true",
+               help="re-run the matcher and diff against the snapshot")
+ap.add_argument("--no-rematch", action="store_true",
+                help="reuse the existing state/matched_rows.parquet instead of re-running the matcher")
+ap.add_argument("--top", type=int, default=40,
+                help="how many per-polity movements to print (default 40)")
+ap.add_argument("--skip-checks", action="store_true",
+                help="skip the follow-up mechanical checks (shadowing, polygons, placeholder areas)")
+A = ap.parse_args()
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+def run_matcher():
+    """Re-run 01_match_and_findings.py so matched_rows.parquet reflects the tree."""
+    if A.no_rematch:
+        if not os.path.exists(MATCHED):
+            sys.exit(f"FAIL: --no-rematch but {os.path.relpath(MATCHED, REPO)} does not exist")
+        age = (time.time() - os.path.getmtime(MATCHED)) / 60
+        print(f"reusing {os.path.relpath(MATCHED, REPO)} ({age:.0f} min old)")
+        return
+    print(f"running the matcher ({os.path.relpath(MATCHER, REPO)}) ...")
+    r = subprocess.run([sys.executable, MATCHER], cwd=REPO,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        print(r.stdout[-3000:]); print(r.stderr[-3000:])
+        sys.exit("FAIL: the matcher did not run. It needs the layer-B dataset "
+                 "(WHEP_LAYERB); this script cannot work without it.")
+    for line in r.stdout.splitlines():
+        if line.startswith(("Stage 0:", "bare-iso", "excluded from matching")):
+            print("  " + line)
+
+
+def counts():
+    """Per-polity matched-row counts, the total, matching labels, and areas."""
+    df = pd.read_parquet(MATCHED)
+    m = df[df.whep_code.notna()]
+    per = m.groupby("whep_code").size().sort_values(ascending=False)
+    # a label is the (entity, iso-in-data) pair the matcher routes; keep the
+    # pairs that currently resolve, so a rename that orphans one is visible
+    lab = m[["country", "iso3c"]].fillna("").astype(str).drop_duplicates()
+    labels = sorted({f"{c}\t{i}" for c, i in lab.itertuples(index=False)})
+    p = pd.read_csv(POLDB, keep_default_na=False, na_values=[""])
+    area = pd.to_numeric(p.polygon_area_km2, errors="coerce")
+    return {
+        "total_rows": int(len(df)),
+        "matched_rows": int(len(m)),
+        "per_polity": {k: int(v) for k, v in per.items()},
+        "labels": labels,
+        "areas": {c: (None if pd.isna(v) else float(v))
+                  for c, v in zip(p.polity_code, area)},
+    }
+
+
+def names():
+    p = pd.read_csv(POLDB, keep_default_na=False, na_values=[""])
+    return (dict(zip(p.polity_code, p.polity_name)),
+            dict(zip(p.polity_code, p.wiki_status.astype(str))))
+
+
+# ---------------------------------------------------------------- snapshot
+if A.snapshot:
+    run_matcher()
+    snap = counts()
+    snap["taken_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
+    snap["git_head"] = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=REPO,
+                                      capture_output=True, text=True).stdout.strip()
+    json.dump(snap, open(SNAPSHOT, "w"), indent=1)
+    section("SNAPSHOT TAKEN")
+    print(f"  {snap['matched_rows']:,} matched rows of {snap['total_rows']:,} "
+          f"({100*snap['matched_rows']/snap['total_rows']:.2f}%)")
+    print(f"  {len(snap['per_polity']):,} polities receive data; "
+          f"{len(snap['labels']):,} labels resolve")
+    print(f"  written to {os.path.relpath(SNAPSHOT, REPO)}  (HEAD {snap['git_head']})")
+    print("\nPASS: snapshot recorded. Make the structural change, run "
+          "scripts/build_database.py, then re-run with --compare.")
+    sys.exit(0)
+
+# ---------------------------------------------------------------- compare
+if not os.path.exists(SNAPSHOT):
+    sys.exit(f"FAIL: no snapshot at {os.path.relpath(SNAPSHOT, REPO)} — run "
+             f"--snapshot BEFORE making the structural change.")
+before = json.load(open(SNAPSHOT))
+run_matcher()
+after = counts()
+name, status = names()
+fails, reviews = [], []
+
+
+def label(code):
+    return f"{code:18s} {str(name.get(code, '?'))[:38]:38s}"
+
+
+# 1. total ------------------------------------------------------------------
+section("1. TOTAL MATCHED ROWS")
+b, a = before["matched_rows"], after["matched_rows"]
+print(f"  snapshot ({before.get('taken_at')}, HEAD {before.get('git_head')}): {b:,}")
+print(f"  now:                                        {a:,}")
+print(f"  delta: {a-b:+,}   (of {after['total_rows']:,} non-aggregate rows)")
+if a < b:
+    fails.append(f"total matched rows DROPPED by {b-a:,} — those rows were orphaned")
+    print(f"  FAIL: {b-a:,} rows no longer match any polity")
+elif a > b:
+    print(f"  OK: {a-b:,} more rows match than before")
+else:
+    print("  OK: total unchanged — but see section 2, the total alone hides "
+          "rows moving to the WRONG polity")
+
+# 2. per-polity movement ----------------------------------------------------
+section("2. PER-POLITY MOVEMENT (biggest first)")
+bp, apc = before["per_polity"], after["per_polity"]
+moved = []
+for code in set(bp) | set(apc):
+    d = apc.get(code, 0) - bp.get(code, 0)
+    if d: moved.append((abs(d), d, code))
+moved.sort(reverse=True)
+print(f"  {len(moved)} polity/polities changed row count "
+      f"(gained {sum(d for _, d, _ in moved if d > 0):+,} / "
+      f"lost {sum(d for _, d, _ in moved if d < 0):+,})")
+if moved:
+    print()
+    for _, d, code in moved[:A.top]:
+        tag = "NEW " if code not in bp else ("GONE" if apc.get(code, 0) == 0 else "    ")
+        print(f"   {tag} {d:+7,}  {label(code)} {bp.get(code,0):>7,} -> {apc.get(code,0):>7,}")
+    if len(moved) > A.top:
+        print(f"   ... {len(moved)-A.top} more (raise --top to see them)")
+    reviews.append(f"{len(moved)} polity/polities changed row count — confirm EACH "
+                   f"movement is the intended one (the Newfoundland case had an "
+                   f"unchanged total and rows on the wrong side of a boundary)")
+
+# 3. polities that went to zero --------------------------------------------
+section("3. POLITIES THAT NOW RECEIVE ZERO ROWS (but did before)")
+zeroed = sorted(((bp[c], c) for c in bp if apc.get(c, 0) == 0), reverse=True)
+print(f"  {len(zeroed)} polity/polities")
+for n, code in zeroed[:A.top]:
+    print(f"   FAIL {n:>7,} rows lost  {label(code)} wiki_status={status.get(code,'?')}")
+if zeroed:
+    fails.append(f"{len(zeroed)} polity/polities lost ALL their data "
+                 f"({sum(n for n, _ in zeroed):,} rows) — a row was superseded "
+                 f"without its data being re-routed to the successor")
+
+# 4. labels that became unmatched ------------------------------------------
+section("4. LABELS THAT BECAME UNMATCHED")
+lost = sorted(set(before["labels"]) - set(after["labels"]))
+gained = len(set(after["labels"]) - set(before["labels"]))
+print(f"  {len(lost)} label(s) stopped resolving; {gained} newly resolve")
+if lost:
+    # how many rows those labels carry now, so the cost is explicit
+    df = pd.read_parquet(MATCHED)
+    key = df.country.fillna("").astype(str) + "\t" + df.iso3c.fillna("").astype(str)
+    n_rows = df.assign(_k=key).groupby("_k").size()
+    for k in lost[:A.top]:
+        c, i = k.split("\t")
+        print(f"   FAIL {n_rows.get(k, 0):>7,} rows  label={c!r} iso={i or '-'}  "
+              f"(resolved before, now unmatched — add an alias for the old name)")
+    fails.append(f"{len(lost)} label(s) that resolved before are now UNMATCHED — "
+                 f"a rename orphaned them (add an alias, do not leave the rows adrift)")
+
+# ---------------------------------------------------------------- mechanical follow-ups
+if not A.skip_checks:
+    section("5. PLACEHOLDER polygon_area_km2")
+    p = pd.read_csv(POLDB, keep_default_na=False, na_values=[""])
+    live = p[~p.wiki_status.astype(str).isin(DEAD)].copy()
+    live["area"] = pd.to_numeric(live.polygon_area_km2, errors="coerce")
+    ar = live[live.area.notna() & (live.area > 0)]
+    place = ar[ar.area % 100_000 == 0]
+    suspect = ar[(ar.area % 10_000 == 0) & (ar.area % 100_000 != 0)]
+    print(f"  {len(ar):,} live polities carry an area; a measured equal-area figure "
+          f"(ESRI:54034) is never an exact multiple of 100,000")
+    # only areas THIS change introduced or altered block: pre-existing round
+    # figures are a separate cleanup, not this change's regression
+    was = before.get("areas", {})
+    new_place = [r for r in place.itertuples() if was.get(r.polity_code) != r.area]
+    old_place = [r for r in place.itertuples() if was.get(r.polity_code) == r.area]
+    for r in new_place:
+        print(f"   FAIL {r.area:>12,.0f} km2  {label(r.polity_code)} <- placeholder "
+              f"introduced/changed by this change; re-measure the attached geometry")
+    for r in old_place:
+        print(f"   WARN {r.area:>12,.0f} km2  {label(r.polity_code)} <- rounded, but "
+              f"predates this change (pre-existing placeholder; fix separately)")
+    for r in suspect.itertuples():
+        tag = "FAIL" if was.get(r.polity_code) != r.area else "WARN"
+        print(f"   {tag} {r.area:>12,.0f} km2  {label(r.polity_code)} <- suspiciously "
+              f"round (multiple of 10,000); confirm it was measured")
+    new_suspect = [r for r in suspect.itertuples() if was.get(r.polity_code) != r.area]
+    if new_place:
+        fails.append(f"{len(new_place)} polity/polities carry a rounded placeholder "
+                     f"polygon_area_km2 introduced by this change "
+                     f"(ETH-1936-1941's 1000000 case)")
+    if new_suspect:
+        fails.append(f"{len(new_suspect)} suspiciously round area(s) (multiple of "
+                     f"10,000) introduced by this change")
+    if old_place or (len(suspect) - len(new_suspect)):
+        reviews.append(f"{len(old_place) + len(suspect) - len(new_suspect)} "
+                       f"pre-existing round area(s) — cleanup, not this change")
+
+    for script in ("audit_family_shadowing.py", "validate_polygons.py"):
+        section(f"6. {script}")
+        r = subprocess.run([sys.executable, os.path.join(REPO, "scripts", script)],
+                           cwd=REPO, capture_output=True, text=True)
+        out = (r.stdout or "").rstrip().splitlines()
+        for line in out[-30:]: print("  " + line)
+        if r.returncode != 0:
+            if r.stderr.strip(): print("  " + r.stderr.strip()[-1500:])
+            fails.append(f"{script} exited {r.returncode} — a structural change "
+                         f"broke it (new row ties on type rank / geometry claim)")
+else:
+    print("\n(mechanical follow-up checks skipped: --skip-checks)")
+
+# ---------------------------------------------------------------- verdict
+section("VERDICT")
+for f in fails:    print(f"  FAIL    {f}")
+for r in reviews:  print(f"  REVIEW  {r}")
+if not fails and not reviews:
+    print("  nothing moved, nothing flagged"
+          + ("  (follow-up checks were skipped)" if A.skip_checks else ""))
+print("\nStill HUMAN, not checkable here (see the checklist in "
+      "pipelines/polity-autoimprove/README.md):")
+print("  * the wiki page body and frontmatter agree, and say what changed and why")
+print("  * a wiki/log.md entry of kind `decision` naming who signed off")
+print(f"\n{'FAIL' if fails else 'PASS'}: {len(fails)} blocking problem(s), "
+      f"{len(reviews)} item(s) needing human confirmation")
+sys.exit(1 if fails else 0)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -327,6 +327,17 @@ Prompts for each workflow live in `wiki/prompts/`:
   `git push`, no closed-access source acquisition, no `draft → reviewed`
   status changes unless schema requirements are met).
 
+**Splitting, merging, retiring, re-dating or creating a polity** is a
+*structural* change: it silently re-routes the data rows that match the affected
+polities, and the wiki diff shows none of that. Follow the eleven-step
+**structural-change checklist** in
+[`pipelines/polity-autoimprove/README.md`](../pipelines/polity-autoimprove/README.md#structural-change-checklist-split--merge--retire--re-date--create)
+— snapshot the per-polity row counts *before* the edit with
+`python3 scripts/structural_change_check.py --snapshot`, then `--compare` after.
+The checklist lives with the pipeline because its central check needs the matcher
+and the layer-B dataset; the human steps (writing the page, the `log.md`
+`decision` entry naming who signed off) are recorded there alongside.
+
 ## Rules for the agent
 
 1. **Never invent citations.** If a claim has no source in `wiki/sources/`,


### PR DESCRIPTION
Structural changes to the polity set — create, split, merge, retire, re-date — re-route data rows invisibly. The matcher resolves a label by alias → iso3 family + year containment → name, so an edit can move rows that were never mentioned on the page being edited. All four failures in the issue were invisible in the wiki diff.

## What this adds

`scripts/structural_change_check.py`, a snapshot/compare tool:

```bash
python3 scripts/structural_change_check.py --snapshot   # BEFORE the edit
#   ... edit the wiki page(s), run scripts/build_database.py ...
python3 scripts/structural_change_check.py --compare    # AFTER
```

`--snapshot` re-runs `01_match_and_findings.py` and records per-polity matched-row counts, the total, the set of resolving `(entity, iso)` labels, and every `polygon_area_km2`. `--compare` re-runs the matcher and reports:

1. **TOTAL matched rows** before vs after — a drop is a FAIL (rows orphaned).
2. **PER-POLITY movement**, biggest first — the Newfoundland case, where the total held and 54 rows sat on the wrong side of a boundary. Reported as REVIEW: only a human can say the movement was the intended one.
3. **Polities that received rows and now receive zero** — a row superseded without its data re-routed.
4. **Labels that became UNMATCHED** — the Indonesia rename that orphaned 23 name-resolved rows.

then the mechanical follow-ups: `audit_family_shadowing.py` (the Hyderabad/type-rank case), `validate_polygons.py`, and a placeholder-area scan (exact multiples of 100,000 — the `ETH-1936-1941: 1000000` case). Only a round area *this change* introduced or altered blocks; pre-existing round figures are reported as separate cleanup, so the tool measures the change rather than the backlog.

The eleven-step checklist itself is in `pipelines/polity-autoimprove/README.md` — it lives with the pipeline because its central check needs that pipeline's matcher and the layer-B dataset — mapping each step to script-or-human, and keeping the human-only steps explicit: writing the page (frontmatter *and* body), marking superseded rows, the FAOSTAT-era rematch, and the `wiki/log.md` `decision` entry **naming who signed off**. `wiki/README.md` points at it from the page-editing side.

## Deliberately not in CI

`--compare` needs matched-row counts, which need `01_match_and_findings.py`, which reads the consolidated layer-B dataset (`WHEP_LAYERB`, ~190k rows) from personal Nextcloud — not redistributable, so CI cannot see it. This is a local pre/post-change tool and is **not** added to `.github/workflows/validate.yml`; CI keeps running the data-free validators. #17 tracks that limitation. The snapshot lands in `pipelines/polity-autoimprove/state/structural_snapshot.json`, gitignored like the other per-run artefacts.

## Negative test (the change it caught)

Temporarily renamed `SWA-1912-1958` "Spanish West Africa (1912-1958)" → "TESTRENAME Atlantic Coast Colony (1912-1958)" (its 2 data rows resolve by NAME, and its `iso3: SWA` matches nothing in the data) and set `polygon_area_km2: 200000`, then rebuilt the database:

```
=== 1. TOTAL MATCHED ROWS ===
  snapshot (2026-07-28 14:09:56, HEAD 9deb5d8): 189,694
  now:                                        189,692
  delta: -2   (of 190,529 non-aggregate rows)
  FAIL: 2 rows no longer match any polity

=== 2. PER-POLITY MOVEMENT (biggest first) ===
  1 polity/polities changed row count (gained +0 / lost -2)

   GONE      -2  SWA-1912-1958      TESTRENAME Atlantic Coast Colony (1912       2 ->       0

=== 3. POLITIES THAT NOW RECEIVE ZERO ROWS (but did before) ===
  1 polity/polities
   FAIL       2 rows lost  SWA-1912-1958      TESTRENAME Atlantic Coast Colony (1912 wiki_status=draft

=== 4. LABELS THAT BECAME UNMATCHED ===
  1 label(s) stopped resolving; 0 newly resolve
   FAIL       2 rows  label='Spanish West Africa' iso=-  (resolved before, now unmatched — add an alias for the old name)

=== 5. PLACEHOLDER polygon_area_km2 ===
  176 live polities carry an area; a measured equal-area figure (ESRI:54034) is never an exact multiple of 100,000
   FAIL      200,000 km2  SWA-1912-1958      TESTRENAME Atlantic Coast Colony (1912 <- placeholder introduced/changed by this change; re-measure the attached geometry
   WARN    1,700,000 km2  AOI-1936-1941      Italian East Africa (1936-1941)        <- rounded, but predates this change (pre-existing placeholder; fix separately)
   WARN      500,000 km2  CAN-1866-1870      Canada (original four provinces, 1866– <- rounded, but predates this change (pre-existing placeholder; fix separately)
   WARN      290,000 km2  ADE-1839-1963      Aden Protectorate (1839-1963)          <- suspiciously round (multiple of 10,000); confirm it was measured

=== VERDICT ===
  FAIL    total matched rows DROPPED by 2 — those rows were orphaned
  FAIL    1 polity/polities lost ALL their data (2 rows) — a row was superseded without its data being re-routed to the successor
  FAIL    1 label(s) that resolved before are now UNMATCHED — a rename orphaned them (add an alias, do not leave the rows adrift)
  FAIL    1 polity/polities carry a rounded placeholder polygon_area_km2 introduced by this change (ETH-1936-1941's 1000000 case)
  REVIEW  1 polity/polities changed row count — confirm EACH movement is the intended one (the Newfoundland case had an unchanged total and rows on the wrong side of a boundary)
  REVIEW  3 pre-existing round area(s) — cleanup, not this change

FAIL: 4 blocking problem(s), 2 item(s) needing human confirmation
```

Four of the classes at once — including the Indonesia case (§4) and the ETH placeholder case (§5). After reverting the test edit and rebuilding, `--compare` is clean:

```
=== 1. TOTAL MATCHED ROWS ===  delta: +0   (of 190,529 non-aggregate rows)
=== 2. PER-POLITY MOVEMENT ===  0 polity/polities changed row count
=== 3. ZERO ROWS ===            0 polity/polities
=== 4. LABELS UNMATCHED ===     0 label(s) stopped resolving; 0 newly resolve
PASS: 0 blocking problem(s), 1 item(s) needing human confirmation   (the pre-existing round areas)
```

The three pre-existing round areas (`AOI-1936-1941` 1,700,000; `CAN-1866-1870` 500,000; `ADE-1839-1963` 290,000) are a real finding this surfaced — worth a separate re-measure, not a blocker here.

## Validators on the final tree

`validate_citations.py`, `build_database.py --check`, `update_wiki_index.py --check`, `validate_polygons.py`, `audit_family_shadowing.py` — all PASS. Working tree clean of the test edit (the rebuilt GPKG was reverted; only the script, the two READMEs and `state/.gitignore` are committed).

Closes #28
