### PR TITLE
Sharpen the Morocco gap comment: those 261 rows are not in the hole

### DIFF
--- a/scripts/validate_period_gaps.py
+++ b/scripts/validate_period_gaps.py
@@ -72,9 +72,14 @@ BASELINE = {
     #
     # THE HOLE IT REPRESENTED IS STILL THERE and this check can no longer see it.
     # MOR-1800-1904 ends 1903, MAR-1911-1958 begins 1911, so 1904-1910 is covered by
-    # nothing -- while the "French Morocco" alias claims from 1904 on 261 observed rows.
-    # It is now a CROSS-FAMILY hole, and this check is per-family by construction.
-    # Exactly the blind spot issue 82 is about.
+    # nothing. It is now a CROSS-FAMILY hole, and this check is per-family by
+    # construction. Exactly the blind spot issue 82 is about.
+    #
+    # Sharpened 2026-08-05 after joining against the observations: the "French Morocco"
+    # alias claims from 1904 and carries 261 rows, which I first cited here as if they
+    # landed in the hole. They do not -- every one is 1937-1951, inside MAR-1911-1958.
+    # The hole routes ZERO rows today. Real as coverage, empty in practice, and the
+    # alias's 1904 records when French influence began rather than where data is.
     ("SEN-1886-1959", "SEN-1960-2025"),
     # SER pair removed 2026-08-05: SER-2006-2008 is retired (a duplicate of
     # SRB-2006-2008, issue 43), so family SER ends at SER-1918-1945 and has no


### PR DESCRIPTION
Comment-only correction to something I wrote in #83. Refs #77, #82.

In #83 I wrote — in this baseline comment and on #82 — that the 1904-1910 Morocco hole matters because *"the French Morocco alias claims from 1904 on 261 observed rows"*. Literally true and misleading: it reads as though 261 rows land in the hole.

Joined against consolidated layer B:

```
'French Morocco' -> MAR-1911-1958 (covers 1911-1957)
   data years present:          1937-1951
   rows falling in 1904-1910:   0
```

**The hole routes zero rows.** The alias's `year_start: 1904` records when French influence began (the Entente Cordiale), not where observations are.

Kept as a comment rather than deleted — the hole still exists and this check still cannot see it across the family rename, which was #83's point. Only the urgency changes, and a reader acting on "261 rows" would have mis-prioritised it.

`validate_period_gaps` still passes. No behaviour change; this touches one comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ