### PR TITLE
Document the four gates that were running in CI undocumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ python3 scripts/validate_iso_collisions.py
 python3 scripts/validate_cow_codes.py
 python3 scripts/validate_cross_family_names.py
 python3 scripts/validate_period_overlaps.py
+python3 scripts/validate_period_gaps.py
 python3 scripts/validate_reporting_areas.py
 python3 scripts/validate_code_year_agreement.py
+python3 scripts/validate_references.py
+python3 scripts/validate_map_area_year.py
+python3 scripts/validate_alias_year_coverage.py
 
 # geometry
 python3 scripts/validate_polygons.py


### PR DESCRIPTION
**`main`'s CI has been red since 2026-08-04T17:26** and I did not notice.

```
FAIL: 1 problem(s)
  4 gate script(s) run in CI but are not named in README.md:
    ['validate_alias_year_coverage.py', 'validate_map_area_year.py',
     'validate_period_gaps.py', 'validate_references.py']
```

## Why it went unnoticed

`selftest_gates.py` enforces that every gate wired into `validate.yml` is listed in the README, so a check cannot be added silently and then quietly removed. I added those four gates in earlier PRs (#76, #78, #80) and never listed them.

The meta-gate did exactly its job. I ignored it — because I was running validators **individually** and never ran the one that checks the others. "I ran the gates" meant 14 of the 24 that exist. A green local suite is not a green CI.

## The fix

The four are now listed under *identity and periodisation* in the README's gate block. `selftest_gates.py` passes:

```
every gate runs in CI and is named in the README (24 scripts)
PASS: 11 gate(s) fail on an injected defect and name it, and every gate runs in CI
```

## Still outstanding, deliberately kept separate

That `11 gate(s)` is the remaining gap: those four have **no injected-defect case** in `selftest_gates.py`, so the self-test proves 11 of 24 gates can fail, not 24. Each was mutation-tested by hand in its own PR — but by hand is not by CI, which is the whole premise of the self-test. Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ