### PR TITLE
Make the external-data readers fail loudly instead of returning nothing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -209,6 +209,13 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/write_faostat_area_map.py --check
 
+      - name: The external-data guards can still fail
+        # extdata.py asserts the columns and categorical VALUES of the datasets the
+        # autoimprove pipeline reads. Its self-test uses synthetic frames, so unlike
+        # the pipeline itself it runs anywhere. Here for the same reason
+        # selftest_gates exists: a guard that is only hand-tested decays quietly.
+        run: python3 pipelines/polity-autoimprove/extdata.py
+
       - name: The polygon feature index still matches its sources
         # SKIPs in CI, where data/geodata is gitignored: rebuilding from a partial
         # set of sources would delete the rows of every unfetched one. It verifies

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ python3 scripts/validate_succession_geography.py   # needs the built .gpkg, so l
 
 # and the one that asks whether the checks above can fail at all
 python3 scripts/selftest_gates.py
+
+# the external-data guards, whose self-test uses synthetic frames and so runs anywhere
+python3 pipelines/polity-autoimprove/extdata.py
 ```
 
 | check | what it caught when first run |

--- a/pipelines/polity-autoimprove/07_yield_consistency.py
+++ b/pipelines/polity-autoimprove/07_yield_consistency.py
@@ -47,18 +47,18 @@ import warnings
 
 import pandas as pd
 
+import extdata
+
 warnings.filterwarnings("ignore")
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 H = os.path.join(REPO, "pipelines/polity-autoimprove/state")
-LAYER_B = os.path.expanduser("~/Nextcloud/whep/layer_b/consolidated_layer_b.parquet")
-
-# Unit -> multiplier into hectares / tonnes. Anything not listed is not an area or a
-# production figure and is ignored: heads, people, bushels, gallons, hectolitres.
-AREA_UNITS = {"ha": 1.0, "hectares": 1.0, "1000 hectares": 1e3, "1000 ha": 1e3,
-              "1000000 hectares": 1e6}
-PROD_UNITS = {"tonnes": 1.0, "t": 1.0, "1000 tonnes": 1e3, "metric tons": 1.0,
-              "tons": 1.0}
+# Paths, schema assertions and the unit maps live in extdata.py, so a rename upstream
+# raises here instead of quietly yielding an empty result. Six analyses in one session
+# were wrong that way; see that module's docstring.
+LAYER_B = extdata.LAYER_B
+AREA_UNITS = extdata.AREA_UNITS
+PROD_UNITS = extdata.PROD_UNITS
 
 # Physical ceiling and floor on t/ha. Sugarcane reaches ~150 and a few fodder crops more,
 # so 200 is above every real crop rather than at the edge of a distribution.
@@ -84,7 +84,12 @@ def main() -> int:
         print(f"SKIP: {LAYER_B} not present (it lives outside the repo)")
         return 0
 
-    d = pd.read_parquet(LAYER_B)
+    # Asserts layer B's documented columns; raises rather than returning an empty frame.
+    d = extdata.load_layer_b()
+    # And assert the unit spellings this whole check depends on actually occur. Without
+    # this, an upstream change from "ha" to "hectare" would report zero paired
+    # observations and a clean pass.
+    extdata.require_any_value(d, "unit", ["ha", "tonnes"], "layer B units")
     d = d[d["value"].notna() & d["year"].notna()].copy()
     d["u"] = d["unit"].astype(str).str.lower()
 

--- a/pipelines/polity-autoimprove/extdata.py
+++ b/pipelines/polity-autoimprove/extdata.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Loud loaders for the external datasets this pipeline reads.
+
+WHY THIS EXISTS. Six analyses in one session produced a wrong ANSWER rather than an
+exception, because pandas and csv both treat a name that is not there as absent data
+rather than as a mistake:
+
+  read `year_start` where match_confidence.csv has `year_min`
+      -> empty result, nearly reported as "no polities affected"
+  join on layer B's `polity_code`, which holds LOWERCASE ISO CODES ("fra"), not polity codes
+      -> zero for every row; a table of zeros nearly published as evidence of absence
+  read `source_label`/`polity_code` against applied_aliases.csv's
+  `original_name`/`target_polity_code`
+      -> "0 clipped", reported as success
+  read `iso3` where polities_database.csv has `iso3_code`
+      -> KeyError; the ONLY one of the six caught immediately, and only by luck of being
+         indexed directly rather than filtered on
+  filter Element == "Export quantity" on the bilateral trade pin, which spells it
+  "Export Quantity" with a capital Q
+      -> 0 of 19,868,672 rows matched, printed as "flows reported from both sides: 0"
+
+The last is the clearest case for this module. Zero mirrored flows in a bilateral trade
+dataset is absurd on its face, which is the only reason it was questioned. A less obviously
+impossible zero would have shipped.
+
+None of the eleven scripts in this pipeline asserts its columns or its categorical values.
+This module gives them somewhere to.
+
+WHAT IT DOES NOT DO: it does not normalise or repair. It raises. A pipeline that quietly
+copes with a renamed column is how the rename goes unnoticed; the point is to stop.
+"""
+from __future__ import annotations
+
+import os
+
+# --------------------------------------------------------------------------------------
+# Paths. Overridable by environment variable, matching 01_match_and_findings.py's WHEP_LAYERB.
+# --------------------------------------------------------------------------------------
+LAYER_B = os.environ.get(
+    "WHEP_LAYERB",
+    os.path.expanduser("~/Nextcloud/whep/layer_b/consolidated_layer_b.parquet"),
+)
+
+# --------------------------------------------------------------------------------------
+# Documented schemas. These are ASSERTED, not hoped for.
+# --------------------------------------------------------------------------------------
+LAYER_B_COLUMNS = (
+    "source", "source_detail", "continent",
+    "country",        # THE LABEL. Not `source_label`, not `original_name`, not `label`.
+    "item", "item_code", "indicator", "year", "period", "value", "unit",
+    "iso3c",          # not `iso3`, not `iso3_code`
+    "polity_code",    # HOLDS LOWERCASE ISO CODES ("fra", "deu"), NOT WHEP POLITY CODES.
+                      # Joining this to polities_database.polity_code matches NOTHING and
+                      # returns zero counts, not an error. Use `country` with the alias map.
+    "is_aggregate",
+)
+
+# Unit spellings seen in layer B, mapped into hectares and tonnes. Anything absent from
+# both maps is not an area or a production figure: heads, people, bushels, gallons,
+# hectolitres, kilograms, number.
+AREA_UNITS = {"ha": 1.0, "hectares": 1.0, "1000 hectares": 1e3, "1000 ha": 1e3,
+              "1000000 hectares": 1e6}
+PROD_UNITS = {"tonnes": 1.0, "t": 1.0, "1000 tonnes": 1e3, "metric tons": 1.0,
+              "tons": 1.0}
+
+# THE TWO FAOSTAT PINS DISAGREE ON CAPITALISATION. This is not a style quibble: filtering
+# with the wrong one silently matches zero rows out of tens of millions.
+#
+#   faostat-trade.parquet            Element = "Export quantity"   lowercase q
+#   faostat-trade-bilateral.parquet  Element = "Export Quantity"   capital  Q
+#
+# Compare case-insensitively, always. These are the lowercased forms to compare against.
+TRADE_ELEMENTS = ("export quantity", "import quantity", "export value", "import value")
+
+
+class ExternalDataError(RuntimeError):
+    """An external dataset does not look the way this pipeline believes it does."""
+
+
+def require_columns(df, columns, where: str) -> None:
+    """Raise unless every named column is present, naming what is missing AND what is there.
+
+    Printing the actual columns matters more than printing the missing ones: the usual cause
+    is a near-miss spelling, and seeing `year_min` beside a request for `year_start` explains
+    it instantly.
+    """
+    missing = [c for c in columns if c not in df.columns]
+    if missing:
+        raise ExternalDataError(
+            f"{where}: missing column(s) {missing}.\n"
+            f"  present: {list(df.columns)}\n"
+            f"  If this is an upstream rename, fix the reader AND this module's schema; a\n"
+            f"  column that is merely absent returns None and propagates as an empty result."
+        )
+
+
+def require_any_value(df, column: str, expected, where: str, case_insensitive=True):
+    """Raise if NONE of `expected` occurs in `column`. Warn if only some do.
+
+    This is the check that would have caught the "Export quantity" / "Export Quantity" case.
+    A filter matching zero rows is indistinguishable from a filter matching nothing real,
+    and the difference is the whole answer.
+    """
+    require_columns(df, [column], where)
+    series = df[column].dropna().astype(str)
+    if case_insensitive:
+        series = series.str.lower()
+        expected = [str(e).lower() for e in expected]
+    present = set(series.unique())
+    hit = [e for e in expected if e in present]
+    if not hit:
+        sample = sorted(present)[:12]
+        raise ExternalDataError(
+            f"{where}: none of {list(expected)} occurs in column {column!r}.\n"
+            f"  actual values (up to 12): {sample}\n"
+            f"  A filter on an absent value matches zero rows and reports a clean result."
+        )
+    if len(hit) < len(expected):
+        missing = [e for e in expected if e not in present]
+        print(f"  note: {where}: {missing} absent from {column!r}; proceeding with {hit}")
+    return hit
+
+
+def load_layer_b(path: str | None = None):
+    """Load the consolidated layer-B parquet, asserting its documented columns."""
+    import pandas as pd
+    p = path or LAYER_B
+    if not os.path.exists(p):
+        raise FileNotFoundError(
+            f"{p} not present. Layer B lives outside the repository, in the maintainer's "
+            f"own store; set WHEP_LAYERB to point elsewhere."
+        )
+    df = pd.read_parquet(p)
+    require_columns(df, LAYER_B_COLUMNS, f"layer B ({os.path.basename(p)})")
+    return df
+
+
+def _selftest() -> int:
+    """Prove the guards fire. Run: python3 extdata.py"""
+    import pandas as pd
+    ok = True
+
+    df = pd.DataFrame({"year_min": [1, 2], "n_rows": [3, 4]})
+    try:
+        require_columns(df, ["year_start"], "selftest")
+        print("FAIL: require_columns accepted a missing column"); ok = False
+    except ExternalDataError as e:
+        assert "year_min" in str(e), "the error should show what IS present"
+        print("pass: require_columns raises and shows the near-miss (`year_min`)")
+
+    df = pd.DataFrame({"Element": ["Export Quantity", "Import Quantity"]})
+    try:
+        # The real bug: lowercase q, case-sensitive comparison.
+        require_any_value(df, "Element", ["Export quantity"], "selftest",
+                          case_insensitive=False)
+        print("FAIL: require_any_value accepted a value that does not occur"); ok = False
+    except ExternalDataError as e:
+        assert "Export Quantity" in str(e), "the error should show the actual values"
+        print("pass: require_any_value raises on the capital-Q mismatch")
+
+    hit = require_any_value(df, "Element", ["Export quantity"], "selftest")
+    assert hit == ["export quantity"]
+    print("pass: the same comparison succeeds case-insensitively")
+
+    print("\nPASS: the guards fire" if ok else "\nFAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_selftest())


### PR DESCRIPTION
Refs #95. Prompted by my own failure rate, not by a filed issue.

## The problem, counted

**Six** analyses in one session produced a wrong *answer* rather than an exception, because pandas and csv both treat a name that is not there as **absent data** rather than as a mistake:

| mistake | result |
|---|---|
| `year_start` where `match_confidence.csv` has **`year_min`** | empty result, nearly reported as "no polities affected" |
| a join on layer B's **`polity_code`**, which holds lowercase ISO codes (`fra`) | zero for every row — a table of zeros nearly published as evidence of absence |
| `source_label`/`polity_code` against `applied_aliases.csv`'s **`original_name`**/**`target_polity_code`** | "0 clipped", reported as success |
| `iso3` where the database has **`iso3_code`** | `KeyError` — the **only** one caught at once, and only by luck of being indexed directly rather than filtered on |
| `Element == "Export quantity"` on the bilateral pin, which spells it **`"Export Quantity"`** | **0 of 19,868,672** rows matched, printed as "flows reported from both sides: 0" |

The last is the clearest case for this module. **Zero mirrored flows in a bilateral trade dataset is absurd on its face, which is the only reason it was questioned.** A less obviously impossible zero would have shipped as fact.

**None of the eleven scripts in this pipeline asserted its columns or its categorical values.** Every one reads a parquet and indexes in.

## What `extdata.py` provides

- **`require_columns()`** — raises on a missing column and prints **what is present**. The usual cause is a near-miss spelling, and seeing `year_min` beside a request for `year_start` explains it instantly.
- **`require_any_value()`** — raises when **none** of the expected values occurs in a column. This is the check that catches the capital-Q case. Warns when only some occur.
- **`load_layer_b()`** — loads and asserts layer B's documented columns.
- **Documented schemas**, including that layer B's `polity_code` holds ISO codes, and that the two FAOSTAT pins **disagree on capitalisation** — not a style quibble, since filtering with the wrong one silently matches zero of tens of millions of rows.

**It does not normalise or repair. It raises.** A pipeline that quietly copes with a renamed column is how the rename goes unnoticed.

## Proof rather than assertion

`07_yield_consistency.py` is retrofitted, and now also asserts that the **unit spellings** the whole check depends on actually occur — without that, an upstream change from `"ha"` to `"hectare"` would report zero paired observations and a clean pass. Results identical after the retrofit: **49,939 paired, 77 implausible, 42 powers of ten**.

Self-test output:

```
pass: require_columns raises and shows the near-miss (`year_min`)
pass: require_any_value raises on the capital-Q mismatch
pass: the same comparison succeeds case-insensitively
```

## Wired into CI

For the same reason `selftest_gates` exists: **a guard that is only hand-tested decays quietly.** The self-test uses synthetic frames, so unlike the pipeline itself it runs anywhere — which is what makes it CI-able where `07` is not.

**26 gates, 6 `--check` modes and the new self-test pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ