### PR TITLE
Point stale cross-repo references at the new owner, and un-stale one gate comment

### DIFF
--- a/scripts/validate_spatial_containment.py
+++ b/scripts/validate_spatial_containment.py
@@ -138,10 +138,15 @@ ap = argparse.ArgumentParser()
 # never reported, and that is arguably the commonest real error: a polygon one neighbour
 # too large.
 #
-# A confirmed instance: ITS-1908-1960 (Italian Somaliland) uses CShapes 520, all of
-# Somalia at 635,888 km2, and geometrically contains BSS-1884-1960 (British Somaliland,
-# 171,633 km2) at 100%. This check does not see it. It is fixed independently in
-# lbm364dl/whep-polities#35, which rebinds the row to 520 MINUS 521 = 464,743 km2.
+# The instance that used to be cited here is FIXED (issue 21, closed 2026-08-05):
+# ITS-1908-1960 used CShapes 520, all of Somalia at 635,888 km2, and contained
+# BSS-1884-1960 (British Somaliland, 171,633 km2) at 100%. It is now a `constructed`
+# 520 MINUS 521 at 464,286 km2 and the two no longer intersect at all.
+#
+# THE LIMITATION IS UNCHANGED, which is why this note stays. That pair was found by
+# reading the data, not by this check -- a single swallow is invisible at the default
+# threshold however wrong it is, and the fix removed the instance rather than the blind
+# spot. Another single-swallow error of the same shape would be equally unreported.
 #
 # Lowering the default to 1 would require judging all 37 single-swallow cases, and most
 # ARE legitimate history — GBR-1800-1921 contains IRL-1800-1921, ESP-1800-2025 contains

--- a/wiki/polities/hnd-1800-2025.md
+++ b/wiki/polities/hnd-1800-2025.md
@@ -35,7 +35,7 @@ successor: []
 > polygon), `IDN-1800-1945` (1900), `IND-1800-1886` (1880), `POL-1919-1920` (1919). In
 > practice the value marks a vintage *unrepresentative of much of the span*, not one
 > strictly outside it — which is exactly this row's problem. Aligned with
-> lbm364dl/whep-polities#38, whose author checked established usage where I checked only
+> eduaguilera/whep-polities#38, whose author checked established usage where I checked only
 > the wording.
 
 

--- a/wiki/polities/mmr-1885-2025.md
+++ b/wiki/polities/mmr-1885-2025.md
@@ -34,7 +34,7 @@ successor: []
 > polygon), `IDN-1800-1945` (1900), `IND-1800-1886` (1880), `POL-1919-1920` (1919). In
 > practice the value marks a vintage *unrepresentative of much of the span*, not one
 > strictly outside it — which is exactly this row's problem. Aligned with
-> lbm364dl/whep-polities#38, whose author checked established usage where I checked only
+> eduaguilera/whep-polities#38, whose author checked established usage where I checked only
 > the wording.
 
 


### PR DESCRIPTION
Refs #21, #49. No data change.

## The transfer

The repository moved from `lbm364dl/whep-polities` to `eduaguilera/whep-polities`. GitHub redirects the old URLs, so nothing was broken — but three files carried `lbm364dl/whep-polities#N` issue references that now name a redirect rather than the repo:

```
wiki/polities/mmr-1885-2025.md
wiki/polities/hnd-1800-2025.md
scripts/validate_spatial_containment.py
```

**Deliberately not touched:** `lbm364dl.github.io/follow-the-workflow`, which appears in the whep R package's `README`, `_pkgdown.yml` and `CLAUDE.md`. That is a *different* resource — a workflow guide on GitHub Pages — and there is no evidence it moved. Renaming it on the assumption that one transfer implies another is how a working link gets broken.

## A gate comment that had gone stale in a more interesting way

`validate_spatial_containment` cited `ITS-1908-1960` containing `BSS-1884-1960` at 100% as its **confirmed instance** of the single-swallow blind spot. That instance is now fixed (#21, closed today): `ITS` is a `constructed` `520 MINUS 521` at 464,286 km² and the two no longer intersect.

The note now says so — **and says the limitation is unchanged**, because the pair was found by reading the data rather than by this check. The fix removed the *instance*, not the *blind spot*, and another single-swallow error of the same shape would be equally unreported. A comment citing a fixed defect as a live example would have read as if the gap had been closed.

**26 gates and 6 `--check` modes pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ