### PR TITLE
A gate disagreed with six others about what "live" means — and all 14 of its findings were artifacts

### DIFF
--- a/scripts/validate_live_name_ambiguity.py
+++ b/scripts/validate_live_name_ambiguity.py
@@ -54,6 +54,15 @@ import unicodedata
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CSV_PATH = os.path.join(REPO, "data/final/polities_database.csv")
+
+# Matches the six other gates that already agree on this: validate_cow_codes,
+# validate_family_areas, validate_iso_collisions, validate_cross_family_names,
+# audit_family_shadowing and structural_change_check all define exactly this tuple.
+# This gate tested `== "retired"` alone until 2026-08-05, so it counted the 20
+# `superseded` rows as LIVE -- 728 against the repo convention's 708 -- and any
+# name it flagged where one member was superseded was an artifact of that, not an
+# ambiguity a data source could ever hit.
+DEAD_STATUS = ("retired", "superseded")
 BASELINE_PATH = os.path.join(
     REPO, "scripts/validate_live_name_ambiguity_baseline.txt"
 )
@@ -95,7 +104,7 @@ def main() -> int:
     live = []
     with open(CSV_PATH, encoding="utf-8") as fh:
         for row in csv.DictReader(fh):
-            if (row.get("wiki_status") or "").strip() == "retired":
+            if (row.get("wiki_status") or "").strip() in DEAD_STATUS:
                 continue
             try:
                 start = int(row["start_year"])

--- a/scripts/validate_live_name_ambiguity_baseline.txt
+++ b/scripts/validate_live_name_ambiguity_baseline.txt
@@ -1,29 +1,37 @@
 # Normalised names held by two or more LIVE polities whose years overlap, so a consumer
 # resolving a label by that name cannot pick one and returns NA.
 #
-# The remaining entries are a coarse period listed alongside its own finer sub-periods
-# (same prefix) — the consumer's view of issue 49.
+# Bidirectional: a new entry fails, and an entry that stops overlapping must be deleted.
 #
-# THREE LEFT ON 2026-08-05, all fixed rather than accepted:
+# ---------------------------------------------------------------------------------------
+# WHY THIS GATE EARNS ITS KEEP — three cases it caught that a code-keyed gate cannot
+# ---------------------------------------------------------------------------------------
+# Fixed rather than accepted, 2026-08-05:
 #   morocco     MOR-1956-1958 retired, a duplicate of MAR-1911-1958 (issue 82, PR 83)
 #   serbia      SER-2006-2008 retired, a duplicate of SRB-2006-2008 (issue 43, PR 86)
 #   montenegro  MNE-1913-1915 retired, a duplicate of MNE-1913-1918 (issue 62)
 # The first two crossed prefix families, which is why validate_period_overlaps could see
-# neither: it compares periods within one prefix. A name-keyed view caught what a
-# code-keyed one structurally cannot.
+# neither: it compares periods WITHIN one prefix. A name-keyed view caught what a
+# code-keyed one structurally cannot. Keep that reasoning even though the list is empty.
 #
-# Bidirectional: a new entry fails, and an entry that stops overlapping must be deleted.
-belize
-brazil
-china
-egypt
-ethiopia
-france
-german kamerun
-greece
-hungary
-iraq
-italy
-paraguay
-peru
-romania
+# ---------------------------------------------------------------------------------------
+# THE LIST IS NOW EMPTY, AND THAT IS ITSELF THE FINDING
+# ---------------------------------------------------------------------------------------
+# Until 2026-08-05 it held 14 names: belize, brazil, china, egypt, ethiopia, france,
+# german kamerun, greece, hungary, iraq, italy, paraguay, peru, romania. The header
+# described them as "a coarse period listed alongside its own finer sub-periods".
+#
+# ALL FOURTEEN WERE ARTIFACTS OF THIS GATE, not facts about the data. It selected live rows
+# with `== "retired"`, while the six other gates making the same distinction — validate_cow_codes,
+# validate_family_areas, validate_iso_collisions, validate_cross_family_names,
+# audit_family_shadowing and structural_change_check — all define
+# DEAD_STATUS = ("retired", "superseded"). So the 20 `superseded` rows counted as LIVE here:
+# 728 against the convention's 708. Each of the 14 was a superseded coarse period overlapping
+# the finer rows that replaced it. No data source can reach a superseded row, so not one of
+# them was ever an ambiguity a consumer could hit.
+#
+# Once the status test matched the rest of the repo, overlapping-holder names went 14 -> 0.
+#
+# The cost was never the 14 false entries. It is that a REAL new ambiguity would have arrived
+# as a 15th line among 14 known-harmless ones, in a file whose header explained them away.
+# Empty means the next addition is unambiguously a regression.


### PR DESCRIPTION
`validate_live_name_ambiguity.py` selected live rows with

```python
if (row.get("wiki_status") or "").strip() == "retired": continue
```

while **every other gate in the repo** that makes the same distinction defines

```python
DEAD_STATUS = ("retired", "superseded")
```

— `validate_cow_codes`, `validate_family_areas`, `validate_iso_collisions`, `validate_cross_family_names`, `audit_family_shadowing`, `structural_change_check`. **Six to one.**

```
live by this gate's test                728
live by the other six gates' test       708
wiki_status:  draft 649  reviewed 59  retired 21  superseded 20
```

## All 14 baselined names were artifacts of that

`belize, brazil, china, egypt, ethiopia, france, german kamerun, greece, hungary, iraq, italy, paraguay, peru, romania`

Each was a **superseded coarse period overlapping the finer rows that replaced it**. No data source can reach a superseded row, so **not one was ever an ambiguity a consumer could hit**. Aligning the status test took overlapping-holder names from **14 → 0**.

The baseline file's own header described them as *"a coarse period listed alongside its own finer sub-periods"* — an accurate description of the shape, offered as the reason to accept them. It was the gate's **selection** that was wrong, not the data.

## The cost was never the 14 false entries

It's that a real new ambiguity would have arrived as a **15th line among 14 known-harmless ones**, in a file whose header explained them away. Empty means the next addition is unambiguously a regression.

## Kept while emptying

The record of three cases this gate caught that a code-keyed gate **structurally cannot** — morocco (MOR/MAR, #82), serbia (SER/SRB, #43), montenegro (#62). The first two crossed prefix families, so `validate_period_overlaps` could see neither: it compares periods *within* one prefix. That reasoning is why the gate is worth having, and it would have been deleted along with the entries.

**28 gates, 6 `--check` modes and the extdata self-test pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ