### PR TITLE
Convert every baseline to a frozenset, and check structurally that they stay that way

### DIFF
--- a/scripts/crosscheck_matchers.py
+++ b/scripts/crosscheck_matchers.py
@@ -54,7 +54,7 @@ PUBLISHED = os.path.join(REPO, "data/final/faostat_area_polity_map.csv")
 # family ORDER decided. "Malaysia" 1961 resolved to BNB-1881-1963 (British North Borneo,
 # 72,557 km2). Retyping BNB and BSW to `colonial` and MASG to `aggregate` -- all three
 # accurate -- let the preference work, and the two matchers now agree.
-BASELINE_DIFFERENT = {237}
+BASELINE_DIFFERENT = frozenset({237})
 
 # Labels matchlib cannot resolve without the faostat alias, so an explicit route is
 # REQUIRED. One area, and it is genuinely nominal: the Yugoslav SFR chain sits under
@@ -73,7 +73,7 @@ BASELINE_DIFFERENT = {237}
 #
 # I also first guessed this set would be the four China components, assuming an aggregate
 # with no ISO3 would be the hard case. Those resolve fine.
-BASELINE_UNRESOLVED = {248}
+BASELINE_UNRESOLVED = frozenset({248})
 
 
 def main() -> int:

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -651,6 +651,45 @@ def check_every_gate_runs_in_ci() -> list:
     # claim in prose is exactly what goes stale. This caught the live-name-ambiguity gate,
     # which had a table row describing it but no mention of the script that runs it — so
     # it read as documented while being invisible to any structural check.
+    # EVERY BASELINE MUST BE A frozenset({...}), NOT A BARE {...}.
+    #
+    # A bare set literal is fine until it is EMPTIED, at which point `{}` is a DICT, and
+    # `set(observed) - BASELINE` raises TypeError. The gate then breaks precisely when the
+    # data becomes correct — the one moment nobody is expecting a failure, and the failure
+    # looks like a bug in the check rather than a success in the data.
+    #
+    # This is not hypothetical and it is not new. validate_spatial_containment has carried a
+    # comment explaining the trap since its KNOWN_DISCONTINUOUS was first emptied. On
+    # 2026-08-05 it bit validate_period_overlaps anyway, when retiring BLX-1921-1999 removed
+    # its last entry — the warning existed and had not been applied to the sibling. Checked
+    # structurally here so the next baseline cannot repeat it.
+    #
+    # Detected by AST rather than by regex: a first pass with a pattern misread
+    # `BASELINE_DIFFERENT = {237}` as empty, because the heuristic looked for quotes.
+    import ast
+    import glob as _glob
+    bare = []
+    for path in sorted(_glob.glob(os.path.join(REPO, "scripts", "*.py"))):
+        try:
+            tree = ast.parse(open(path, encoding="utf-8").read())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Set):
+                continue
+            names = [getattr(t, "id", "") for t in node.targets]
+            if names and any(
+                names[0].startswith(p)
+                for p in ("BASELINE", "KNOWN", "TRACKED", "LEGITIMATE")
+            ):
+                bare.append(f"{os.path.basename(path)}:{names[0]}")
+    if bare:
+        problems.append(
+            f"{len(bare)} baseline constant(s) declared as a bare set literal, which "
+            f"becomes a DICT when emptied and raises TypeError on set arithmetic — use "
+            f"frozenset({{...}}): {bare}"
+        )
+
     readme = os.path.join(REPO, "README.md")
     if os.path.exists(readme):
         with open(readme, encoding="utf-8") as fh:

--- a/scripts/validate_map_area_year.py
+++ b/scripts/validate_map_area_year.py
@@ -45,12 +45,12 @@ DB = os.path.join(REPO, "data/final/polities_database.csv")
 DEAD_STATUS = ("retired", "superseded")
 
 # (area_code, year) pairs known to have two live answers. See the module docstring.
-BASELINE = {
+BASELINE = frozenset({
     # area 240 year 1917 cleared 2026-08-05 by the Group A alias clip (issue 90): the earlier
     # alias stopped claiming 1917, which its successor covers. Left as a set with one entry
     # rather than emptied so a regression still names the pair.
     ("205", 1975),
-}
+})
 
 
 def live_polity_codes() -> set:

--- a/scripts/validate_period_gaps.py
+++ b/scripts/validate_period_gaps.py
@@ -53,7 +53,7 @@ CODE_RE = re.compile(r"^(.*)-(\d{4})-(\d{4})$")
 
 # (earlier_code, later_code) pairs with a known gap between them. See the docstring:
 # most are correct, four are issue 77.
-BASELINE = {
+BASELINE = frozenset({
     ("ANT-1816-1960", "ANT-1961-2010"),
     ("BFA-1919-1932", "BFA-1947-1960"),
     ("CHL-1810-1883", "CHL-1884-1899"),
@@ -93,7 +93,7 @@ BASELINE = {
     ("TCD-1912-1919", "TCD-1920-1960"),
     ("VNM-1887-1954", "VNM-1975-2025"),
     ("ZWE-1900-1953", "ZWE-1964-1980"),
-}
+})
 
 
 def live_rows() -> list:


### PR DESCRIPTION
Refs #40, where this bit.

## The failure mode

A bare set literal is fine until it is **emptied**, at which point `{}` is a **dict** and `set(observed) - BASELINE` raises `TypeError`. The gate then breaks *precisely when the data becomes correct* — the one moment nobody expects a failure, and the failure reads as a bug in the check rather than a success in the data.

## This is not new, and that is the point

`validate_spatial_containment` has carried a comment explaining the trap since its `KNOWN_DISCONTINUOUS` was first emptied:

> *"frozenset(...) rather than a bare {...}: when the last entry is removed — which is the goal — a bare literal becomes an empty DICT, and `dict - set` raises TypeError. The gate would crash precisely when the data became correct."*

**It bit `validate_period_overlaps` yesterday anyway**, when retiring `BLX-1921-1999` removed its last entry (#40). The warning existed, in this repository, and had not been applied to the sibling gate. **Documentation did not propagate; a check does.**

## Four constants converted

```
crosscheck_matchers.py       BASELINE_DIFFERENT    {237}
crosscheck_matchers.py       BASELINE_UNRESOLVED   {248}
validate_map_area_year.py    BASELINE              one entry left -> ONE removal from
                                                   crashing, and I had emptied it from
                                                   two to one earlier this session
validate_period_gaps.py      BASELINE
```

`selftest_gates` now asserts structurally that no constant named `BASELINE*`, `KNOWN*`, `TRACKED*` or `LEGITIMATE*` is a bare set literal. That is the right home — it already checks structural properties of the gate *set* rather than of the data.

## Detected by AST, not by regex, and the first attempt shows why

A regex pass **misread `BASELINE_DIFFERENT = {237}` as empty**, because the heuristic looked for quotes or parens in the body and a bare integer has neither. It reported **2** at-risk constants when there were **4**. The AST version cannot make that mistake: `ast.Set` is `ast.Set` whatever is inside it.

## Verification

```
revert one frozenset to a bare literal ->
  FAIL: 1 baseline constant(s) declared as a bare set literal, which becomes a DICT
        when emptied and raises TypeError on set arithmetic — use frozenset({...}):
        ['validate_map_area_year.py:BASELINE']
```

**26 gates, 6 `--check` modes and the extdata self-test pass**; `selftest_gates` reports 13 of 26 proving they fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ