### PR TITLE
Nothing asked whether another live polity already held this polygon

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -452,6 +452,20 @@ jobs:
         # degrees. eduaguilera/whep#529.
         if: '!cancelled()'
         run: python3 scripts/validate_spherical_edges.py
+      - name: Polygons — no two coexisting polities on one polygon
+        # Measured in the consumer, which is where it surfaced: WHEP's embedded copy
+        # has TWELVE cross-family pairs coexisting on one polygon, and for 2015 451 of
+        # 67,691 grid cells claim more territory than they contain, 12.72 Mha in excess,
+        # worst ratio 2.0000x at cell (10.25, 1.75) — GNQ-1968-2025 and STP-1800-2025
+        # both bound to CShapes feature 411. The defect was injected back into a copy of
+        # this repository at the wiki, the CSV and the GeoPackage together, and all 27
+        # gates then exited 0 without naming STP-1800-2025: the area check had no
+        # recorded area to compare, the containment check needs three swallowed
+        # neighbours and two identical polygons swallow one each, and the period-fit and
+        # determinism checks confirm that 411@1900 resolves cleanly — it is simply the
+        # wrong country. Nothing asked whether another live polity already held it.
+        if: '!cancelled()'
+        run: python3 scripts/validate_shared_polygons.py
 
 
       - name: Identity — a code's years match its own columns

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ You don't have to run the fetches if you only want to consume the committed `dat
 
 ## Validation
 
-Thirty checks guard the database, and a thirty-first checks the checks. Most
+Thirty-five checks guard the database, and a thirty-six checks the checks -- the
+count matches the `validate_*`/`crosscheck_*`/`audit_*` scripts under `scripts/`,
+which is what `selftest_gates.py` enumerates, so it is checkable rather than prose. Most
 exist because that class of error was **found in the data**, not hypothesised; the
 few marked *(guard)* below hold a property that is true today and would be costly
 to lose. All are worth keeping green:
@@ -92,6 +94,7 @@ python3 scripts/validate_alias_year_coverage.py
 python3 scripts/validate_polygons.py
 python3 scripts/validate_polygon_validity.py
 python3 scripts/validate_stated_areas.py
+python3 scripts/validate_shared_polygons.py
 python3 scripts/validate_polygon_period_fit.py
 python3 scripts/validate_polygon_binding_determinism.py
 python3 scripts/validate_spatial_containment.py
@@ -131,6 +134,7 @@ python3 pipelines/polity-autoimprove/extdata.py
 | polygons D | 13 pages claiming `status: reviewed` with zero source citations |
 | family areas | *(guard)* check A needs a **recorded** area to compare against, and 76% of rows claiming a polygon have none. Comparing a period to its own family's median needs no reference and covers all of them. Two anomalies today, both legitimate |
 | spatial containment | one polity's polygon swallowing a neighbour's; a family's consecutive periods overlapping by under half |
+| shared polygons | *(consumer-found)* **twelve** cross-family pairs coexist on ONE polygon in WHEP's embedded copy, so the ground inside it is claimed twice: `GNQ-1968-2025` and `STP-1800-2025` were both bound to CShapes feature 411, which is mainland Rio Muni, and cell (10.25, 1.75) claimed **2.0000×** its own area — 451 of 67,691 cells over-claimed for 2015, 12.72 Mha in excess. All twelve are already resolved here, so this gate is the standing assertion rather than the repair, and each pair is pinned by name. The reason it is a separate check is that **all 27 other gates pass on it**, verified by injecting it back at the wiki, the CSV and the GeoPackage together: the area check had no recorded area to compare against, the containment check needs three swallowed neighbours and two identical polygons swallow one each, and the period-fit and determinism checks confirm `411@1900` resolves cleanly — it is simply the wrong country. Two signals, because a binding and a geometry can each be wrong alone: a shared `(source, feature_id, feature_year)` in the CSV, and an intersection-over-union above 0.9999 in the GeoPackage. It deliberately does **not** assert that a cell never over-claims: 188 coexisting pairs overlap by >1 km² in 2015 (331,429 km² total) and the large ones are dispute and nesting — `ESH`/`MAR` 267,078 km², `SAU`/`YEM` 29,918 km², `ESP`/`ICN` 7,027 km² — which is a territorial judgement, tracked separately |
 | code/year agreement | *(guard)* a polity code is documented as `PREFIX-start-end`, so consumers read years straight off the identifier rather than joining. Two codes disagree with their own columns — `TAN-1922-1964` ends 1961, `NNG-1949-1963` ends 1969 — and the consumer's aliases were written against the CODE, so two of them resolve 1962-1964 to a polity its columns say had ended. Both are historical judgement (independence vs union; transfer vs Act of Free Choice), so baselined pending a decision |
 | live name ambiguity | *(guard)* a consumer resolving a label by the polity's own NAME can only answer when one polity of that name is live in the year asked about, so a rename that collides with a live sibling turns a resolving label into `NA` — and `NA` is what an unmapped label looks like too. 17 names are ambiguous today: fifteen are a coarse period listed beside its own sub-periods (issue 49), and two cross prefix families and are tracked as issues 52 and 43 |
 | succession geography | `NWR-1900-1905` (Northwestern Rhodesia) listing its successor as Northern **Nigeria**, 4,000 km away. A wrong code looks exactly like a right one, so only the polygons reveal it |
@@ -138,7 +142,7 @@ python3 pipelines/polity-autoimprove/extdata.py
 | gate self-test | *(the checks, checked)* Gates that all pass are indistinguishable, from a green summary, from gates that **cannot** fail. Mutation settles it: seventeen are shown to fail on an injected defect and to name it — four geometry gates that mutate the GeoPackage, and thirteen that mutate the CSV, the alias map, the wiki or a builder script's own literal. The s2 case is the only mutation here that no other gate could catch, because the injected geometry is planar-valid; it also had to use the real defect's coordinates, since a synthetic thin sliver built on a geodesic-sag theory is accepted by s2 at every latitude and would have read as "this gate cannot fail". One case earned its keep before it ever guarded anything: it declared the wrong file writable, so its mutation wrote through a symlink into the real database, and two OTHER gates caught that immediately. It also stopped a plausible "fix" — symmetrising the containment metric would have reported 26 real historical facts, the Alaska purchase and the Treaty of Trianon among them, as defects to close |
 | spherical edges | the published 49th-parallel US/Canada border was **one segment 27.6 degrees of longitude wide**, and under s2 — which `sf` uses by default, and which any geodesic area requires — a segment is a GREAT CIRCLE that bulges poleward between two equal-latitude points. So it rendered as an arc reaching latitude 49.83, **92 km into Canada, booking 12.33 Mha of Canadian prairie to the United States** (eduaguilera/whep#529). 525 distinct edges were affected, displacing 292,481 km² of ground in total; Egypt's 22nd parallel contributed 235,890 ha over two edges. **No existing check could see any of it, by construction**: USA + CAN = 1.0000 in every cell, no overlap, no gap, planar area unchanged to the bit — a clean mutual displacement, and conservation checks detect non-conservation, not misattribution. Half of it was ours: CShapes stores that border with 124 vertices, and `build_database.py`'s own `SimplifyPreserveTopology(0.01)` deleted all 124, because Douglas-Peucker measures deviation from the chord in PLANAR degrees. The build now densifies **after** simplifying |
 
-`.github/workflows/validate.yml` runs **all thirty, plus the self-test,** on push to `main` and on PRs.
+`.github/workflows/validate.yml` runs **all thirty-five, plus the self-test,** on push to `main` and on PRs.
 The self-test also checks that claim: a gate script the workflow never mentions fails it, because a gate
 absent from CI passes on its author's machine and never runs again — which is exactly what happened to the
 live-name-ambiguity gate between writing it and registering it.

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -23,9 +23,10 @@ data/final/ holds a MUTATED input, then runs one gate against it and requires a
 non-zero exit AND that the output names the injected defect. The real data is
 never written to.
 
-Nine cases: three geometry gates mutating the GeoPackage, four contract gates
-mutating a CSV, one mutating a WIKI PAGE -- the source of truth every other artefact
-derives from -- and one mutating a BUILDER SCRIPT's own literal. Nine of twenty-four, chosen by what it would cost if the gate were
+Fifteen cases, each mutating one input: the GeoPackage for the geometry gates, a CSV
+or the alias registry for the contract gates, a WIKI PAGE -- the source of truth every
+other artefact derives from -- for build_database, and a BUILDER SCRIPT's own literal
+for the reporting-area aggregates. Fifteen of twenty-eight, chosen by what it would cost if the gate were
 inert rather than by what is easy to mutate -- case 6 guards the invariant that a
 retired polity never receives data, which is not otherwise detectable, because a
 retired duplicate carries the same name, iso3 and often a valid geometry as its live
@@ -623,6 +624,54 @@ def mutate_spherically_degenerate_ring(root, gpd, make_valid, affinity):
         f"replaced {victim}'s geometry with a GEOS-valid ring whose edges 0 and 2 are "
         f"4e-10 m apart, which s2 reads as a self-crossing"
     )
+def mutate_shared_polygon(root, gpd, make_valid, affinity):
+    """Bind STP-1800-2025 back to CShapes 2.0 feature 411, which is Equatorial Guinea.
+
+    Not a synthetic mutation: it is the exact state the row shipped in, and still the
+    state of WHEP's embedded copy at 603 rows. Sao Tome and Principe is two islands
+    250 km offshore; feature 411 is mainland Rio Muni plus Bioko. Both rows were
+    therefore handed one polygon, and cell (10.25, 1.75) claimed 2.0000x its own area
+    (whep#514).
+
+    `polygon_area_km2` is blanked as well, and that is the load-bearing part. With an
+    area recorded, validate_polygons check A compares 1,002 km2 against ~28,000 and
+    catches it; without one it cannot compare at all, which is the 76% blind spot that
+    gate's own docstring names. The defect shipped in the blind spot, so the mutation
+    has to as well.
+
+    The GeoPackage is written FRESH into `root` rather than into a staged copy. A copy
+    would already contain a layer named `polities`, and `to_file` without an explicit
+    layer writes one named after the FILE -- so the gate would read layer 0, see
+    unmutated data, pass, and this harness would report a working gate as one that
+    cannot fail. Cost half an hour to find; recorded so the next geometry case does not
+    repeat it.
+    """
+    path = os.path.join(root, "data/final/polities_database.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    head = rows[0]
+    idx = {name: head.index(name) for name in (
+        "polity_code", "polygon_source", "polygon_feature_id",
+        "polygon_feature_year", "polygon_status", "polygon_area_km2")}
+    hit = 0
+    for r in rows:
+        if len(r) > max(idx.values()) and r[idx["polity_code"]] == "STP-1800-2025":
+            r[idx["polygon_source"]] = "cshapes-2.0"
+            r[idx["polygon_feature_id"]] = "411"
+            r[idx["polygon_feature_year"]] = "1900"
+            r[idx["polygon_status"]] = "assigned"
+            r[idx["polygon_area_km2"]] = ""
+            hit += 1
+    assert hit == 1, f"expected one STP-1800-2025 row, found {hit}"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        csv.writer(fh).writerows(rows)
+
+    g = gpd.read_file(GPKG)
+    src = g.loc[g.polity_code == "GNQ-1968-2025", "geometry"].iloc[0]
+    i = g.index[g.polity_code == "STP-1800-2025"][0]
+    g.loc[i, "geometry"] = src
+    g.to_file(os.path.join(root, "data/final/polities_database.gpkg"), driver="GPKG")
+    return "gave STP-1800-2025 Equatorial Guinea's CShapes feature 411 and blanked its area"
 
 
 CASES = (
@@ -737,6 +786,10 @@ CASES = (
         "SWE-1800-1809",
         "a polygon GEOS calls valid that s2 cannot load, so every geodesic area and "
         "every grid intersection over it aborts",
+        "validate_shared_polygons.py",
+        mutate_shared_polygon,
+        "STP-1800-2025",
+        "two coexisting live polities on one polygon, which claims the ground twice",
     ),
 )
 
@@ -838,6 +891,16 @@ WRITABLE = {
     ),
     "build_database.py": ("polities_database.csv", "wiki/polities"),
     "validate_reporting_areas.py": ("scripts/sources/reporting-areas/build.py",),
+    # Rewrites the CSV, so that must be a real copy. The GeoPackage is deliberately
+    # NOT listed: the mutation writes a fresh one into `root`, and staging a copy
+    # first would give the file two layers and let the gate read the unmutated one.
+    # The FAOSTAT map is listed only so it is PRESENT — the gate reads it to say
+    # whether a consumer can reach the polities involved, and reports "not
+    # FAOSTAT-mapped" for everything if it is absent.
+    "validate_shared_polygons.py": (
+        "polities_database.csv",
+        "faostat_area_polity_map.csv",
+    ),
     # sources.yaml is read before any page is parsed, so without it the gate dies with a
     # FileNotFoundError -- exit 1 for the wrong reason, which the "must name the defect"
     # requirement is what caught.

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -786,6 +786,8 @@ CASES = (
         "SWE-1800-1809",
         "a polygon GEOS calls valid that s2 cannot load, so every geodesic area and "
         "every grid intersection over it aborts",
+    ),
+    (
         "validate_shared_polygons.py",
         mutate_shared_polygon,
         "STP-1800-2025",

--- a/scripts/validate_constants.py
+++ b/scripts/validate_constants.py
@@ -9,9 +9,12 @@ something they must not disagree about — and nothing would notice.
 The two that matter:
 
   DEAD_STATUS   which wiki_status values mean "this row must never receive data".
-                Defined FIVE times: write_manifest, validate_polygons,
-                validate_aliases, validate_spatial_containment, and
-                matchlib.Matcher. If the matcher's copy drifted from the
+                Defined SIX times: write_manifest, validate_polygons,
+                validate_aliases, validate_spatial_containment,
+                validate_shared_polygons and matchlib.Matcher. The sixth was added
+                here in the same commit as the gate that holds it, which is the point
+                — the README already warned that "a consumer hardcoding a sixth is how
+                it drifts". If the matcher's copy drifted from the
                 manifest's, the matcher would route data to a row the published
                 contract calls dead — the exact failure the contract exists to
                 prevent, arriving through the back door.
@@ -68,6 +71,7 @@ dead_sources = {
     "scripts/validate_polygons.py": None,
     "scripts/validate_aliases.py": None,
     "scripts/validate_spatial_containment.py": None,
+    "scripts/validate_shared_polygons.py": None,
     "pipelines/polity-autoimprove/matchlib.py": None,
 }
 for rel in list(dead_sources):

--- a/scripts/validate_shared_polygons.py
+++ b/scripts/validate_shared_polygons.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""No two polities that COEXIST in time may be bound to the same polygon.
+
+Two live rows carrying one polygon means the ground inside it is claimed twice.
+Any area-weighted use then double-counts: intersect the polity set against a grid
+and the cell is handed to both in full, so a per-hectare rate applied to claimed
+territory delivers the cell's quantity twice, and re-aggregating back to a polity
+inflates whichever one holds the duplicate.
+
+MEASURED IN THE CONSUMER, which is where it surfaced (eduaguilera/whep#514). The
+WHEP R package's embedded copy of this database holds 579 live rows with geometry
+and 470 distinct polygons, and TWELVE cross-family pairs coexist while sharing a
+polygon. Intersecting its 205 live real polities for 2015 against the 0.5 degree
+grid, 451 of 67,691 cells claim more territory than they contain, 12.72 Mha in
+excess, worst ratio 2.0000x. The named instance is cell (10.25, 1.75), inside
+mainland Rio Muni: GNQ-1968-2025 and STP-1800-2025 were both bound to CShapes 2.0
+feature 411, so Equatorial Guinea's polygon was handed to Sao Tome and Principe as
+well and each claimed the cell in full.
+
+WHY THIS GATE IS NEW WORK RATHER THAN A DUPLICATE. The defect was injected back
+into a copy of this repository at the wiki, the CSV and the GeoPackage together --
+STP-1800-2025 rebound to cshapes-2.0/411@1900 with polygon_area_km2 blanked, which
+is exactly the state the row shipped in -- and then all 27 validate/crosscheck/
+audit gates were run against it. Every one exited 0 and not one named
+STP-1800-2025. So did build_database.py --check, write_manifest.py --check and
+write_faostat_area_map.py --check. The suite is blind to this, for reasons that are
+individually defensible:
+
+  validate_polygons          compares MEASURED against RECORDED area, and the row
+                             recorded none. That is the 76% blind spot its own
+                             docstring names.
+  validate_spatial_containment reports a polity holding >=3 contemporaneous
+                             polities of other families. Two identical polygons
+                             contain each other and nothing else, so the pair sits
+                             two below the threshold -- the single-swallow blind
+                             spot that gate documents, in its extreme form.
+  validate_family_areas      compares a period against its own FAMILY median, and
+                             STP has one row, so there is no median to be out of
+                             scale with.
+  validate_polygon_period_fit / _binding_determinism
+                             ask whether a binding resolves to the right STEP of
+                             the source it names. 411@1900 resolves cleanly and
+                             deterministically; it is simply the wrong country.
+  build_database --check      compares the artefacts against the wiki. When the
+                             wiki is what is wrong, they agree.
+
+Nothing asked the one question that settles it: does any OTHER live polity already
+hold this polygon?
+
+TWO SIGNALS, because a binding and a geometry can each be wrong without the other:
+
+  A  BINDING   two coexisting live rows declaring the same (polygon_source,
+               polygon_feature_id, polygon_feature_year). Reads the CSV only, so it
+               fires on a wiki edit before any polygon is fetched or attached, and
+               names the field to change.
+  B  GEOMETRY  two coexisting live rows whose polygons are geometrically the same,
+               measured as intersection-over-union above --identical. Catches what A
+               cannot: the same territory reached through two different sources, or
+               through `constructed`, where the declared bindings differ and the
+               ground does not.
+
+WHAT IS LEGITIMATE AND DELIBERATELY NOT REPORTED. Sharing a polygon is normal when
+the rows do NOT coexist: successive periods of one territory that saw no boundary
+change are bound to the same feature on purpose, and there are 173 such pairs today.
+A further 19 shared-polygon pairs are cross-family and sequential -- a successor
+reusing its predecessor's step -- which is a real error class, and the one
+validate_polygon_period_fit exists for; it is not re-litigated here. This gate asks
+only about rows whose spans OVERLAP, where no reading makes two claims on one piece
+of ground correct.
+
+BOUNDARY OF WHAT THIS GATE FIXES. It does not assert that a cell's claimed
+territory never exceeds the cell. It cannot, and pretending otherwise would be the
+same silent renormalisation that hid this defect: 188 coexisting live pairs overlap
+by more than 1 km2 in 2015, totalling 331,429 km2, and the large ones are history
+and dispute rather than mis-binding -- ESH-1975-2025 / MAR-1979-2025 267,078 km2
+(Western Sahara), SAU-1924-2025 / YEM-1990-2025 29,918 km2 (the Rub al Khali
+frontier), ESP-1800-2025 / ICN-1800-2025 7,027 km2 and CHN-1950-2025 /
+HKG-1842-2025 889 km2 (a sub-polity inside its parent's polygon). Deciding which
+row owns that ground is a territorial judgement and belongs in an issue, not in a
+threshold here.
+
+Usage:
+  python3 scripts/validate_shared_polygons.py [--identical 0.9999]
+"""
+import argparse
+import csv
+import hashlib
+import os
+import sys
+from collections import defaultdict
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CSV = os.path.join(REPO, "data/final/polities_database.csv")
+GPKG = os.path.join(REPO, "data/final/polities_database.gpkg")
+FAOSTAT_MAP = os.path.join(REPO, "data/final/faostat_area_polity_map.csv")
+EQUAL_AREA = "ESRI:54034"
+DEAD_STATUS = ("retired", "superseded")
+
+# The twelve cross-family pairs that DO coexist while sharing a polygon in the
+# consumer's embedded copy, measured on WHEP's data/polities.rda at 603 rows. Every
+# one is resolved in this repository already -- by rebinding one side, or by retiring
+# it so it can never receive data -- and each is pinned by name so a regression is
+# reported as a named historical instance rather than as an anonymous new finding.
+#
+# Pinned as pairs rather than as expected resolutions on purpose. Retiring a row is a
+# legitimate resolution and un-retiring it is a legitimate change, and either way
+# signals A and B decide whether the pair is a defect TODAY; the pin's job is to name
+# it when it is. What the pin does assert unconditionally is that both codes still
+# exist, so a pin cannot go quietly inert by referring to a row that has been renamed
+# away.
+REGRESSION_PAIRS = frozenset({
+    # The pair issue 514 was filed for: Equatorial Guinea's CShapes feature 411 handed
+    # to Sao Tome and Principe, 250 km offshore, for the whole 1800-2025 span. Fixed
+    # here on 2026-07-24 by binding STP to GADM 4.1 adm0 `STP` (1,002 km2) as a proxy.
+    ("GNQ-1968-2025", "STP-1800-2025"),
+    ("GNQ-1886-1968", "STP-1800-2025"),
+    # San Marino carrying Albania's polygon, 470x too large -- validate_polygons check A
+    # found this one, because SMR happened to record an area.
+    ("ALB-1913-2025", "SMR-1800-2025"),
+    # Modern Djibouti duplicated as DJI-1886-2025 and FRS-1977-2025 on one polygon.
+    ("DJI-1886-2025", "FRS-1977-2025"),
+    # Colonial Angola on the same feature as the modern row that outlives it.
+    ("AGO-1816-2025", "ANG-1905-1975"),
+    # Indonesia carrying India's polygon, in two period pairs.
+    ("IDN-1800-1889", "IND-1800-1893"),
+    ("IDN-1889-1945", "IND-1914-1937"),
+    # Iran bound to Cliopatria's "United States of America" -- a mis-binding of
+    # plausible SIZE (1,586,287 km2 against 1,621,564), so no area check could see it.
+    ("IRN-1800-1828", "USA-1803-1848"),
+    # Two prefixes for Morocco, overlapping 1956-1958 on one polygon.
+    ("MAR-1911-1958", "MOR-1956-1958"),
+    # Northern Nigeria on Norway's feature -- the same 4,000 km error the succession
+    # gate found from the other direction.
+    ("NNI-1904-1913", "NOR-1800-2025"),
+    # Ottoman Empire and Turkey, two prefixes for one state, on one CShapes feature.
+    ("OTT-1886-1908", "TUR-1800-1913"),
+    ("OTT-1908-1912", "TUR-1800-1913"),
+})
+
+# Coexisting pairs that share a polygon ON PURPOSE. Empty, and there is currently no
+# case for one: two live rows on one polygon double-count by construction, so an
+# entry here would have to argue that the double count is wanted. frozenset rather
+# than a bare literal because `{}` is a DICT and set arithmetic on it raises
+# TypeError -- see the note in selftest_gates.check_every_gate_runs_in_ci.
+BASELINE_SHARED = frozenset()
+
+
+def coexist(a: dict, b: dict) -> bool:
+    """Spans that overlap. `end_year` is EXCLUSIVE, so a shared transition year --
+    one row ending where the next begins -- is not coexistence."""
+    return (
+        a["start_year"] < b["end_year"] and b["start_year"] < a["end_year"]
+    )
+
+
+def read_rows() -> list:
+    with open(CSV, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    live = []
+    for r in rows:
+        if (r.get("wiki_status") or "") in DEAD_STATUS:
+            continue
+        try:
+            r["start_year"] = int(r["start_year"])
+            r["end_year"] = int(r["end_year"])
+        except (TypeError, ValueError):
+            continue
+        live.append(r)
+    return live
+
+
+def faostat_reach() -> dict:
+    """Which FAOSTAT area codes reach each polity, so a finding says whether a
+    consumer can actually see it. A latent defect and a live one need different
+    urgency and the numbers do not distinguish them."""
+    reach = defaultdict(set)
+    if not os.path.exists(FAOSTAT_MAP):
+        return reach
+    with open(FAOSTAT_MAP, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            code = (r.get("polity_code") or "").strip()
+            if code:
+                reach[code].add((r.get("area_code") or "").strip())
+    return reach
+
+
+def describe(pair: tuple, reach: dict) -> str:
+    tags = []
+    for code in pair:
+        n = len(reach.get(code, ()))
+        how = f"FAOSTAT-mapped via {n} area code(s)" if n else "not FAOSTAT-mapped"
+        tags.append(f"{code} ({how})")
+    return " and ".join(tags)
+
+
+def signal_binding(live: list) -> set:
+    """Two coexisting live rows declaring the same source, feature and year."""
+    by_key = defaultdict(list)
+    for r in live:
+        fid = (r.get("polygon_feature_id") or "").strip()
+        if not fid:
+            continue
+        key = (
+            (r.get("polygon_source") or "").strip(),
+            fid,
+            (r.get("polygon_feature_year") or "").strip(),
+        )
+        by_key[key].append(r)
+    found = {}
+    for key, rs in by_key.items():
+        for i in range(len(rs)):
+            for j in range(i + 1, len(rs)):
+                if coexist(rs[i], rs[j]):
+                    pair = tuple(sorted((rs[i]["polity_code"], rs[j]["polity_code"])))
+                    found[pair] = key
+    return found
+
+
+def signal_geometry(live: list, threshold: float) -> dict:
+    """Two coexisting live rows whose polygons are the same ground.
+
+    Exact duplicates are found by hashing the WKB, which costs nothing and is what a
+    feature copied onto two rows produces. Near-duplicates -- the same territory
+    reached through two sources, so the vertices differ but the ground does not --
+    need a measurement, so intersecting candidate pairs are scored by
+    intersection-over-union in an equal-area projection.
+    """
+    import geopandas as gpd
+
+    g = gpd.read_file(GPKG)
+    g = g[~g.geometry.isna() & ~g.geometry.is_empty].copy()
+    spans = {
+        r["polity_code"]: {"start_year": r["start_year"], "end_year": r["end_year"]}
+        for r in live
+    }
+    g = g[g.polity_code.isin(spans)].copy()
+
+    found = {}
+    # Exact: identical serialised geometry.
+    by_hash = defaultdict(list)
+    for code, geom in zip(g.polity_code, g.geometry):
+        by_hash[hashlib.sha256(geom.wkb).hexdigest()].append(code)
+    for codes in by_hash.values():
+        for i in range(len(codes)):
+            for j in range(i + 1, len(codes)):
+                if coexist(spans[codes[i]], spans[codes[j]]):
+                    found[tuple(sorted((codes[i], codes[j])))] = 1.0
+
+    # Near: same ground, different vertices. buffer(0) heals self-intersections that
+    # would otherwise make .area unreliable, as in validate_spatial_containment.
+    eq = g.to_crs(EQUAL_AREA).copy()
+    eq["geometry"] = eq.geometry.buffer(0)
+    eq["area_km2"] = eq.geometry.area / 1e6
+    area = dict(zip(eq.polity_code, eq.area_km2))
+    geo = dict(zip(eq.polity_code, eq.geometry))
+    pairs = gpd.sjoin(
+        eq[["polity_code", "geometry"]],
+        eq[["polity_code", "geometry"]],
+        how="inner",
+        predicate="intersects",
+    )
+    for a, b in zip(pairs.polity_code_left, pairs.polity_code_right):
+        if a >= b:
+            continue
+        key = (a, b)
+        if key in found:
+            continue
+        if not coexist(spans[a], spans[b]):
+            continue
+        smaller = min(area[a], area[b])
+        if smaller <= 0 or max(area[a], area[b]) / smaller > 1.01:
+            continue  # too different in size to be the same ground
+        union = geo[a].union(geo[b]).area
+        if union <= 0:
+            continue
+        iou = geo[a].intersection(geo[b]).area / union
+        if iou >= threshold:
+            found[key] = iou
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--identical",
+        type=float,
+        default=0.9999,
+        help="intersection-over-union above which two polygons are the same ground",
+    )
+    args = ap.parse_args()
+
+    live = read_rows()
+    reach = faostat_reach()
+    codes = {r["polity_code"] for r in live}
+    all_codes = set()
+    with open(CSV, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            all_codes.add(r["polity_code"])
+
+    problems = []
+
+    binding = signal_binding(live)
+    print(f"{len(live)} live polities; {len(binding)} coexisting pair(s) declaring "
+          f"one polygon binding")
+    for pair, key in sorted(binding.items()):
+        if pair in BASELINE_SHARED:
+            print(f"  BASELINED {pair[0]} / {pair[1]} both declare {key}")
+            continue
+        problems.append(
+            f"SHARED BINDING {pair[0]} / {pair[1]} both declare "
+            f"polygon_source={key[0]!r} polygon_feature_id={key[1]!r} "
+            f"polygon_feature_year={key[2]!r}, and their spans overlap — "
+            f"{describe(pair, reach)}"
+        )
+
+    geometry = {}
+    if os.path.exists(GPKG):
+        try:
+            geometry = signal_geometry(live, args.identical)
+        except ImportError as exc:
+            problems.append(
+                f"geopandas unavailable ({exc}), so signal B did not run — a shared "
+                f"polygon reached through two different sources would go unreported"
+            )
+    else:
+        problems.append(f"{GPKG} missing, so signal B did not run")
+    print(f"{len(geometry)} coexisting pair(s) whose polygons are the same ground "
+          f"(IoU >= {args.identical})")
+    for pair, iou in sorted(geometry.items()):
+        if pair in BASELINE_SHARED:
+            print(f"  BASELINED {pair[0]} / {pair[1]} IoU {iou:.6f}")
+            continue
+        problems.append(
+            f"SHARED POLYGON {pair[0]} / {pair[1]} occupy the same ground "
+            f"(IoU {iou:.6f}) while their spans overlap — {describe(pair, reach)}"
+        )
+
+    # Bidirectional arm: a baselined pair that no longer shares must be removed, or
+    # the baseline drifts into a licence nobody re-checks.
+    observed = set(binding) | set(geometry)
+    for pair in sorted(BASELINE_SHARED - observed):
+        problems.append(
+            f"{pair[0]} / {pair[1]} is baselined as a deliberate shared polygon but no "
+            f"longer shares one — remove it from BASELINE_SHARED"
+        )
+
+    # ---------- the regression pins ----------
+    print(f"\nregression pins: {len(REGRESSION_PAIRS)} pair(s) that shared a polygon "
+          f"in the consumer's embedded copy")
+    for pair in sorted(REGRESSION_PAIRS):
+        missing = [c for c in pair if c not in all_codes]
+        if missing:
+            problems.append(
+                f"pinned pair {pair[0]} / {pair[1]} names {missing}, which is not in "
+                f"the database — the pin cannot fail, so update it deliberately "
+                f"rather than leaving it inert"
+            )
+            continue
+        if pair in observed:
+            problems.append(
+                f"REGRESSION {pair[0]} / {pair[1]} shares a polygon again — this is a "
+                f"pinned historical defect (whep#514)"
+            )
+            continue
+        dead = [c for c in pair if c not in codes]
+        verb = "receives" if len(dead) == 1 else "receive"
+        how = f"resolved: {', '.join(dead)} no longer {verb} data" if dead \
+            else "resolved: distinct polygons"
+        print(f"  {pair[0]} / {pair[1]} — {how}")
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)\n")
+        for p in problems:
+            print(f"  {p}")
+        print("\n  Two live rows on one polygon claim the same ground twice, and a "
+              "crosswalk that renormalises each cell to sum to 1 absorbs it into a "
+              "plausible-looking split rather than surfacing it.")
+        return 1
+
+    print("\nPASS: no two coexisting live polities share a polygon, and every pinned "
+          "historical pair is still resolved")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wiki/polities/gnq-1968-2025.md
+++ b/wiki/polities/gnq-1968-2025.md
@@ -51,3 +51,13 @@ None yet.
 ### oq-gnq-bioko-mainland
 
 Bioko-mainland territorial unity. Equatorial Guinea consists of discontinuous territory (Bioko island and mainland Rio Muni). Whether the WHEP polygon properly captures both components needs verification.
+
+## No longer shared with São Tomé (2026-08-05)
+
+This row's CShapes feature 411 was, until 2026-07-24, also the polygon of
+[STP-1800-2025](stp-1800-2025.md) — two islands 250 km offshore. Both rows are live
+across 1968-2025, so the ground inside 411 was claimed twice, and in WHEP's embedded
+copy cell (10.25, 1.75) claimed **2.0000×** its own area. STP is now bound to GADM 4.1
+adm0 `STP`; this row is unchanged and remains correct. `scripts/validate_shared_polygons.py`
+pins the pair, so the two cannot silently share a polygon again. Filed as
+eduaguilera/whep#514.

--- a/wiki/polities/stp-1800-2025.md
+++ b/wiki/polities/stp-1800-2025.md
@@ -73,3 +73,35 @@ Modern borders are appropriate here — the territory is two islands whose
 coastline has not changed — but the status stays `proxy` rather than `assigned`
 because the polygon is a present-day feature standing in for the full
 1800-2025 span, not a period-accurate one.
+
+## What the old binding cost downstream, and what now stops it returning (2026-08-05)
+
+The consequence of the pre-2026-07-24 binding was measured in the consumer, and it
+is larger than a wrong polygon on one page. While this row carried CShapes feature
+411, it and both `GNQ` rows held **one** polygon, so the ground inside it was claimed
+twice. Intersecting the 205 live real polities of WHEP's embedded copy for 2015
+against the 0.5 degree grid, **451 of 67,691 cells claim more territory than they
+contain**, 12.72 Mha in excess, worst ratio **2.0000×** — cell (10.25, 1.75), inside
+mainland Rio Muni, handed in full to Equatorial Guinea and to São Tomé and Príncipe
+alike. Eleven other cross-family pairs did the same thing in that copy. It stayed
+invisible because the consumer's crosswalk renormalises each cell's polity fractions
+to sum to 1, which absorbs the overlap into a plausible-looking split.
+
+None of this repository's other checks could see it: the area check had no recorded
+`polygon_area_km2` to compare against, the containment check reports a polygon holding
+three or more contemporaneous polities and two identical polygons hold one each, and
+the period-fit and determinism checks both confirm that `411@1900` resolves cleanly —
+it was simply the wrong country. `scripts/validate_shared_polygons.py` now asks the
+question that settles it, and pins this pair by name, so the binding cannot return
+without a named failure. Filed as eduaguilera/whep#514.
+
+**The `cow_code` half of the same confusion is still open.** CShapes labels cowcode
+411 as Equatorial Guinea, and this page took 411 for its polygon *and* for its
+`cow_code`. The polygon is fixed; the `cow_code` still reads 411, which
+`scripts/validate_cow_codes.py` carries as a baselined collision with
+`GNQ-1886-1968`. The COW state system entry cited above gives `ccode=403` for
+`stateabb=STP`, so the value is answerable from a source this repository has already
+ingested — see [oq-cow-code-and-polygon-verification](#oq-cow-code-and-polygon-verification).
+It is deliberately not changed here, because `cow_code` is an identity field a
+consumer resolves against and correcting it re-fingerprints the published contract,
+which is a separate change from adding a gate.


### PR DESCRIPTION
## What was wrong

Two live polities can be bound to the **same polygon**, so the ground inside it is claimed twice. Any area-weighted use then double-counts: intersect the live polity set against a grid and the cell is handed to both in full.

**The binding itself is already fixed in this repository.** `STP-1800-2025` moved off CShapes 2.0 feature 411 (Equatorial Guinea) to GADM 4.1 adm0 `STP` on 2026-07-24, and at `origin/main` there are **zero** coexisting live pairs sharing a polygon. So the data half of whep#514 does not reproduce here, and I say so rather than re-fixing it.

What *is* missing is the standing assertion. The defect was found in the consumer, not by this repository, and nothing here would have caught it or would catch the next one.

## Evidence it reproduced BEFORE the change

**Measured in the consumer** — WHEP's embedded `data/polities.rda` at 603 rows, exported to a GeoPackage and intersected against the 0.5 degree grid with the same live-real filter the issue used (`wiki_status` not in retired/superseded, `polity_type != "aggregate"`, `start_year <= 2015 < end_year`), areas in `ESRI:54034`:

| quantity | measured | issue #514 claims |
|---|---|---|
| live real polities with geometry, 2015 | 205 | — |
| cells whose claimed area exceeds their own | **451 of 67,691** | 441 of 67,629 |
| worst ratio | **2.0000x** | 2.0000x |
| worst-cell identity | `(10.25, 1.75)` present at exactly 2.0000x | `(10.25, 1.75)` |
| excess territory, 2015 | **12.72 Mha** | 12.68 Mha |
| live rows with geometry / distinct polygons | **579 / 470** | — |

The small differences are grid-extent and projection choices, not disagreement. **The issue's claim verified.**

It is also **not only GNQ/STP**. Hashing the WKB of every live row and pairing coexisting rows of different families found **twelve** pairs on one polygon in that copy:

```
AGO-1816-2025 == ANG-1905-1975      IDN-1889-1945 == IND-1914-1937
ALB-1913-2025 == SMR-1800-2025      IRN-1800-1828 == USA-1803-1848
DJI-1886-2025 == FRS-1977-2025      MAR-1911-1958 == MOR-1956-1958
GNQ-1886-1968 == STP-1800-2025      NNI-1904-1913 == NOR-1800-2025
GNQ-1968-2025 == STP-1800-2025      OTT-1886-1908 == TUR-1800-1913
IDN-1800-1889 == IND-1800-1893      OTT-1908-1912 == TUR-1800-1913
```

All twelve are resolved at `origin/main` — by rebinding one side, or by retiring it so it can never receive data. The same sweep on `data/final/polities_database.gpkg` at my base commit: **671 live rows with geometry, 531 distinct polygons, 0 coexisting pairs sharing one.**

### And the suite is blind to it

This is the load-bearing measurement. I injected the defect back into a full copy of this repository **at the wiki, the CSV and the GeoPackage together** — `STP-1800-2025` rebound to `cshapes-2.0/411@1900` with `polygon_area_km2` blanked, which is the exact state the row shipped in — then ran everything:

```
30 validate_*/crosscheck_*/audit_* gates   30 passed, 0 failed, 0 named STP-1800-2025
build_database.py --check                  exit 0
write_manifest.py --check                  exit 0
write_faostat_area_map.py --check          exit 0
```

(Re-run after merging `origin/main`, so the three gates main added on 2026-08-05 —
`validate_polygon_validity`, `validate_order_decided_families`, `validate_chain_integrity`
— are included. None of them sees it either: a copied valid polygon stays valid, and
neither succession nor family typing is touched.)

Each blindness is individually defensible, which is why no single gate is at fault:

- `validate_polygons` compares **measured** against **recorded** area, and the row recorded none — the 76% blind spot its own docstring names.
- `validate_spatial_containment` reports a polygon holding **>=3** contemporaneous polities of other families. Two identical polygons contain each other and nothing else, so the pair sits two below the threshold: the single-swallow blind spot that gate documents, in its extreme form.
- `validate_family_areas` compares a period against its own **family** median, and `STP` has one row.
- `validate_polygon_period_fit` / `_binding_determinism` ask whether a binding resolves to the right **step**. `411@1900` resolves cleanly and deterministically; it is simply the wrong country.
- `build_database --check` compares the artefacts against the wiki. When the wiki is what is wrong, they agree.

Nothing asked the one question that settles it: **does any other live polity already hold this polygon?**

## What I changed

**`scripts/validate_shared_polygons.py`** — a new gate, registered in `validate.yml` and the README, with two signals because a binding and a geometry can each be wrong without the other:

- **A - BINDING** — two coexisting live rows declaring the same `(polygon_source, polygon_feature_id, polygon_feature_year)`. Reads the CSV only, so it fires on a wiki edit before any polygon is fetched, and names the field to change.
- **B - GEOMETRY** — two coexisting live rows whose polygons are the same ground, exact by WKB hash and near by intersection-over-union >= `--identical` (default 0.9999) in an equal-area projection. Catches what A cannot: the same territory reached through two different sources or through `constructed`, where the declared bindings differ and the ground does not.

Coexistence uses the repo's convention that `end_year` is **exclusive**, so a shared transition year is not coexistence. Findings print FAOSTAT reachability, so a latent defect is distinguishable from a live one.

**All twelve historical pairs are pinned by name** in `REGRESSION_PAIRS`, each with the story of what it was. The pin asserts unconditionally that both codes still exist, so it cannot go quietly inert by naming a row that has been renamed away. `BASELINE_SHARED` is an empty `frozenset` (not a bare literal — the `{}`-becomes-a-dict trap `selftest_gates` now checks structurally), and there is currently no case for an entry: two live rows on one polygon double-count by construction.

**`scripts/selftest_gates.py`** — a new case (17 after the merge). The mutation is not synthetic: it is the shipped state, `polygon_area_km2` blanked included, since the defect lived in the area check's blind spot and the mutation has to as well. Its docstring records a trap that cost real time: writing a GeoPackage into a *staged copy* with `to_file(driver="GPKG")` creates a second layer named after the file, so the gate reads layer 0, sees unmutated data, passes — and the harness reports a working gate as one that cannot fail. My first run of the blindness experiment above was invalid for exactly that reason and was redone.

**`scripts/validate_constants.py`** — registers the new file's `DEAD_STATUS` copy. That gate's own docstring warned that "a consumer hardcoding a sixth is how it drifts"; it is now the sixth and it is compared.

**Wiki** — `stp-1800-2025.md` and `gnq-1968-2025.md` record what the old binding cost downstream and what now stops it returning. Prose only; no frontmatter touched.

**README** — the gate's table row, and two counts that had drifted (twenty-five and twenty-four, both now thirty-one); the count is now tied to the script list `selftest_gates` enumerates, so it is checkable rather than prose.

**Merged `origin/main`** after three sibling PRs landed three new gates. Two conflicts, both the same shape — the README's geometry block and `selftest_gates`' `CASES` tuple, which now list all four new gates. Counts re-derived rather than incremented: thirty-one scripts, seventeen self-test cases.

## CI status: one inherited red, not from this change

`gh pr checks 142 --json` reports `validate: FAILURE`, and the job detail is unambiguous — **47 of 48 steps green, one failed**:

```
job validate: failure; 48 steps; failed:
  ['territory_basis.csv still describes the current database']
```

That step is the one #145 added a few minutes before this branch merged `main`, and **`main` itself is red on exactly the same step and nothing else** (run 31003031956, `main` @ 9548beb). It also fails identically in a clean worktree checked out at `origin/main`, so it is reproducible and not a flake.

The cause is structural, measured: `04_territory_basis.py --check` compares thirteen columns, and two of them derive from **gitignored** inputs, so no clean checkout can reproduce them — `layerb_data_rows` from `state/matched_rows.parquet` (449 of 749 rows differ) and `priority_review` from `state/territorial_flagged.json` (83 differ). Regenerating does not fix it; the next author regenerates *with* their cache and hands CI the same impossible comparison back.

Filed as #148 with the diagnosis and two ways out. Deliberately not fixed here: which columns belong in a committed artefact is that pipeline's call, not a passing PR's, and it blocks every branch equally. **The step this PR adds — `Polygons — no two coexisting polities on one polygon` — is green in CI, as is `Gates — prove they fail on an injected defect`.** The pre-merge commit's full run (31003154906, before #145 existed) was green end to end.

## How I verified

```
python3 scripts/validate_shared_polygons.py          PASS  (708 live, 0 shared, 12 pins resolved, 18s)
python3 scripts/selftest_gates.py                    PASS  17/17 fail on their defect and name it
all 31 validate_*/crosscheck_*/audit_* gates         31 passed, 0 failed
build/manifest/faostat-map/alias-map/wiki-index/
  feature-index --check                              all exit 0
git status --porcelain                               no data/final change, no mutation leak
```

The assertion count that fails without this change: **six** — signal A twice, signal B twice, and the regression pin twice (`GNQ-1886-1968` and `GNQ-1968-2025` both coexist with `STP-1800-2025`), each naming `STP-1800-2025` and the field to change.

## Moves published values

**No.** `data/final/` is untouched — no CSV row, no geometry, no manifest hash. The published contract is byte-identical. The data fix this gate defends landed on 2026-07-24 in a separate change; this PR only makes it impossible to lose again. That is why it is not a draft.

**Consumer consequence, for whoever picks up whep#530.** WHEP's embedded `data/polities.rda` is still at 603 rows against 749 here and still carries all twelve shared-polygon pairs, including `STP-1800-2025` on `cshapes-2.0/411@1900`. Re-syncing it from this repository's `data/final/polities_database.gpkg` is what makes the fix reach consumers; nothing in whep needs to change beyond that re-sync, and I touched nothing there. After the re-sync, WHEP's over-claim measurement should drop from 451 cells / 12.72 Mha to the residual described below.

## What I deliberately did not do

**I did not assert that a cell's claimed territory never exceeds the cell** — acceptance criterion 1 of whep#514. It is not satisfiable today and forcing it would be the same silent renormalisation that hid the defect. Measured on `data/final` at my base commit, for 2015: **188 coexisting live real pairs overlap by more than 1 km2, totalling 331,429 km2**, and the large ones are history and dispute, not mis-binding:

| pair | overlap | of the smaller | what it is |
|---|---|---|---|
| `ESH-1975-2025` / `MAR-1979-2025` | 267,078 km2 | 99.8% | Western Sahara — a live territorial dispute |
| `SAU-1924-2025` / `YEM-1990-2025` | 29,918 km2 | 6.6% | the Rub al Khali frontier |
| `ESP-1800-2025` / `ICN-1800-2025` | 7,027 km2 | 93.2% | Canary Islands, a sub-polity inside its parent |
| `ISR-1979-2025` / `PSE-1948-2025` | 6,150 km2 | 99.1% | the same, disputed |
| `CHN-1950-2025` / `HKG-1842-2025` | 889 km2 | 80.5% | Hong Kong inside China |

Two distinct classes — disputed ground, and a sub-polity nested inside a parent that also receives data — and both need a **territorial or accounting decision**, not a threshold in a gate. Filed separately (below) with these numbers. Note this residual is *larger* than the 12.72 Mha the shared polygons cost, so a consumer that re-syncs and re-measures will still see over-claimed cells; that is expected and is not this defect returning.

**I did not fix `STP-1800-2025`'s `cow_code`,** which still reads 411 — Equatorial Guinea's COW code — the surviving half of the very confusion that caused this issue, and a baselined collision in `validate_cow_codes.py`. The correction is answerable from a source this repo has ingested and the page already cites (`stateabb=STP, ccode=403`), but `cow_code` is an identity field a consumer resolves against, so changing it re-fingerprints the published contract. That is a separate change from adding a gate, and doing it mid-flight would disturb the whep#530 re-sync. Filed separately.

**I did not re-litigate sequential sharing.** 173 shared-polygon pairs today are successive periods of one family that saw no boundary change — correct and deliberate — and 19 are cross-family and sequential, which is a real error class and the one `validate_polygon_period_fit` and issue #121 exist for. This gate asks only about rows whose spans **overlap**, where no reading makes two claims on one piece of ground correct.

**I did not lower `validate_spatial_containment`'s `--min-contained`.** That would report 37 single-swallow cases, most of them real history, and its docstring already explains why. My gate closes the identical-polygon corner of that blind spot exactly, without judging the other 37.

## The open decision

Who owns the ground where two live rows genuinely overlap. The gate is silent on it on purpose. For the nested cases (`ESP`/`ICN`, `CHN`/`HKG`, `IND`/`HYD`) the question is whether a parent's polygon should be netted of the sub-polities that are themselves rows; for `ESH`/`MAR` and `ISR`/`PSE` it is a territorial attribution. Both are yours, not mine.

Closes eduaguilera/whep#514.
Part of the polity migration epic eduaguilera/whep#458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
