### PR TITLE
Clear the six baselines tonight's fixes emptied, and regenerate the alias map

### DIFF
--- a/data/final/label_alias_map.csv
+++ b/data/final/label_alias_map.csv
@@ -679,7 +679,7 @@ serbia,,1945,1947,F248-1920-1947,Yugoslavia (1945-1947) — serbia sub-territory
 serbia,,1947,1991,F248-1947-1991,Yugoslavia (1947-1991) — serbia sub-territory data approximation,low,
 serbia,,1991,1992,F248-1991-1992,Serbia within Yugoslavia/SFR dissolution (1991-1992),medium,
 serbia,,1992,2006,SCG-1992-2006,Serbia within Federal Republic of Yugoslavia / Serbia and Montenegro,medium,
-serbia,,2006,2008,SER-2006-2008,Serbia (2006-2008 pre-independence),medium,
+serbia,,2006,2008,SRB-2006-2008,Serbia (2006-2008 pre-independence),medium,
 serbia,,2008,2025,SRB-2008-2025,,medium,
 Serbia,faostat,2006,2007,SRB-2006-2008,Serbia (including Kosovo),high,68875
 Serbia,faostat,2008,2024,SRB-2008-2025,Serbia,high,68875

--- a/data/final/polities_manifest.json
+++ b/data/final/polities_manifest.json
@@ -150,7 +150,7 @@
  },
  "label_alias_map": {
   "path": "data/final/label_alias_map.csv",
-  "sha256": "3dbd9c078c1c83741006bd1159c1fa3b64ec2f45871d007492d70a7d4bea31b6",
+  "sha256": "4e6457f9530252229b244990cc8d3f2e265a00ba06c3395576f43bc79a865f9c",
   "aliases": 869,
   "labels": 470,
   "sources": [

--- a/scripts/crosscheck_matchers.py
+++ b/scripts/crosscheck_matchers.py
@@ -46,7 +46,10 @@ PUBLISHED = os.path.join(REPO, "data/final/faostat_area_polity_map.csv")
 
 # Known disagreements, by FAOSTAT area code. Each is an open defect, not an
 # accepted difference — see the issues named above.
-BASELINE_DIFFERENT = {131, 237, 272}
+# 272 removed 2026-08-05: retiring the duplicate SER-2006-2008 (issue 43, PR 86) left
+# one Serbia row for 2006-2007, so match.R and matchlib now agree on area 272. The
+# disagreement was a SYMPTOM of the duplicate, not an independent matcher bug.
+BASELINE_DIFFERENT = {131, 237}
 
 # Labels matchlib cannot resolve without the faostat alias, so an explicit route is
 # REQUIRED. One area, and it is genuinely nominal: the Yugoslav SFR chain sits under

--- a/scripts/validate_alias_year_baseline.txt
+++ b/scripts/validate_alias_year_baseline.txt
@@ -239,7 +239,7 @@ serbia		SER-1816-1878
 serbia		SER-1878-1913
 serbia		SER-1913-1918
 serbia		SER-1918-1945
-serbia		SER-2006-2008
+serbia		SRB-2006-2008
 serbia		SRB-2008-2025
 south africa		ZAF-1910-2025
 south africa	iia	ZAF-1910-2025

--- a/scripts/validate_cow_codes.py
+++ b/scripts/validate_cow_codes.py
@@ -36,8 +36,8 @@ DEAD_STATUS = ("retired", "superseded")
 # (cow_code, earlier polity, later polity) for every pair already sharing a code over overlapping
 # years. Generated from the database, not hand-listed.
 BASELINE = frozenset({
-    ("135", "PER-1825-1884", "PER-1825-1909"),
-    ("135", "PER-1825-1909", "PER-1884-1909"),
+    # PER pairs removed 2026-08-05: PER-1825-1909 is superseded (issue 49).
+
     ("220", "FRA-1800-1871", "FRIN-1816-1954"),
     ("220", "FRIN-1816-1954", "FRA-1871-1919"),
     ("220", "FRIN-1816-1954", "FRA-1919-2025"),
@@ -46,7 +46,8 @@ BASELINE = frozenset({
     ("260", "WZO-1938-1949", "DEU-1945-1949"),
     ("325", "ITA-1870-1919", "ITAEG-1912-1947"),
     ("325", "ITAEG-1912-1947", "ITA-1919-2025"),
-    ("341", "MNE-1913-1915", "MNE-1913-1918"),
+    # MNE pair removed 2026-08-05: MNE-1913-1915 is retired (issue 62).
+
     ("380", "SNW-1814-1905", "SWE-1814-1905"),
     ("385", "NOR-1800-2025", "NNI-1899-1904"),
     ("385", "NOR-1800-2025", "NNI-1904-1913"),

--- a/scripts/validate_cross_family_names.py
+++ b/scripts/validate_cross_family_names.py
@@ -46,8 +46,13 @@ POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
 DEAD_STATUS = ("retired", "superseded")
 
 BASELINE = frozenset({
-    ("MAR-1911-1958", "MOR-1956-1958"),
-    ("SER-2006-2008", "SRB-2006-2008"),
+    # Both pairs removed 2026-08-05, fixed rather than accepted:
+    #   MOR-1956-1958 retired as a duplicate of MAR-1911-1958 (issue 82, PR 83)
+    #   SER-2006-2008 retired as a duplicate of SRB-2006-2008 (issue 43, PR 86)
+    # Both were CROSS-FAMILY duplicates, which is why validate_period_overlaps could
+    # not see either: it compares periods within one prefix. This check saw them
+    # because it compares NAMES, which is the argument for keeping a name-keyed view.
+
     ("TAN-1922-1964", "TZA-1961-1964"),
 })
 

--- a/scripts/validate_iso_collisions.py
+++ b/scripts/validate_iso_collisions.py
@@ -80,7 +80,8 @@ BASELINE = frozenset({
     ("LBY", "TRP-1943-1951", "CYR-1949-1951"),
     ("LBY", "TRP-1943-1951", "LBY-1950-1951"),
     ("MMR", "MMR-1852-1885", "MMR-LWR-1852-1885"),
-    ("MNE", "MNE-1913-1915", "MNE-1913-1918"),
+    # MNE pair removed 2026-08-05: MNE-1913-1915 is retired (issue 62).
+
     ("MYS", "BNB-1881-1963", "GBM-1895-1946"),
     ("MYS", "BNB-1881-1963", "MASG-1946-1963"),
     ("MYS", "BNB-1881-1963", "MYS-1946-1957"),
@@ -94,8 +95,9 @@ BASELINE = frozenset({
     ("MYS", "MYS-1946-1957", "MASG-1946-1963"),
     ("NGA", "NUP-1800-1897", "NGA-1886-1914"),
     ("PAN", "CZN-1903-1979", "PAN-1903-1979"),
-    ("PER", "PER-1825-1884", "PER-1825-1909"),
-    ("PER", "PER-1825-1909", "PER-1884-1909"),
+    # PER pairs removed 2026-08-05: PER-1825-1909 is superseded by the finer
+    # PER-1825-1884 / PER-1884-1909 split (issue 49).
+
     ("PNG", "TPAP-1906-1949", "TNGU-1920-1949"),
     ("TUR", "TUR-1920-2025", "HATAY-1938-1939"),
     ("USA", "ALK-1867-1959", "USA-1867-1959"),})

--- a/scripts/validate_live_name_ambiguity_baseline.txt
+++ b/scripts/validate_live_name_ambiguity_baseline.txt
@@ -1,10 +1,16 @@
 # Normalised names held by two or more LIVE polities whose years overlap, so a consumer
 # resolving a label by that name cannot pick one and returns NA.
 #
-# Fifteen are a coarse period listed alongside its own finer sub-periods (same prefix) —
-# the consumer's view of issue 49. Two cross prefix families and are tracked elsewhere:
-# morocco is issue 52 (MAR-1911-1958 running past its successor) and serbia is issue 43
-# (SER-2006-2008 duplicating SRB-2006-2008).
+# The remaining entries are a coarse period listed alongside its own finer sub-periods
+# (same prefix) — the consumer's view of issue 49.
+#
+# THREE LEFT ON 2026-08-05, all fixed rather than accepted:
+#   morocco     MOR-1956-1958 retired, a duplicate of MAR-1911-1958 (issue 82, PR 83)
+#   serbia      SER-2006-2008 retired, a duplicate of SRB-2006-2008 (issue 43, PR 86)
+#   montenegro  MNE-1913-1915 retired, a duplicate of MNE-1913-1918 (issue 62)
+# The first two crossed prefix families, which is why validate_period_overlaps could see
+# neither: it compares periods within one prefix. A name-keyed view caught what a
+# code-keyed one structurally cannot.
 #
 # Bidirectional: a new entry fails, and an entry that stops overlapping must be deleted.
 belize
@@ -18,9 +24,6 @@ greece
 hungary
 iraq
 italy
-montenegro
-morocco
 paraguay
 peru
 romania
-serbia

--- a/scripts/validate_succession_geography.py
+++ b/scripts/validate_succession_geography.py
@@ -70,6 +70,13 @@ POLITIES_CSV = os.path.join(REPO, "data/final/polities_database.csv")
 POLITIES_GPKG = os.path.join(REPO, "data/final/polities_database.gpkg")
 
 BASELINE = frozenset({
+    # Alaska, purchased from Russia in 1867. The seller and an overseas possession need
+    # not touch: ALK and the Russian Empire are separated by the Bering Strait, and
+    # CShapes' 1856-1905 Russian Empire polygon post-dates the sale, so it does not
+    # include Russian America. Same shape as HAWI/USA below. Flagged when ALK-1867-1959
+    # was reclassified subnational (2026-08-04), which is the check working -- a new
+    # link has to justify itself.
+    ("ALK-1867-1959", "predecessor", "F228-1856-1905"),
     ("CAR-1920-1945", "predecessor", "JPN-1895-1945"),
     ("CXR-1946-1958", "predecessor", "GBM-1895-1946"),
     ("GCAR-1899-1914", "predecessor", "DEU-1871-1919"),


### PR DESCRIPTION
CI was red for a **second reason hidden behind the first**. The earlier run aborted at `selftest_gates`, so seven later steps never ran. With #88 merged they ran — and failed.

Almost all of it was the gates working exactly as designed. They are **bidirectional**: a baselined defect that gets *fixed* fails the gate until its entry is deleted. I had been running 14 validators of the 24 that exist, so I never saw them.

## Baselines emptied by fixes, now removed

| gate | entries removed |
|---|---|
| `validate_iso_collisions` | `MNE-1913-1915`/`MNE-1913-1918`, and both `PER` pairs |
| `validate_cow_codes` | the same three, on cow 341 and 135 |
| `validate_cross_family_names` | `MAR`/`MOR` (#83) and `SER`/`SRB` (#86) |
| `validate_live_name_ambiguity` | `montenegro`, `morocco`, `serbia` |
| `crosscheck_matchers` | area **272** — the two matchers now **agree** |

That last one is worth naming. `match.R` and `matchlib` disagreed on FAOSTAT area 272 because there were **two Serbia rows** for 2006-2007. The disagreement was a *symptom of the duplicate*, not an independent matcher bug, and retiring `SER-2006-2008` resolved it. Nobody had connected the two.

Both cross-family duplicates were caught here by a **name-keyed** view, which is why `validate_period_overlaps` could see neither: it compares periods within one prefix. Recorded in the comments as the argument for keeping a name-keyed check.

## Two failures were mine, not stale baselines

**1. I never regenerated the published alias map.** I edited `applied_aliases.csv` to retarget the `serbia` alias in #86 and stopped there, so `data/final/label_alias_map.csv` still routed 2006-2007 Serbia to a **retired** polity:

```
committed: serbia,,2006,2008,SER-2006-2008,...
expected:  serbia,,2006,2008,SRB-2006-2008,...
```

`write_label_alias_map --check` caught it and named the exact line. Regenerated, plus `write_manifest` re-run since the map's `sha256` is in the manifest, plus `validate_alias_year_baseline.txt` retargeted.

**2. A new disjoint succession link.** `validate_succession_geography` flagged `ALK-1867-1959`'s predecessor `F228-1856-1905`, from the Alaska reclassification. Baselined **with the reason**, not silenced: Alaska was *purchased* from Russia in 1867, and a seller and an overseas possession need not touch — they are split by the **Bering Strait**, and CShapes' 1856-1905 Russian Empire polygon post-dates the sale, so it excludes Russian America. Same shape as the `HAWI`/`USA` entry already in that baseline.

## Verification

All **24** gates and all **five** `--check` modes pass — the full README set, not the subset I had been running.

Refs #43, #49, #62, #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ