### PR TITLE
Gate the two binding signals that found eight wrong polygons this session

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -306,6 +306,12 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/crosscheck_matchers.py
 
+      - name: Polygon bindings belong to the period their row covers
+        # Reads the committed feature index and GeoPackage only, so unlike the
+        # determinism gate this one does real work in CI from the start. Found eight
+        # wrong bindings across five families, none visible to an area check.
+        run: python3 scripts/validate_polygon_period_fit.py
+
       - name: Polygon bindings are decided by the data, not by shapefile row order
         # Reads data/final/polygon_feature_index.csv, so this runs for real in CI (issue
         # 103). It previously needed the gitignored shapefiles and verified nothing here.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ python3 scripts/validate_alias_year_coverage.py
 
 # geometry
 python3 scripts/validate_polygons.py
+python3 scripts/validate_polygon_period_fit.py
 python3 scripts/validate_polygon_binding_determinism.py
 python3 scripts/validate_spatial_containment.py
 python3 scripts/validate_family_areas.py

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -458,7 +458,34 @@ def mutate_order_dependent_binding(root, gpd, make_valid, affinity):
     return "set VNM-1887-1954's polygon_feature_year to 1893, which matches three steps"
 
 
+def mutate_period_mismatched_binding(root, gpd, make_valid, affinity):
+    """Put COG-1906-1912 back on its predecessor's CShapes step.
+
+    The exact state of the repository before issue 124: polygon_feature_year 1900 on a row
+    covering 1906-1911, selecting French Equatorial Africa's 2,234,540 km2 for a territory
+    that should be 344,022 -- a 6.5x overstatement. Chosen over a synthetic mutation because
+    it is what the data actually looked like, and because the row declares no
+    polygon_area_km2, so no area check would object to it."""
+    path = os.path.join(root, "data/final/polities_database.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    head = rows[0]
+    ci, cy = head.index("polity_code"), head.index("polygon_feature_year")
+    for r in rows:
+        if len(r) > cy and r[ci] == "COG-1906-1912":
+            r[cy] = "1900"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        csv.writer(fh).writerows(rows)
+    return "set COG-1906-1912's polygon_feature_year to its predecessor's, 1900"
+
+
 CASES = (
+    (
+        "validate_polygon_period_fit.py",
+        mutate_period_mismatched_binding,
+        "COG-1906-1912",
+        "a polygon bound to a step from outside the period its row covers",
+    ),
     (
         "validate_schema_contract.py",
         mutate_renamed_column,
@@ -561,6 +588,15 @@ EXTRA_SCRIPTS = {
 
 # Which data files each case needs to be a real, writable copy rather than a symlink.
 WRITABLE = {
+    # Signal A reads the CSV and the feature index; signal B also needs the GeoPackage for
+    # geometry equality. All three must be REAL COPIES: the case rewrites the CSV, and with
+    # only stage()'s default symlink in place the mutation wrote straight through into the
+    # committed database -- which this harness detected and named, for the third time.
+    "validate_polygon_period_fit.py": (
+        "polities_database.csv",
+        "polygon_feature_index.csv",
+        "polities_database.gpkg",
+    ),
     # This gate reads SEVEN tables, so all of them must be staged or it fails for the
     # wrong reason -- "file missing" rather than "column renamed". Listing them here is
     # itself the point of the gate: these are every table a consumer reads by name.

--- a/scripts/validate_polygon_period_fit.py
+++ b/scripts/validate_polygon_period_fit.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Does each polity's polygon binding actually belong to the period the row covers?
+
+Two signals, both derived from the committed `data/final/polygon_feature_index.csv` and the
+committed GeoPackage, so this runs in CI. Between them they found EIGHT wrong bindings across
+five families in one session, none of which any area check could see.
+
+  A. OUT-OF-SPAN VINTAGE. The row's `polygon_feature_year` falls outside its own
+     [start_year, end_year), and the source offers a differently-sized step INSIDE that span.
+     Nearly always the predecessor's step, i.e. the whole family lagged by one.
+
+  B. IDENTICAL GEOMETRY WITH AN ALTERNATIVE. Two consecutive periods of one family share the
+     same (source, feature_id, feature_year) and therefore byte-identical geometry, while the
+     source offers a differently-sized step covering the later row's start year.
+
+WHY BOTH, AND WHY NEITHER SUFFICES ALONE — this is the part worth reading:
+
+  Signal B found ANG-1800-1890 / ANG-1890-1891. Fixing it revealed that ANG-1891-1905 was
+  ALSO wrong, and B was structurally blind to it: a UNIFORM LAG makes every row wrong and no
+  two identical, so there is no collision to detect. Signal A finds lags.
+
+  Signal A in turn cannot see a duplicated binding where both rows legitimately sit inside
+  their spans. Signal B finds those.
+
+WHAT THEY FOUND, so the value is not hypothetical:
+  CHN-1950-2025   1.81M km2 too small for 75 years -- the largest polygon error in this
+                  database, on the largest agricultural producer in it (issue 120)
+  COG x4          the Congo family lagged by one across four rows, worst case a 6.5x
+                  overstatement (issue 124)
+  ANG x2          Angola lagged by one across two rows (issue 122)
+  SNI-1906-1913   bound to the pre-Lagos-merger polygon (issue 51)
+  SWA, TCD        the 1911 Neukamerun cession, lagged in two more families (issue 125)
+
+WHY AN AREA CHECK FINDS NONE OF THEM: every one of those rows declared no
+`polygon_area_km2`, so `validate_polygons`' comparison -- opt-in via that hand-entered field
+-- never examined it. Roughly 590 of 742 rows are in that blind spot (issue 59). These two
+signals need no declared area, because they compare the binding against the SOURCE'S OWN
+alternatives rather than against a number someone typed.
+
+BOTH SIGNALS ARE NOISY WITHOUT THEIR SECOND CLAUSE, and the clauses are what make them
+usable:
+  - 83 live rows have an out-of-span feature_year; most are inherent, because GADM and
+    `constructed` are modern-only and a historical row MUST use a modern vintage. Requiring
+    a TEMPORAL source and a differently-sized in-span step gives 8.
+  - 115 consecutive pairs share geometry, and most are correct: decolonisation usually
+    preserves borders (BDI-1922-1962 -> BDI-1962-2025). Requiring the same binding AND an
+    available alternative gives 5.
+
+Usage:
+  python3 scripts/validate_polygon_period_fit.py
+"""
+import csv
+import os
+import re
+import sys
+from collections import defaultdict
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CSV_PATH = os.path.join(REPO, "data/final/polities_database.csv")
+INDEX = os.path.join(REPO, "data/final/polygon_feature_index.csv")
+GPKG = os.path.join(REPO, "data/final/polities_database.gpkg")
+WIKI = os.path.join(REPO, "wiki/polities")
+DEAD = ("retired", "superseded")
+TEMPORAL = {"cshapes-2.0", "cshapes-europe", "cliopatria"}
+TOL = 0.02          # a step counts as "differently sized" beyond 2%
+
+# Bindings judged and accepted. Two kinds, and the distinction is deliberate:
+#
+#   "documented"  the page states a proxy or vintage choice, so an out-of-span year is
+#                 intentional. ROU-1918-1919's 1921 vintage was chosen on DATA evidence
+#                 (maize production consistent only with Greater Romania) -- a check that
+#                 failed on it would be failing on its own correct decision.
+#   "undecided"   flagged, unexplained, and NOT yet judged. Tracked in issues 121 and 123.
+#                 Listed here so the gate can run at zero without pretending these are fine.
+BASELINE = frozenset({
+    # --- documented proxies (signal A) ---
+    "A:F237-1954-1975",
+    "A:ITA-1861-1866",
+    "A:ITA-1866-1870",
+    "A:ROU-1918-1919",
+    "A:TUR-1800-1913",
+    # --- undecided (signal A), issue 123 ---
+    "A:MOR-1800-1904",     # Cliopatria vintage 1769, 31 years before the row starts; not a
+                           # one-step lag, and Cliopatria's step density differs from CShapes'
+    "A:SUD-1934-1956",     # -3.6%, within simplification and boundary-vintage noise
+    "A:TUR-1913-1914",     # points FORWARD (1914 for a 1913 row); every fixed case pointed back
+    # --- documented / undecided (signal B), issues 121 and 123 ---
+    "B:ITA-1861-1866 / ITA-1866-1870",
+    "B:ITA-1866-1870 / ITA-1870-1919",
+    "B:HUN-1944-1947 / HUN-1947-2025",   # here the LATER row is right: 93,004 km2 matches
+                                         # modern Hungary, so the earlier row is the suspect
+    "B:SUD-1899-1934 / SUD-1934-1956",
+    "B:TUR-1913-1914 / TUR-1914-1918",
+})
+
+PROXY_RE = re.compile(
+    r"polygon_vintage_proxy:\s*true|polygon_vintage_note:|"
+    r"polygon_status:\s*(proxy|estimate|polygon_vintage_drift)"
+)
+
+
+def declares_proxy(code: str) -> bool:
+    p = os.path.join(WIKI, f"{code.lower()}.md")
+    if not os.path.exists(p):
+        return False
+    with open(p, encoding="utf-8") as fh:
+        return bool(PROXY_RE.search(fh.read()))
+
+
+def num(v):
+    try:
+        return int(float(v))
+    except (TypeError, ValueError):
+        return None
+
+
+def main() -> int:
+    if not os.path.exists(INDEX):
+        print(f"SKIP: {INDEX} missing; run scripts/write_feature_index.py")
+        return 0
+
+    steps = defaultdict(list)
+    with open(INDEX, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            steps[(r["source"], r["feature_id"])].append(
+                (num(r["start_year"]), num(r["end_year"]), float(r["area_km2"] or 0))
+            )
+
+    with open(CSV_PATH, encoding="utf-8") as fh:
+        rows = [r for r in csv.DictReader(fh) if r["wiki_status"] not in DEAD]
+
+    problems, observed = [], set()
+
+    # ---------- SIGNAL A ----------
+    for r in rows:
+        src = (r.get("polygon_source") or "").strip()
+        if src not in TEMPORAL:
+            continue
+        fy, s, e = (num(r["polygon_feature_year"]), num(r["start_year"]),
+                    num(r["end_year"]))
+        if None in (fy, s, e) or s <= fy < e:
+            continue
+        cand = steps.get((src, str(r["polygon_feature_id"]).strip()), [])
+        chosen = [c for c in cand if c[0] is not None and c[0] <= fy <= c[1]]
+        inspan = [c for c in cand if c[0] is not None and s <= c[0] < e]
+        if not chosen or not inspan:
+            continue
+        ch = chosen[0][2]
+        alt = [c for c in inspan if abs(c[2] - ch) / max(ch, 1) > TOL]
+        if not alt:
+            continue
+        key = f"A:{r['polity_code']}"
+        observed.add(key)
+        if key in BASELINE:
+            continue
+        best = max(alt, key=lambda c: abs(c[2] - ch))
+        problems.append(
+            f"A {r['polity_code']}: covers {s}-{e - 1} but polygon_feature_year={fy} is "
+            f"OUTSIDE that span, selecting {ch:,.0f} km2; the source offers "
+            f"{best[0]}-{best[1]} = {best[2]:,.0f} km2 ({100 * (best[2] - ch) / max(ch, 1):+.1f}%) "
+            f"inside it"
+            + ("" if declares_proxy(r["polity_code"])
+               else "  [the page declares no proxy or vintage note]")
+        )
+
+    # ---------- SIGNAL B ----------
+    try:
+        import geopandas as gpd
+        import pandas as pd
+    except ImportError as exc:
+        print(f"  note: signal B skipped, geopandas unavailable ({exc})")
+        gpd = None
+    if gpd is not None and os.path.exists(GPKG):
+        g = gpd.read_file(GPKG)
+        g = g[~g.wiki_status.astype(str).isin(DEAD)]
+        g = g[g.geometry.notna() & ~g.geometry.is_empty].copy()
+        g["km2"] = g.to_crs("ESRI:54034").geometry.area / 1e6
+        g["s"] = pd.to_numeric(g.start_year, errors="coerce")
+        g["prefix"] = g.polity_code.str.rsplit("-", n=2).str[0]
+        for _pre, fam in g.groupby("prefix"):
+            if len(fam) < 2:
+                continue
+            rs = list(fam.sort_values("s").itertuples())
+            for k in range(len(rs) - 1):
+                a, b = rs[k], rs[k + 1]
+                if not a.geometry.equals(b.geometry):
+                    continue
+                bind = (str(a.polygon_source), str(a.polygon_feature_id),
+                        str(a.polygon_feature_year))
+                if bind != (str(b.polygon_source), str(b.polygon_feature_id),
+                            str(b.polygon_feature_year)):
+                    continue
+                cand = steps.get((bind[0], bind[1]), [])
+                if len(cand) < 2:
+                    continue
+                cur = [c for c in cand
+                       if c[0] is not None and c[0] <= (b.s or -1) <= (c[1] or 9999)]
+                alt = [c for c in cur if abs(c[2] - b.km2) / max(b.km2, 1) > TOL]
+                if not alt:
+                    continue
+                key = f"B:{a.polity_code} / {b.polity_code}"
+                observed.add(key)
+                if key in BASELINE:
+                    continue
+                best = max(alt, key=lambda c: abs(c[2] - b.km2))
+                problems.append(
+                    f"B {a.polity_code} / {b.polity_code}: identical geometry at "
+                    f"{b.km2:,.0f} km2 from one binding, while {best[0]}-{best[1]} = "
+                    f"{best[2]:,.0f} km2 ({100 * (best[2] - b.km2) / max(b.km2, 1):+.1f}%) "
+                    f"covers the later row"
+                )
+
+    for key in sorted(BASELINE - observed):
+        problems.append(f"{key} is baselined but no longer flagged — remove it")
+
+    print(f"bindings on a temporal source checked against their period: {len(observed)} "
+          f"flagged, {len(BASELINE)} baselined")
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)\n")
+        for p in problems:
+            print(f"  {p}")
+        print("\n  A row bound to a step from outside its own period measures the wrong\n"
+              "  territory for every year it covers, and no area check will say so: these\n"
+              "  rows typically declare no polygon_area_km2 at all (issue 59).")
+        return 1
+
+    print("\nPASS: every binding fits the period its row covers, or is baselined with a reason")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Turns two throwaway analyses into a standing check. Refs #121, #123, #59.

## The two signals

- **A. Out-of-span vintage** — `polygon_feature_year` falls outside the row's own `[start_year, end_year)` while the source offers a differently-sized step *inside* it. Nearly always the predecessor's step: the family lagged by one.
- **B. Identical geometry with an alternative** — two consecutive periods share a binding, and therefore geometry, while a differently-sized step covers the later row.

**Neither suffices alone, and Angola proved it.** Signal B found `ANG-1800-1890` / `ANG-1890-1891`; fixing that revealed `ANG-1891-1905` was *also* wrong, and B was structurally blind to it — a **uniform lag makes every row wrong and no two identical**, so there is no collision to detect. A finds lags; B finds duplicated bindings where both rows sit legitimately inside their spans.

## What they found, measured rather than claimed

| defect | scale |
|---|---|
| `CHN-1950-2025` | **1.81M km² too small for 75 years**, on the largest producer in the data (#120) |
| `COG` ×4 | Congo lagged across four rows, worst case **6.5× overstated** (#124) |
| `ANG` ×2 | Angola lagged across two rows (#122) |
| `SNI-1906-1913` | the pre-Lagos-merger polygon (#51) |
| `SWA`, `TCD` | the 1911 Neukamerun cession, two more families (#125) |

**None was visible to an area check** — every one declared no `polygon_area_km2`, so `validate_polygons`' opt-in comparison never examined it. These signals need no declared area, because they compare the binding against the **source's own alternatives** rather than a hand-typed number.

Both are noisy without their second clause, which is why earlier attempts at each failed: 83 rows have an out-of-span year but most are inherent (GADM and `constructed` are modern-only); 115 consecutive pairs share geometry but most are correct (decolonisation preserves borders). The clauses give **8** and **5**.

## The baseline distinguishes documented from undecided

Rather than lumping them. **Five** pages state a proxy or vintage choice — `ROU-1918-1919`'s 1921 vintage was chosen on data evidence, so a check failing on it would be failing on its own correct decision. **Eight** are flagged, unexplained and **not yet judged**; they are listed so the gate runs at zero without pretending they are fine.

## Verification, and one honest correction

Three CSV-level mutations fired and named the row. **But the CHN mutation was caught by signal A, not B** — editing the CSV does not rebuild the GeoPackage, so B's comparison still saw the corrected geometry. My mutation had not tested B at all.

Re-ran it properly by reverting `SNI-1906-1913` **and rebuilding**, which fired both together:

```
A SNI-1906-1913: covers 1906-1912 but polygon_feature_year=1899 is OUTSIDE that span ...
B SNI-1899-1906 / SNI-1906-1913: identical geometry at 130,457 km2 ...
```

## And the harness caught me twice

While wiring the selftest case, my `WRITABLE` entry landed in **`EXTRA_SCRIPTS`** instead, because the anchor string I matched appears there first. So the data files were never staged — the gate SKIPped on a missing index and **"passed" the mutation** — and with no `WRITABLE` entry the CSV stayed a symlink, so the mutation **wrote straight through into the committed database**.

`selftest_gates` reported both, by name. That leak detector has now paid for itself three times.

**27 gates, 6 `--check` modes and the extdata self-test pass**; `selftest_gates` reports **14 of 27** proving they fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ