### PR TITLE
territory_basis.csv had stopped describing the database 122 commits ago

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -266,6 +266,10 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/update_wiki_index.py --check
 
+      - name: territory_basis.csv still describes the current database
+        if: '!cancelled()'
+        run: python3 pipelines/polity-autoimprove/04_territory_basis.py --check
+
       - name: Polygons — area agreement, claimed-but-absent, reviewed-means-documented
         if: '!cancelled()'
         run: python3 scripts/validate_polygons.py

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ python3 scripts/write_manifest.py --check
 python3 scripts/write_faostat_area_map.py --check
 python3 scripts/write_label_alias_map.py --check
 python3 scripts/update_wiki_index.py --check
+python3 pipelines/polity-autoimprove/04_territory_basis.py --check
 python3 scripts/write_feature_index.py --check
 
 # provenance and internal consistency

--- a/pipelines/polity-autoimprove/04_territory_basis.py
+++ b/pipelines/polity-autoimprove/04_territory_basis.py
@@ -24,7 +24,7 @@ A polity is "territory_assumed" (needs review) when basis != measured.
 The report focuses on polities overlapping the WINDOW (default 1860-1961).
 Data magnitude per polity is attached from the layer-B matched_rows when present.
 """
-import pandas as pd, numpy as np, json, os
+import pandas as pd, numpy as np, json, os, sys
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 H = os.path.join(REPO, "pipelines/polity-autoimprove/state")
 POLDB = os.path.join(REPO, "data/final/polities_database.csv")
@@ -126,7 +126,39 @@ for _, r in pol.iterrows():
     })
 
 out = pd.DataFrame(recs)
-out.to_csv(os.path.join(H, "territory_basis.csv"), index=False)
+_DEST = os.path.join(H, "territory_basis.csv")
+
+# --check mirrors the write_*.py convention in scripts/: regenerate in memory and compare,
+# exiting 1 on drift, so staleness is a CI failure rather than something a reader has to
+# notice. Added 2026-08-05 after this file was found 122 commits behind the database it
+# describes -- 721 rows against 749, with 28 polities simply absent. A derived file with no
+# freshness check is a file that silently stops describing its input, and this one feeds the
+# territory-basis assessment that answers "is WHEP carrying 1860-1961 data on borders that
+# were not the real territory" -- so 28 missing rows read as 28 polities with nothing to
+# worry about.
+if "--check" in sys.argv:
+    import io
+    fresh = out.to_csv(index=False)
+    if not os.path.exists(_DEST):
+        print(f"FAIL: {_DEST} missing; run this script without --check")
+        raise SystemExit(1)
+    committed = open(_DEST, encoding="utf-8").read()
+    if fresh.replace("\r\n", "\n") != committed.replace("\r\n", "\n"):
+        import csv as _csv
+        cf = {r["polity_code"] for r in _csv.DictReader(io.StringIO(fresh))}
+        cc = {r["polity_code"] for r in _csv.DictReader(io.StringIO(committed))}
+        print(f"FAIL: territory_basis.csv is stale ({len(cc)} committed rows vs "
+              f"{len(cf)} regenerated)")
+        if cf - cc:
+            print(f"  in the database but MISSING from the committed file: {sorted(cf - cc)}")
+        if cc - cf:
+            print(f"  in the committed file but no longer in the database: {sorted(cc - cf)}")
+        print("  rerun: python3 pipelines/polity-autoimprove/04_territory_basis.py")
+        raise SystemExit(1)
+    print(f"OK: territory_basis.csv matches the database ({len(out)} polities)")
+    raise SystemExit(0)
+
+out.to_csv(_DEST, index=False)
 
 ORDER = ["measured", "assumed_constant", "back_projected", "unassigned"]
 print(f"classified {len(out)} polities -> state/territory_basis.csv\n")

--- a/pipelines/polity-autoimprove/state/territory_basis.csv
+++ b/pipelines/polity-autoimprove/state/territory_basis.csv
@@ -1,88 +1,93 @@
 polity_code,polity_name,start_year,end_year,polygon_source,polygon_feature_year,polygon_status,overlaps_1860_1961,territory_basis,territory_assumed,priority_review,basis_reason,layerb_data_rows
-ADE-1839-1963,Aden Protectorate (1839-1963),1839,1963,cshapes-2.0,1967.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),18
-AEF-1910-1960,French Equatorial Africa (AEF),1910,1960,cshapes-2.0,1938.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),130
+ADE-1839-1963,Aden Protectorate (1839-1963),1839,1963,cshapes-2.0,1967.0,proxy,True,back_projected,True,False,polygon vintage 1967 is AFTER the period ends (1963) — later/modern border applied back,18
+AEF-1910-1960,French Equatorial Africa (AEF),1910,1960,constructed,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 50y span (1910-1960); borders may have changed,130
 AFG-1800-1893,Afghanistan (to 1893),1800,1893,cshapes-2.0,1888.0,assigned,True,assumed_constant,True,False,single 1888 polygon held across a 93y span (1800-1893); borders may have changed,0
 AFG-1893-1919,Afghanistan (1893-1919),1893,1919,cshapes-2.0,1893.0,assigned,True,assumed_constant,True,False,single 1893 polygon held across a 26y span (1893-1919); borders may have changed,0
 AFG-1919-2025,Afghanistan,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 106y span (1919-2025); borders may have changed,84
-AGO-1816-2025,Angola,1816,2025,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,True,single 1905 polygon held across a 209y span (1816-2025); borders may have changed,0
+AGO-1816-2025,Angola,1816,2025,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 209y span (1816-2025); borders may have changed,0
 AGO-1975-2025,"Angola (independent, 1975–2025)",1975,2025,cshapes-2.0,1975.0,assigned,False,assumed_constant,True,False,single 1975 polygon held across a 50y span (1975-2025); borders may have changed,0
 ALB-1913-2025,Albania (1913-2025),1913,2025,cshapes-2.0,1913.0,assigned,True,assumed_constant,True,False,single 1913 polygon held across a 112y span (1913-2025); borders may have changed,534
-ALK-1867-1959,Territory of Alaska,1867,1959,gadm-level1,2020.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),8078
+ALK-1867-1959,Territory of Alaska,1867,1959,gadm-4.1-adm1,2020.0,assigned,True,back_projected,True,True,polygon vintage 2020 is AFTER the period ends (1959) — later/modern border applied back,39
 AMI-1946-1953,Amami Islands (US-administered),1946,1953,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
 AND-1800-2025,Andorra,1800,2025,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 225y span (1800-2025); borders may have changed,4
 ANG-1800-1890,Angola (to 1890),1800,1890,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 90y span (1800-1890); borders may have changed,0
-ANG-1890-1891,Angola (1890-1891),1890,1891,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1890),0
-ANG-1891-1905,Angola (1891-1905),1891,1905,cshapes-2.0,1890.0,assigned,True,back_projected,True,False,polygon vintage 1890 is BEFORE the period starts (1891),6
-ANG-1905-1975,Angola (1905-1975),1905,1975,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 70y span (1905-1975); borders may have changed,488
-ANT-1816-1960,Dutch Caribbean (colonial),1816,1960,gadm-4.1,2024.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),58
-ANT-1961-2010,Netherlands Antilles,1961,2010,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+ANG-1890-1891,Angola (1890-1891),1890,1891,cshapes-2.0,1890.0,assigned,True,measured,False,False,vintage 1890 faithful to period 1890-1891,0
+ANG-1891-1905,Angola (1891-1905),1891,1905,cshapes-2.0,1891.0,assigned,True,measured,False,False,vintage 1891 faithful to period 1891-1905,6
+ANG-1905-1975,Angola (1905-1975),1905,1975,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,True,single 1905 polygon held across a 70y span (1905-1975); borders may have changed,488
+ANT-1816-1960,Dutch Caribbean (colonial),1816,1960,reporting-areas,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,58
+ANT-1961-2010,Netherlands Antilles,1961,2010,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 AOF-1895-1960,French West Africa (AOF),1895,1960,constructed,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 65y span (1895-1960); borders may have changed,162
-AOI-1936-1941,Italian East Africa (1936-1941),1936,1941,constructed,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),12
+AOI-1936-1941,Italian East Africa (1936-1941),1936,1941,constructed,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),10
 ARE-1892-2025,United Arab Emirates,1892,2025,cshapes-2.0,1913.0,assigned,True,assumed_constant,True,False,single 1913 polygon held across a 133y span (1892-2025); borders may have changed,0
-ARG-1800-1899,Argentina (to 1899),1800,1899,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 99y span (1800-1899); borders may have changed,106
-ARG-1800-2025,Argentina,1800,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 225y span (1800-2025); borders may have changed,4110
-ARG-1899-1902,Argentina (1899-1902),1899,1902,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1902,0
-ARG-1902-2025,Argentina,1902,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,True,single 1902 polygon held across a 123y span (1902-2025); borders may have changed,0
+ARG-1800-1899,Argentina (to 1899),1800,1899,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 99y span (1800-1899); borders may have changed,94
+ARG-1800-2025,Argentina,1800,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,True,single 1902 polygon held across a 225y span (1800-2025); borders may have changed,0
+ARG-1899-1902,Argentina (1899-1902),1899,1902,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1902,48
+ARG-1902-2025,Argentina,1902,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 123y span (1902-2025); borders may have changed,4074
 ARM-1991-2025,Armenia,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 ASH-1800-1896,Ashanti Empire,1800,1896,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-ASM-1900-2025,Territory of American Samoa,1900,2025,gadm-4.1,2023.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),38
+ASM-1900-2025,Territory of American Samoa,1900,2025,gadm-4.1-adm0,2023.0,assigned,True,assumed_constant,True,False,single 2023 polygon held across a 125y span (1900-2025); borders may have changed,38
 ATG-1800-2025,Antigua and Barbuda,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,122
 AUH-1800-1859,Austrian Empire (to 1859),1800,1859,cliopatria,1820.0,assigned,False,assumed_constant,True,False,single 1820 polygon held across a 59y span (1800-1859); borders may have changed,0
 AUH-1859-1866,Austrian Empire (1859-1866),1859,1866,cliopatria,1860.0,assigned,True,measured,False,False,vintage 1860 faithful to period 1859-1866,0
 AUH-1866-1908,Austria-Hungary (1866-1908),1866,1908,cliopatria,1880.0,assigned,True,assumed_constant,True,False,single 1880 polygon held across a 42y span (1866-1908); borders may have changed,0
 AUH-1908-1918,Austria-Hungary (1908-1918),1908,1918,cshapes-2.0,1908.0,assigned,True,measured,False,False,vintage 1908 faithful to period 1908-1918,0
-AUS-1800-1901,Australian Colonies (to 1901),1800,1901,cshapes-2.0,1901.0,proxy,True,assumed_constant,True,False,single 1901 polygon held across a 101y span (1800-1901); borders may have changed,928
-AUS-1901-2025,Australia,1901,2025,cshapes-2.0,1927.0,assigned,True,assumed_constant,True,False,single 1927 polygon held across a 124y span (1901-2025); borders may have changed,2393
+AUS-1800-1901,Australian Colonies (to 1901),1800,1901,cshapes-2.0,1901.0,proxy,True,assumed_constant,True,True,single 1901 polygon held across a 101y span (1800-1901); borders may have changed,715
+AUS-1901-2025,Australia,1901,2025,cshapes-2.0,1927.0,assigned,True,assumed_constant,True,True,single 1927 polygon held across a 124y span (1901-2025); borders may have changed,2411
 AUSA-1836-1900,South Australia (to 1900),1836,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 64y span (1836-1900); borders may have changed,195
-AUT-1800-1918,Austria (Cisleithania),1800,1918,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1217
-AUT-1918-1919,Austria (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,30
-AUT-1919-2025,Austria,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 106y span (1919-2025); borders may have changed,2085
-AUWA-1829-1900,Western Australia (to 1900),1829,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 71y span (1829-1900); borders may have changed,0
+AUT-1800-1918,Austria (Cisleithania),1800,1918,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1182
+AUT-1918-1919,Austria (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,35
+AUT-1919-2025,Austria,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 106y span (1919-2025); borders may have changed,2115
+AUWA-1829-1900,Western Australia (to 1900),1829,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 71y span (1829-1900); borders may have changed,195
 AZE-1991-2025,Azerbaijan,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 AZE-SSR-1920-1991,Azerbaijan SSR,1920,1991,cshapes-2.0,1991.0,proxy,True,assumed_constant,True,False,single 1991 polygon held across a 71y span (1920-1991); borders may have changed,27
 BCM-1916-1961,British Cameroons,1916,1961,cshapes-2.0,1953.0,assigned,True,assumed_constant,True,False,single 1953 polygon held across a 45y span (1916-1961); borders may have changed,23
+BDI-1922-1962,Burundi (within Ruanda-Urundi),1922,1962,cshapes-2.0,1962.0,assigned,True,assumed_constant,True,False,single 1962 polygon held across a 40y span (1922-1962); borders may have changed,0
 BDI-1962-2025,Burundi,1962,2025,cshapes-2.0,1962.0,assigned,False,assumed_constant,True,False,single 1962 polygon held across a 63y span (1962-2025); borders may have changed,0
 BDK-1800-1890,Kingdom of Burundi,1800,1890,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-BEC-1885-1966,Bechuanaland Protectorate (1885-1966),1885,1966,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),176
+BEC-1885-1966,Bechuanaland Protectorate (1885-1966),1885,1966,cshapes-2.0,1938.0,assigned,True,assumed_constant,True,True,single 1938 polygon held across a 81y span (1885-1966); borders may have changed,176
 BEL-1831-2025,Belgium,1831,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 194y span (1831-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),2475
 BEN-1895-1898,Benin (1895-1898),1895,1898,cshapes-2.0,1895.0,assigned,True,measured,False,False,vintage 1895 faithful to period 1895-1898,0
-BEN-1898-1960,Benin (1898-1960),1898,1960,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,False,single 1898 polygon held across a 62y span (1898-1960); borders may have changed,254
-BEN-1960-2025,Benin,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+BEN-1898-1960,Benin (1898-1960),1898,1960,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,False,single 1898 polygon held across a 62y span (1898-1960); borders may have changed,248
+BEN-1960-2025,Benin,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,6
 BFA-1919-1932,Upper Volta (1919-1932),1919,1932,cshapes-2.0,1947.0,assigned,True,back_projected,True,False,polygon vintage 1947 is AFTER the period ends (1932) — later/modern border applied back,67
-BFA-1947-1960,Burkina Faso (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,50
-BFA-1960-2025,Burkina Faso,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+BFA-1947-1960,Burkina Faso (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,40
+BFA-1960-2025,Burkina Faso,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,10
 BGA-1800-1894,Kingdom of Buganda,1800,1894,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BGD-1947-1971,East Pakistan (1947-1971),1947,1971,cshapes-2.0,1971.0,assigned,True,measured,False,False,vintage 1971 faithful to period 1947-1971,8
 BGD-1971-2025,Bangladesh,1971,2025,cshapes-2.0,1971.0,assigned,False,assumed_constant,True,False,single 1971 polygon held across a 54y span (1971-2025); borders may have changed,0
-BGR-1878-1913,Bulgaria (to 1913),1878,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 35y span (1878-1913); borders may have changed,543
-BGR-1913-1918,Bulgaria (1913-1918),1913,1918,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1918,228
+BGR-1878-1913,Bulgaria (to 1913),1878,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 35y span (1878-1913); borders may have changed,466
+BGR-1913-1918,Bulgaria (1913-1918),1913,1918,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1918,259
 BGR-1918-1919,Bulgaria (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,46
-BGR-1919-1940,Bulgaria (1919-1940),1919,1940,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1940,1371
-BGR-1940-2025,Bulgaria (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,980
+BGR-1919-1940,Bulgaria (1919-1940),1919,1940,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1940,1347
+BGR-1940-2025,Bulgaria (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,True,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,1050
 BHR-1800-2025,Bahrain,1800,2025,cshapes-2.0,1971.0,assigned,True,assumed_constant,True,False,single 1971 polygon held across a 225y span (1800-2025); borders may have changed,0
 BHS-1800-2025,Bahamas,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,14
 BIH-1992-2025,Bosnia and Herzegovina,1992,2025,cshapes-2.0,1992.0,assigned,False,assumed_constant,True,False,single 1992 polygon held across a 33y span (1992-2025); borders may have changed,0
 BKN-1800-1897,Kingdom of Benin,1800,1897,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BLI-1833-1960,British Leeward Islands Colony,1833,1960,gadm-4.1-adm0,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),20
 BLR-1991-2025,Belarus,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
-BLX-1850-1999,Belgium-Luxembourg,1850,1999,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+BLX-1850-1999,Belgium-Luxembourg,1850,1999,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BLX-1921-1999,Belgium-Luxembourg Economic Union,1921,1999,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BLZ-1800-1886,Belize (to 1886),1800,1886,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-BLZ-1800-2025,Belize,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,66
-BLZ-1886-1970,British Honduras,1886,1970,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 84y span (1886-1970); borders may have changed,0
+BLZ-1800-2025,Belize,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,0
+BLZ-1886-1970,British Honduras,1886,1970,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 84y span (1886-1970); borders may have changed,66
 BLZ-1970-1981,Belize (pre-independence),1970,1981,cshapes-2.0,1886.0,assigned,False,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1970),0
 BLZ-1981-2025,Belize,1981,2025,cshapes-2.0,1886.0,assigned,False,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1981),0
 BMB-1800-1899,Bemba Kingdom,1800,1899,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BMU-1684-1968,British Crown Colony of Bermuda,1684,1968,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,58
-BNB-1881-1963,British North Borneo,1881,1963,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,False,single 1889 polygon held across a 82y span (1881-1963); borders may have changed,502
+BMU-1968-2025,Bermuda,1968,2025,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
+BNB-1881-1963,British North Borneo,1881,1963,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,True,single 1889 polygon held across a 82y span (1881-1963); borders may have changed,344
 BND-1800-1887,Kingdom of Bundu,1800,1887,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BNU-1800-1893,Bornu Empire,1800,1893,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BNY-1800-1899,Kingdom of Bunyoro,1800,1899,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BOL-1825-1903,Bolivia (to 1903),1825,1903,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 78y span (1825-1903); borders may have changed,0
 BOL-1903-1909,Bolivia (1903-1909),1903,1909,cshapes-2.0,1903.0,assigned,True,measured,False,False,vintage 1903 faithful to period 1903-1909,0
-BOL-1909-1938,Bolivia (1909-1938),1909,1938,cshapes-2.0,1909.0,assigned,True,assumed_constant,True,False,single 1909 polygon held across a 29y span (1909-1938); borders may have changed,320
-BOL-1938-2025,Bolivia,1938,2025,cshapes-2.0,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 87y span (1938-2025); borders may have changed,361
-BRA-1800-2025,Brazil,1800,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 225y span (1800-2025); borders may have changed,3484
+BOL-1909-1938,Bolivia (1909-1938),1909,1938,cshapes-2.0,1909.0,assigned,True,assumed_constant,True,False,single 1909 polygon held across a 29y span (1909-1938); borders may have changed,269
+BOL-1938-2025,Bolivia,1938,2025,cshapes-2.0,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 87y span (1938-2025); borders may have changed,412
+BRA-1800-1903,Brazil (to 1903),1800,1903,cshapes-2.0,1890.0,polygon_vintage_drift,True,assumed_constant,True,False,single 1890 polygon held across a 103y span (1800-1903); borders may have changed,34
+BRA-1800-2025,Brazil,1800,2025,cshapes-2.0,1960.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+BRA-1903-1909,Brazil (1903-1909),1903,1909,cshapes-2.0,1905.0,assigned,True,measured,False,False,vintage 1905 faithful to period 1903-1909,36
+BRA-1909-2025,Brazil,1909,2025,cshapes-2.0,1930.0,assigned,True,assumed_constant,True,False,single 1930 polygon held across a 116y span (1909-2025); borders may have changed,3414
 BRB-1800-2025,Barbados,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,309
 BRG-1800-1897,Borgu Confederacy,1800,1897,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 BRL-1938-1945,Greater Berlin (1938-1945),1938,1945,cshapes-2.0,1938.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),19
@@ -90,85 +95,88 @@ BRL-1945-1949,Berlin (Allied Occupation),1945,1949,cshapes-2.0,1945.0,unassigned
 BRN-1816-1888,Brunei (greater),1816,1888,cshapes-2.0,1888.0,assigned,True,assumed_constant,True,False,single 1888 polygon held across a 72y span (1816-1888); borders may have changed,0
 BRN-1888-2025,Brunei Darussalam,1888,2025,cshapes-2.0,1888.0,assigned,True,assumed_constant,True,False,single 1888 polygon held across a 137y span (1888-2025); borders may have changed,77
 BSS-1884-1960,British Somaliland Protectorate (1884-1960),1884,1960,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 76y span (1884-1960); borders may have changed,86
-BSW-1841-1963,Sarawak (Brooke Raj / Crown Colony),1841,1963,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,False,single 1889 polygon held across a 122y span (1841-1963); borders may have changed,1
-BTL-1920-1957,British Togoland (1920-1957),1920,1957,composed-difference,1957.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),12
+BSW-1841-1963,Sarawak (Brooke Raj / Crown Colony),1841,1963,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,True,single 1889 polygon held across a 122y span (1841-1963); borders may have changed,45
+BTL-1920-1957,British Togoland (1920-1957),1920,1957,constructed,1957.0,assigned,True,assumed_constant,True,True,single 1957 polygon held across a 37y span (1920-1957); borders may have changed,12
 BTN-1800-2025,Bhutan,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,4
 BWA-1966-2025,Botswana,1966,2025,cshapes-2.0,1966.0,assigned,False,assumed_constant,True,False,single 1966 polygon held across a 59y span (1966-2025); borders may have changed,0
 BWI-1833-1962,British West Indies (colonial aggregate),1833,1962,gadm-4.1-adm0,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),24
 CAF-1906-1912,Central African Republic (1906-1912),1906,1912,cshapes-2.0,1906.0,assigned,True,measured,False,False,vintage 1906 faithful to period 1906-1912,0
 CAF-1912-1919,Central African Republic (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,0
-CAF-1919-1960,Central African Republic (1919-1960),1919,1960,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 41y span (1919-1960); borders may have changed,15
-CAF-1960-2025,Central African Republic,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
-CAN-1800-1866,Canada (pre-Confederation),1800,1866,gadm-composed-union,1800.0,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),40
-CAN-1866-1870,"Canada (original four provinces, 1866–1870)",1866,1870,gadm-4.1,2023.0,estimate,True,unassigned,True,False,no polygon (honest gap; never a false territory),5
-CAN-1866-1886,"Canada (Confederation era, to 1886)",1866,1886,cshapes-2.0,1886.0,proxy,True,measured,False,False,vintage 1886 faithful to period 1866-1886,56
-CAN-1870-1886,Canada (post-Rupert's Land 1870-1886),1870,1886,cshapes-2.0,1886.0,proxy,True,measured,False,False,vintage 1886 faithful to period 1870-1886,0
-CAN-1886-1948,Canada (to 1948),1886,1948,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 62y span (1886-1948); borders may have changed,2214
-CAN-1948-2025,Canada,1948,2025,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,True,single 1948 polygon held across a 77y span (1948-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),978
+CAF-1919-1960,Central African Republic (1919-1960),1919,1960,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 41y span (1919-1960); borders may have changed,14
+CAF-1960-2025,Central African Republic,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,1
+CAN-1800-1866,Canada (pre-Confederation),1800,1866,gadm-composed-union,1800.0,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),39
+CAN-1866-1870,"Canada (original four provinces, 1866–1870)",1866,1870,gadm-4.1,2023.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),4
+CAN-1866-1886,"Canada (Confederation era, to 1886)",1866,1886,cshapes-2.0,1886.0,proxy,True,measured,False,False,vintage 1886 faithful to period 1866-1886,0
+CAN-1870-1886,Canada (post-Rupert's Land 1870-1886),1870,1886,cshapes-2.0,1886.0,proxy,True,measured,False,False,vintage 1886 faithful to period 1870-1886,53
+CAN-1886-1948,Canada (to 1948),1886,1948,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 62y span (1886-1948); borders may have changed,2219
+CAN-1886-1949,Canada (to the Newfoundland accession),1886,1949,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 63y span (1886-1949); borders may have changed,0
+CAN-1948-2025,Canada,1948,2025,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,False,single 1948 polygon held across a 77y span (1948-2025); borders may have changed,978
+CAN-1949-2025,Canada,1949,2025,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 76y span (1949-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),0
 CAP-1800-1910,Cape Colony (to 1910),1800,1910,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 110y span (1800-1910); borders may have changed,536
 CAR-1920-1945,Caroline Islands (Japanese Mandate),1920,1945,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,31
 CAY-1800-1886,Kingdom of Cayor,1800,1886,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 CHE-1800-2025,Switzerland,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,3132
 CHL-1810-1883,Chile (to 1883),1810,1883,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),168
-CHL-1884-1899,Chile (1884-1899),1884,1899,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1884-1899,112
-CHL-1899-1902,Chile (1899-1902),1899,1902,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1902,36
-CHL-1902-2025,Chile,1902,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 123y span (1902-2025); borders may have changed,2353
+CHL-1884-1899,Chile (1884-1899),1884,1899,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1884-1899,105
+CHL-1899-1902,Chile (1899-1902),1899,1902,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1902,25
+CHL-1902-2025,Chile,1902,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 123y span (1902-2025); borders may have changed,2371
 CHN-1800-1895,China (to 1895),1800,1895,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 95y span (1800-1895); borders may have changed,5
-CHN-1895-1913,China (1895-1913),1895,1913,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1895-1913,5
-CHN-1913-1914,China (1913-1914),1913,1914,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1914,12
+CHN-1895-1913,China (1895-1913),1895,1913,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1895-1913,0
+CHN-1913-1914,China (1913-1914),1913,1914,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1914,17
 CHN-1914-1921,China (1914-1921),1914,1921,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1921,17
 CHN-1921-1932,China (1921-1932),1921,1932,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1921-1932,151
-CHN-1921-1945,China (1921-1945),1921,1945,cshapes-2.0,1921.0,assigned,True,measured,False,True,vintage 1921 faithful to period 1921-1945; footnote coverage caveat (FAO/IIA yearbook),382
-CHN-1932-1945,China (1932-1945),1932,1945,composed-difference,,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-CHN-1945-1947,China (1945-1947),1945,1947,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1947,69
-CHN-1947-1949,China (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,97
-CHN-1949-1950,China (1949-1950),1949,1950,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1949-1950,50
-CHN-1950-2025,China (PRC),1950,2025,cshapes-2.0,1949.0,assigned,True,back_projected,True,True,polygon vintage 1949 is BEFORE the period starts (1950); footnote coverage caveat (FAO/IIA yearbook),320
+CHN-1921-1945,China (1921-1945),1921,1945,cshapes-2.0,1921.0,assigned,True,measured,False,True,vintage 1921 faithful to period 1921-1945; footnote coverage caveat (FAO/IIA yearbook),0
+CHN-1932-1945,China (1932-1945),1932,1945,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year,361
+CHN-1945-1947,China (1945-1947),1945,1947,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1947,79
+CHN-1947-1949,China (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,27
+CHN-1949-1950,China (1949-1950),1949,1950,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1949-1950,112
+CHN-1950-2025,China (PRC),1950,2025,cshapes-2.0,1950.0,assigned,True,assumed_constant,True,True,single 1950 polygon held across a 75y span (1950-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),330
 CIV-1889-1893,Côte d'Ivoire (1889-1893),1889,1893,cshapes-2.0,1889.0,assigned,True,measured,False,False,vintage 1889 faithful to period 1889-1893,0
 CIV-1893-1900,Côte d'Ivoire (1893-1900),1893,1900,cshapes-2.0,1893.0,assigned,True,measured,False,False,vintage 1893 faithful to period 1893-1900,0
-CIV-1902-1932,Côte d'Ivoire (1902-1932),1902,1932,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 30y span (1902-1932); borders may have changed,127
-CIV-1932-1947,Côte d'Ivoire (1932-1947),1932,1947,cshapes-2.0,1933.0,assigned,True,measured,False,False,vintage 1933 faithful to period 1932-1947,188
-CIV-1947-1960,Côte d'Ivoire (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,164
-CIV-1960-2025,Côte d'Ivoire,1960,2025,cshapes-2.0,1983.0,assigned,True,assumed_constant,True,False,single 1983 polygon held across a 65y span (1960-2025); borders may have changed,0
+CIV-1902-1932,Côte d'Ivoire (1902-1932),1902,1932,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 30y span (1902-1932); borders may have changed,99
+CIV-1932-1947,Côte d'Ivoire (1932-1947),1932,1947,cshapes-2.0,1933.0,assigned,True,measured,False,False,vintage 1933 faithful to period 1932-1947,207
+CIV-1947-1960,Côte d'Ivoire (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,160
+CIV-1960-2025,Côte d'Ivoire,1960,2025,cshapes-2.0,1983.0,assigned,True,assumed_constant,True,False,single 1983 polygon held across a 65y span (1960-2025); borders may have changed,13
 CMR-1960-1961,Cameroon (1960-1961),1960,1961,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1960-1961,12
 CMR-1961-2025,Cameroon,1961,2025,cshapes-2.0,1961.0,assigned,True,assumed_constant,True,False,single 1961 polygon held across a 64y span (1961-2025); borders may have changed,0
 COD-1885-1891,Congo Free State (to 1891),1885,1891,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1885-1891,0
 COD-1891-1894,Democratic Republic of the Congo (1891-1894),1891,1894,cshapes-2.0,1892.0,assigned,True,measured,False,False,vintage 1892 faithful to period 1891-1894,0
-COD-1894-1910,Democratic Republic of the Congo (1894-1910),1894,1910,cshapes-2.0,1894.0,assigned,True,measured,False,False,vintage 1894 faithful to period 1894-1910,13
-COD-1910-1960,DR Congo (1910-1960),1910,1960,cshapes-2.0,1910.0,assigned,True,assumed_constant,True,True,single 1910 polygon held across a 50y span (1910-1960); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),855
-COD-1960-2025,Democratic Republic of the Congo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+COD-1894-1910,Democratic Republic of the Congo (1894-1910),1894,1910,cshapes-2.0,1894.0,assigned,True,measured,False,False,vintage 1894 faithful to period 1894-1910,12
+COD-1910-1960,DR Congo (1910-1960),1910,1960,cshapes-2.0,1910.0,assigned,True,assumed_constant,True,True,single 1910 polygon held across a 50y span (1910-1960); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),847
+COD-1960-2025,Democratic Republic of the Congo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,9
 CODRU-1922-1960,Belgian Congo and Ruanda-Urundi,1922,1960,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-COG-1898-1900,Congo (1898-1900),1898,1900,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1898),0
-COG-1900-1906,Congo (1900-1906),1900,1906,cshapes-2.0,1898.0,assigned,True,back_projected,True,False,polygon vintage 1898 is BEFORE the period starts (1900),0
-COG-1906-1912,Congo (1906-1912),1906,1912,cshapes-2.0,1900.0,assigned,True,back_projected,True,False,polygon vintage 1900 is BEFORE the period starts (1906),0
-COG-1912-1919,Congo (1912-1919),1912,1919,cshapes-2.0,1906.0,assigned,True,back_projected,True,False,polygon vintage 1906 is BEFORE the period starts (1912),19
+COG-1898-1900,Congo (1898-1900),1898,1900,cshapes-2.0,1898.0,assigned,True,measured,False,False,vintage 1898 faithful to period 1898-1900,0
+COG-1900-1906,Congo (1900-1906),1900,1906,cshapes-2.0,1900.0,assigned,True,measured,False,False,vintage 1900 faithful to period 1900-1906,0
+COG-1906-1912,Congo (1906-1912),1906,1912,cshapes-2.0,1906.0,assigned,True,measured,False,False,vintage 1906 faithful to period 1906-1912,0
+COG-1912-1919,Congo (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,18
 COG-1919-1960,Congo (1919-1960),1919,1960,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 41y span (1919-1960); borders may have changed,223
-COG-1960-2025,Congo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+COG-1960-2025,Congo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,1
+COK-1800-2025,Cook Islands,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,3
 COL-1800-1830,Gran Colombia,1800,1830,cliopatria,1825.0,assigned,False,assumed_constant,True,False,single 1825 polygon held across a 30y span (1800-1830); borders may have changed,0
-COL-1830-1903,Colombia (to 1903),1830,1903,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1830-1903); borders may have changed,10
-COL-1903-1922,Colombia (1903-1922),1903,1922,cshapes-2.0,1903.0,assigned,True,measured,False,False,vintage 1903 faithful to period 1903-1922,100
-COL-1922-2025,Colombia,1922,2025,cshapes-2.0,1922.0,assigned,True,assumed_constant,True,False,single 1922 polygon held across a 103y span (1922-2025); borders may have changed,1221
+COL-1830-1903,Colombia (to 1903),1830,1903,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1830-1903); borders may have changed,7
+COL-1903-1922,Colombia (1903-1922),1903,1922,cshapes-2.0,1903.0,assigned,True,measured,False,False,vintage 1903 faithful to period 1903-1922,99
+COL-1922-2025,Colombia,1922,2025,cshapes-2.0,1922.0,assigned,True,assumed_constant,True,False,single 1922 polygon held across a 103y span (1922-2025); borders may have changed,1225
 COM-1946-1975,Comoros (1946-1975),1946,1975,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,False,single 1946 polygon held across a 29y span (1946-1975); borders may have changed,7
 COM-1975-2025,Comoros,1975,2025,cshapes-2.0,1946.0,assigned,False,back_projected,True,False,polygon vintage 1946 is BEFORE the period starts (1975),0
 CPV-1886-1975,Cape Verde (Portuguese colony),1886,1975,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 89y span (1886-1975); borders may have changed,52
 CPV-1975-2025,Cabo Verde,1975,2025,cshapes-2.0,1886.0,assigned,False,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1975),0
 CRI-1800-2025,Costa Rica,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,930
 CUB-1800-2025,Cuba,1800,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,False,single 1902 polygon held across a 225y span (1800-2025); borders may have changed,1153
-CXR-1946-1958,Christmas Island (under Singapore administration),1946,1958,gadm-4.1,2023.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),6
+CXR-1946-1958,Christmas Island (under Singapore administration),1946,1958,gadm-4.1-adm0,2023.0,assigned,True,back_projected,True,False,polygon vintage 2023 is AFTER the period ends (1958) — later/modern border applied back,6
 CYP-1879-2025,Cyprus,1879,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 146y span (1879-2025); borders may have changed,1130
-CYR-1949-1951,Emirate of Cyrenaica,1949,1951,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),93
+CYR-1949-1951,Emirate of Cyrenaica,1949,1951,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),14
 CZE-1804-1918,"Czech Lands (Crownlands of Bohemia, 1804-1918)",1804,1918,constructed,1860.0,assigned,True,assumed_constant,True,False,single 1860 polygon held across a 114y span (1804-1918); borders may have changed,37
 CZE-1947-1992,Czechoslovakia (1947-1992) [superseded],1947,1992,cshapes-2.0,1945.0,assigned,True,back_projected,True,False,polygon vintage 1945 is BEFORE the period starts (1947),0
 CZE-1993-2025,Czechia,1993,2025,cshapes-2.0,1993.0,assigned,False,assumed_constant,True,False,single 1993 polygon held across a 32y span (1993-2025); borders may have changed,0
-CZN-1903-1979,Panama Canal Zone (US-administered),1903,1979,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-DEU-1800-1866,Prussia (to 1866),1800,1866,cshapes-europe,1851.0,assigned,True,assumed_constant,True,False,single 1851 polygon held across a 66y span (1800-1866); borders may have changed,138
-DEU-1866-1871,North German Confederation (1866-1871),1866,1871,cshapes-europe,1867.0,assigned,True,measured,False,False,vintage 1867 faithful to period 1866-1871,47
-DEU-1871-1919,German Empire (1871-1919),1871,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 48y span (1871-1919); borders may have changed,902
-DEU-1919-1920,Germany (1919-1920),1919,1920,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1920,29
-DEU-1920-1938,Germany (1920-1938),1920,1938,cshapes-2.0,1920.0,assigned,True,measured,False,True,vintage 1920 faithful to period 1920-1938; footnote coverage caveat (FAO/IIA yearbook),868
-DEU-1938-1945,Germany (1938-1945),1938,1945,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1945,266
-DEU-1945-1949,Allied-occupied Germany,1945,1949,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year; footnote coverage caveat (FAO/IIA yearbook),186
-DEU-1949-1990,"Germany (divided, 1949-1990)",1949,1990,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year; footnote coverage caveat (FAO/IIA yearbook),689
+CZN-1903-1979,Panama Canal Zone (US-administered),1903,1979,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),5
+DEU-1800-1866,Prussia (to 1866),1800,1866,cshapes-europe,1851.0,assigned,True,assumed_constant,True,False,single 1851 polygon held across a 66y span (1800-1866); borders may have changed,131
+DEU-1866-1871,North German Confederation (1866-1871),1866,1871,cshapes-europe,1867.0,assigned,True,measured,False,False,vintage 1867 faithful to period 1866-1871,42
+DEU-1871-1919,German Empire (1871-1919),1871,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 48y span (1871-1919); borders may have changed,882
+DEU-1919-1920,Germany (1919-1920),1919,1920,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1920,32
+DEU-1920-1938,Germany (1920-1938),1920,1938,cshapes-2.0,1920.0,assigned,True,measured,False,True,vintage 1920 faithful to period 1920-1938; footnote coverage caveat (FAO/IIA yearbook),779
+DEU-1938-1945,Germany (1938-1945),1938,1945,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1945,378
+DEU-1945-1949,Allied-occupied Germany,1945,1949,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year; footnote coverage caveat (FAO/IIA yearbook),144
+DEU-1949-1990,"Germany (divided, 1949-1990)",1949,1990,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year; footnote coverage caveat (FAO/IIA yearbook),737
 DEU-1990-2025,Germany,1990,2025,cshapes-2.0,1990.0,assigned,False,assumed_constant,True,False,single 1990 polygon held across a 35y span (1990-2025); borders may have changed,0
 DGM-1800-1899,Kingdom of Dagbon (Dagomba),1800,1899,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 DHY-1800-1894,Kingdom of Dahomey,1800,1894,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
@@ -177,82 +185,85 @@ DMA-1800-2025,Dominica,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,T
 DMG-1800-1899,Sultanate of Damagaram,1800,1899,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 DMO-1800-1860,Duchy Modena,1800,1860,cliopatria,1815.0,assigned,True,assumed_constant,True,False,single 1815 polygon held across a 60y span (1800-1860); borders may have changed,0
 DNK-1800-1864,Denmark (with Schleswig-Holstein),1800,1864,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 64y span (1800-1864); borders may have changed,11
-DNK-1864-1920,Denmark (to 1920),1864,1920,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 56y span (1864-1920); borders may have changed,804
-DNK-1920-2025,Denmark,1920,2025,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 105y span (1920-2025); borders may have changed,1290
+DNK-1864-1920,Denmark (to 1920),1864,1920,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 56y span (1864-1920); borders may have changed,775
+DNK-1920-2025,Denmark,1920,2025,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 105y span (1920-2025); borders may have changed,1319
 DOM-1800-2025,Dominican Republic,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,1097
 DPA-1800-1860,Duchy Parma,1800,1860,cliopatria,1815.0,assigned,True,assumed_constant,True,False,single 1815 polygon held across a 60y span (1800-1860); borders may have changed,0
 DRV-1954-1975,Democratic Republic of Vietnam (North Vietnam),1954,1975,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1954-1975,0
-DWI-1800-1917,Danish West Indies,1800,1917,gadm-4.1-adm0,2023.0,proxy,True,back_projected,True,False,polygon vintage 2023 is AFTER the period ends (1917) — later/modern border applied back,10
-DZA-1831-1886,Algeria,1831,1886,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 55y span (1831-1886); borders may have changed,253
-DZA-1886-1902,Algeria (1886-1902),1886,1902,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1886-1902,241
+DWI-1800-1917,Danish West Indies,1800,1917,gadm-4.1-adm0,2023.0,proxy,True,back_projected,True,True,polygon vintage 2023 is AFTER the period ends (1917) — later/modern border applied back,9
+DZA-1831-1886,Algeria,1831,1886,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 55y span (1831-1886); borders may have changed,237
+DZA-1886-1902,Algeria (1886-1902),1886,1902,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1886-1902,257
 DZA-1902-1919,Algeria (1902-1919),1902,1919,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1919,432
 DZA-1919-1962,Algeria (1919-1962),1919,1962,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 43y span (1919-1962); borders may have changed,1505
 DZA-1962-2025,Algeria (1962-2025),1962,2025,cshapes-2.0,1962.0,assigned,False,assumed_constant,True,False,single 1962 polygon held across a 63y span (1962-2025); borders may have changed,0
-ECU-1800-1942,Ecuador (to 1942),1800,1942,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 142y span (1800-1942); borders may have changed,398
-ECU-1942-2025,Ecuador,1942,2025,cshapes-2.0,1942.0,assigned,True,assumed_constant,True,False,single 1942 polygon held across a 83y span (1942-2025); borders may have changed,732
+ECU-1800-1942,Ecuador (to 1942),1800,1942,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 142y span (1800-1942); borders may have changed,376
+ECU-1942-2025,Ecuador,1942,2025,cshapes-2.0,1942.0,assigned,True,assumed_constant,True,False,single 1942 polygon held across a 83y span (1942-2025); borders may have changed,754
 EGB-1830-1914,Egba United Government (Abeokuta),1830,1914,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 EGY-1800-1820,Egypt (to 1820),1800,1820,cliopatria,1811.0,assigned,False,measured,False,False,vintage 1811 faithful to period 1800-1820,0
-EGY-1800-1899,Egypt (to 1899),1800,1899,cliopatria,1848.0,assigned,True,assumed_constant,True,False,single 1848 polygon held across a 99y span (1800-1899); borders may have changed,84
-EGY-1820-1885,Egypt with Sudan (1820-1885),1820,1885,cliopatria,1848.0,assigned,True,assumed_constant,True,False,single 1848 polygon held across a 65y span (1820-1885); borders may have changed,0
-EGY-1885-1899,Egypt (1885-1899),1885,1899,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1885-1899,0
-EGY-1899-1925,Egypt (1899-1925),1899,1925,cshapes-2.0,1899.0,assigned,True,assumed_constant,True,False,single 1899 polygon held across a 26y span (1899-1925); borders may have changed,514
-EGY-1925-1967,Egypt (1925-1967),1925,1967,cshapes-2.0,1925.0,assigned,True,assumed_constant,True,True,single 1925 polygon held across a 42y span (1925-1967); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),1284
+EGY-1800-1899,Egypt (to 1899),1800,1899,cliopatria,1848.0,assigned,True,assumed_constant,True,False,single 1848 polygon held across a 99y span (1800-1899); borders may have changed,0
+EGY-1820-1885,Egypt with Sudan (1820-1885),1820,1885,cliopatria,1848.0,assigned,True,assumed_constant,True,True,single 1848 polygon held across a 65y span (1820-1885); borders may have changed,19
+EGY-1885-1899,Egypt (1885-1899),1885,1899,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1885-1899,65
+EGY-1899-1925,Egypt (1899-1925),1899,1925,cshapes-2.0,1899.0,assigned,True,assumed_constant,True,False,single 1899 polygon held across a 26y span (1899-1925); borders may have changed,479
+EGY-1925-1967,Egypt (1925-1967),1925,1967,cshapes-2.0,1925.0,assigned,True,assumed_constant,True,True,single 1925 polygon held across a 42y span (1925-1967); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),1319
 EGY-1967-1979,Egypt (1967-1979),1967,1979,cshapes-2.0,1967.0,assigned,False,measured,False,False,vintage 1967 faithful to period 1967-1979,0
 EGY-1979-2025,Egypt,1979,2025,cshapes-2.0,1979.0,assigned,False,assumed_constant,True,False,single 1979 polygon held across a 46y span (1979-2025); borders may have changed,0
 EGYSUD-1934-1956,Egypt and Anglo-Egyptian Sudan,1934,1956,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 ERI-1885-1889,"Eritrea (Italian coastal, 1885-1889)",1885,1889,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1885-1889,0
 ERI-1889-1952,"Eritrea (colony/administration, 1889-1952)",1889,1952,cshapes-2.0,1900.0,assigned,True,assumed_constant,True,False,single 1900 polygon held across a 63y span (1889-1952); borders may have changed,291
 ERI-1993-2025,Eritrea,1993,2025,cshapes-2.0,1993.0,assigned,False,assumed_constant,True,False,single 1993 polygon held across a 32y span (1993-2025); borders may have changed,0
-ESH-1958-1975,Western Sahara (1958-1975),1958,1975,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-ESH-1975-2025,Western Sahara,1975,2025,none,,missing,False,unassigned,True,False,no polygon (honest gap; never a false territory),0
+ESH-1958-1975,Western Sahara (1958-1975),1958,1975,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+ESH-1975-2025,Western Sahara,1975,2025,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
 ESP-1800-2025,Spain,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,13360
 EST-1800-1918,Estonia (Governorate),1800,1918,cshapes-2.0,1918.0,assigned,True,assumed_constant,True,False,single 1918 polygon held across a 118y span (1800-1918); borders may have changed,16
-EST-1918-1940,Estonia (interwar republic),1918,1940,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1940,514
-EST-1940-1991,Estonian SSR,1940,1991,cshapes-2.0,1918.0,assigned,True,back_projected,True,False,polygon vintage 1918 is BEFORE the period starts (1940),8
+EST-1918-1940,Estonia (interwar republic),1918,1940,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1940,506
+EST-1940-1991,Estonian SSR,1940,1991,cshapes-2.0,1918.0,assigned,True,back_projected,True,False,polygon vintage 1918 is BEFORE the period starts (1940),16
 EST-1991-2025,Estonia,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 ETH-1800-1889,Ethiopia (to 1889),1800,1889,cliopatria,1769.0,assigned,True,back_projected,True,False,polygon vintage 1769 is BEFORE the period starts (1800),0
 ETH-1889-1897,Ethiopia (1889-1897),1889,1897,cshapes-2.0,1889.0,assigned,True,measured,False,False,vintage 1889 faithful to period 1889-1897,0
 ETH-1897-1902,Ethiopia (1897-1902),1897,1902,cshapes-2.0,1897.0,assigned,True,measured,False,False,vintage 1897 faithful to period 1897-1902,0
 ETH-1902-1907,Ethiopia (1902-1907),1902,1907,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1907,0
-ETH-1907-1936,Ethiopia (1907-1936),1907,1936,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,False,single 1907 polygon held across a 29y span (1907-1936); borders may have changed,32
-ETH-1907-1952,Ethiopia (1907-1952),1907,1952,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,False,single 1907 polygon held across a 45y span (1907-1952); borders may have changed,197
-ETH-1941-1952,Ethiopia (1941-1952),1941,1952,cshapes-2.0,1941.0,assigned,True,measured,False,False,vintage 1941 faithful to period 1941-1952,0
-ETH-1952-1993,Ethiopia (1952-1993),1952,1993,cshapes-2.0,1952.0,assigned,True,assumed_constant,True,False,single 1952 polygon held across a 41y span (1952-1993); borders may have changed,62
+ETH-1907-1936,Ethiopia (1907-1936),1907,1936,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,False,single 1907 polygon held across a 29y span (1907-1936); borders may have changed,31
+ETH-1907-1952,Ethiopia (1907-1952),1907,1952,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,True,single 1907 polygon held across a 45y span (1907-1952); borders may have changed,0
+ETH-1936-1941,"Ethiopia (Italian occupation, proper territory, 1936-1941)",1936,1941,cshapes-2.0,1907.0,assigned,True,back_projected,True,False,polygon vintage 1907 is BEFORE the period starts (1936),7
+ETH-1941-1952,Ethiopia (1941-1952),1941,1952,cshapes-2.0,1941.0,assigned,True,measured,False,False,vintage 1941 faithful to period 1941-1952,190
+ETH-1952-1993,Ethiopia (1952-1993),1952,1993,cshapes-2.0,1952.0,assigned,True,assumed_constant,True,False,single 1952 polygon held across a 41y span (1952-1993); borders may have changed,65
 ETH-1993-2025,Ethiopia,1993,2025,cshapes-2.0,1993.0,assigned,False,assumed_constant,True,False,single 1993 polygon held across a 32y span (1993-2025); borders may have changed,0
 F228-1800-1856,Russian Empire (to 1856),1800,1856,cliopatria,1815.0,assigned,False,assumed_constant,True,False,single 1815 polygon held across a 56y span (1800-1856); borders may have changed,0
 F228-1856-1905,Russian Empire (1856-1905),1856,1905,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 49y span (1856-1905); borders may have changed,10
-F228-1905-1914,Russian Empire (1905-1914),1905,1914,cshapes-2.0,1905.0,assigned,True,measured,False,False,vintage 1905 faithful to period 1905-1914,157
-F228-1914-1917,Russian Empire (1914-1917),1914,1917,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1917,37
-F228-1917-1918,Russia (1917-1918),1917,1918,cshapes-2.0,1917.0,assigned,True,measured,False,False,vintage 1917 faithful to period 1917-1918,8
-F228-1918-1920,RSFSR (1918-1920),1918,1920,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1920,5
-F228-1920-1921,RSFSR (1920-1921),1920,1921,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1921,0
-F228-1921-1940,RSFSR/USSR (1921-1940),1921,1940,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1921-1940,502
-F228-1940-1945,USSR (1940-1945),1940,1945,cshapes-2.0,1940.0,assigned,True,measured,False,False,vintage 1940 faithful to period 1940-1945,12
-F228-1945-1991,USSR (1945-1991),1945,1991,cshapes-2.0,1945.0,assigned,True,assumed_constant,True,True,single 1945 polygon held across a 46y span (1945-1991); borders may have changed,28
+F228-1905-1914,Russian Empire (1905-1914),1905,1914,cshapes-2.0,1905.0,assigned,True,measured,False,False,vintage 1905 faithful to period 1905-1914,136
+F228-1914-1917,Russian Empire (1914-1917),1914,1917,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1917,50
+F228-1917-1918,Russia (1917-1918),1917,1918,cshapes-2.0,1917.0,assigned,True,measured,False,False,vintage 1917 faithful to period 1917-1918,16
+F228-1918-1920,RSFSR (1918-1920),1918,1920,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1920,0
+F228-1920-1921,RSFSR (1920-1921),1920,1921,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1921,5
+F228-1921-1940,RSFSR/USSR (1921-1940),1921,1940,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1921-1940,488
+F228-1940-1945,USSR (1940-1945),1940,1945,cshapes-2.0,1940.0,assigned,True,measured,False,False,vintage 1940 faithful to period 1940-1945,26
+F228-1945-1991,USSR (1945-1991),1945,1991,cshapes-2.0,1945.0,assigned,True,assumed_constant,True,False,single 1945 polygon held across a 46y span (1945-1991); borders may have changed,28
+F237-1954-1975,Vietnam (combined reporting: DRV and RVN),1954,1975,cshapes-2.0,1976.0,estimate,True,back_projected,True,False,polygon vintage 1976 is AFTER the period ends (1975) — later/modern border applied back,0
 F248-1918-1919,Yugoslavia (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,0
-F248-1919-1920,Yugoslavia (1919-1920),1919,1920,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1920,39
-F248-1920-1947,Yugoslavia (1920-1947),1920,1947,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 27y span (1920-1947); borders may have changed,1180
-F248-1920-1991,Yugoslavia (1920-1991),1920,1991,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 71y span (1920-1991); borders may have changed,1040
-F248-1947-1991,Yugoslavia (1947-1991),1947,1991,cshapes-2.0,1920.0,estimate,True,back_projected,True,False,polygon vintage 1920 is BEFORE the period starts (1947),0
+F248-1919-1920,Yugoslavia (1919-1920),1919,1920,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1920,12
+F248-1920-1947,Yugoslavia (1920-1947),1920,1947,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 27y span (1920-1947); borders may have changed,1195
+F248-1920-1991,Yugoslavia (1920-1991),1920,1991,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 71y span (1920-1991); borders may have changed,0
+F248-1947-1991,Yugoslavia (1947-1991),1947,1991,cshapes-2.0,1920.0,estimate,True,back_projected,True,False,polygon vintage 1920 is BEFORE the period starts (1947),1059
 F248-1991-1992,Yugoslavia (1991-1992),1991,1992,cshapes-2.0,1991.0,assigned,False,measured,False,False,vintage 1991 faithful to period 1991-1992,0
-F51-1918-1938,Czechoslovakia (1918-1938),1918,1938,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1938,1288
-F51-1938-1945,Czechoslovakia (1938-1945),1938,1945,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1945,534
-F51-1945-1947,Czechoslovakia (1945-1947),1945,1947,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1947,101
-F51-1947-1993,Czechoslovakia (1947-1993),1947,1993,cshapes-2.0,1947.0,assigned,True,assumed_constant,True,False,single 1947 polygon held across a 46y span (1947-1993); borders may have changed,682
+F249-1918-1990,Yemen (combined reporting: YAR and PDR Yemen),1918,1990,cshapes-2.0,1990.0,estimate,True,assumed_constant,True,False,single 1990 polygon held across a 72y span (1918-1990); borders may have changed,0
+F51-1918-1938,Czechoslovakia (1918-1938),1918,1938,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1938,1146
+F51-1938-1945,Czechoslovakia (1938-1945),1938,1945,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1945,602
+F51-1945-1947,Czechoslovakia (1945-1947),1945,1947,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1947,124
+F51-1947-1993,Czechoslovakia (1947-1993),1947,1993,cshapes-2.0,1947.0,assigned,True,assumed_constant,True,False,single 1947 polygon held across a 46y span (1947-1993); borders may have changed,733
 F77-1949-1990,East Germany,1949,1990,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,False,single 1949 polygon held across a 41y span (1949-1990); borders may have changed,76
 F78-1949-1990,West Germany,1949,1990,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 41y span (1949-1990); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),212
-FCC-1862-1887,French Cochinchina,1862,1887,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),21
-FCM-1920-1960,French Cameroon (1920-1960),1920,1960,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 40y span (1920-1960); borders may have changed,575
-FID-1887-1954,French Indochina,1887,1954,cliopatria,1900.0,assigned,True,assumed_constant,True,False,single 1900 polygon held across a 67y span (1887-1954); borders may have changed,373
-FIN-1809-1917,Grand Duchy of Finland,1809,1917,cshapes-2.0,1917.0,assigned,True,assumed_constant,True,False,single 1917 polygon held across a 108y span (1809-1917); borders may have changed,424
-FIN-1917-1940,Finland (1917-1940),1917,1940,cshapes-2.0,1917.0,assigned,True,measured,False,False,vintage 1917 faithful to period 1917-1940,647
-FIN-1940-2025,Finland (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,713
+FCC-1862-1887,French Cochinchina,1862,1887,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),20
+FCM-1920-1960,French Cameroon (1920-1960),1920,1960,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,True,single 1940 polygon held across a 40y span (1920-1960); borders may have changed,575
+FID-1887-1954,French Indochina,1887,1954,cliopatria,1900.0,assigned,True,assumed_constant,True,True,single 1900 polygon held across a 67y span (1887-1954); borders may have changed,374
+FIN-1809-1917,Grand Duchy of Finland,1809,1917,cshapes-2.0,1917.0,assigned,True,assumed_constant,True,False,single 1917 polygon held across a 108y span (1809-1917); borders may have changed,411
+FIN-1917-1940,Finland (1917-1940),1917,1940,cshapes-2.0,1917.0,assigned,True,measured,False,False,vintage 1917 faithful to period 1917-1940,631
+FIN-1940-2025,Finland (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,742
 FJI-1800-2025,Fiji,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,520
-FLK-1833-2025,Falkland Islands,1833,2025,gadm-4.1-adm0,2023.0,proxy,True,assumed_constant,True,False,single 2023 polygon held across a 192y span (1833-2025); borders may have changed,25
-FRA-1800-1871,"France (with Alsace-Lorraine, to 1871)",1800,1871,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 71y span (1800-1871); borders may have changed,327
-FRA-1800-1919,France (to 1919),1800,1919,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 119y span (1800-1919); borders may have changed,2401
-FRA-1871-1919,"France (without Alsace-Lorraine, 1871-1919)",1871,1919,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 48y span (1871-1919); borders may have changed,0
-FRA-1919-2025,France,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,True,single 1919 polygon held across a 106y span (1919-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),4044
+FLK-1833-2025,Falkland Islands,1833,2025,gadm-4.1-adm0,2023.0,proxy,True,assumed_constant,True,True,single 2023 polygon held across a 192y span (1833-2025); borders may have changed,25
+FRA-1800-1871,"France (with Alsace-Lorraine, to 1871)",1800,1871,cshapes-europe,1816.0,assigned,True,assumed_constant,True,True,single 1816 polygon held across a 71y span (1800-1871); borders may have changed,313
+FRA-1800-1919,France (to 1919),1800,1919,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 119y span (1800-1919); borders may have changed,0
+FRA-1871-1919,"France (without Alsace-Lorraine, 1871-1919)",1871,1919,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 48y span (1871-1919); borders may have changed,2358
+FRA-1919-2025,France,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,True,single 1919 polygon held across a 106y span (1919-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),4101
 FRIN-1816-1954,French India (Établissements français dans l'Inde),1816,1954,gadm-4.1+osm,2024.0,estimate,True,unassigned,True,False,no polygon (honest gap; never a false territory),14
 FRN-1953-1964,Federation of Rhodesia and Nyasaland (1953-1964),1953,1964,cshapes-2.0,1953.0,assigned,True,measured,False,False,vintage 1953 faithful to period 1953-1964,0
 FRO-1800-2025,Faroe Islands,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,13
@@ -260,152 +271,155 @@ FRS-1884-1977,French Somaliland,1884,1977,cshapes-2.0,1900.0,assigned,True,assum
 FRS-1977-2025,Djibouti (formerly French Somaliland),1977,2025,cshapes-2.0,1900.0,assigned,False,back_projected,True,False,polygon vintage 1900 is BEFORE the period starts (1977),0
 FSM-1991-2025,Micronesia,1991,2025,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
 FTJ-1800-1896,Imamate of Futa Jallon,1800,1896,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-FTO-1920-1960,French Togoland (1920-1960),1920,1960,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),188
+FTO-1920-1960,French Togoland (1920-1960),1920,1960,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),182
 FTT-1800-1862,Imamate of Futa Toro,1800,1862,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-GAB-1839-1912,Gabon (to 1912),1839,1912,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1839-1912); borders may have changed,9
-GAB-1912-1919,Gabon (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,25
-GAB-1919-1960,Gabon (1919-1960),1919,1960,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 41y span (1919-1960); borders may have changed,23
-GAB-1960-2025,Gabon,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
-GBM-1895-1946,British Malaya (1895-1946),1895,1946,cshapes-2.0,1909.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-GBR-1800-1921,United Kingdom (to 1921),1800,1921,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 121y span (1800-1921); borders may have changed,907
-GBR-1921-2025,United Kingdom,1921,2025,cshapes-2.0,1921.0,assigned,True,assumed_constant,True,False,single 1921 polygon held across a 104y span (1921-2025); borders may have changed,1803
+GAB-1839-1912,Gabon (to 1912),1839,1912,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1839-1912); borders may have changed,6
+GAB-1912-1919,Gabon (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,26
+GAB-1919-1960,Gabon (1919-1960),1919,1960,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 41y span (1919-1960); borders may have changed,24
+GAB-1960-2025,Gabon,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,1
+GBM-1895-1946,British Malaya (1895-1946),1895,1946,constructed,1909.0,assigned,True,assumed_constant,True,True,single 1909 polygon held across a 51y span (1895-1946); borders may have changed,13
+GBR-1800-1921,United Kingdom (to 1921),1800,1921,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 121y span (1800-1921); borders may have changed,876
+GBR-1921-2025,United Kingdom,1921,2025,cshapes-2.0,1921.0,assigned,True,assumed_constant,True,False,single 1921 polygon held across a 104y span (1921-2025); borders may have changed,1834
 GCAR-1899-1914,German Caroline Islands (Karolinen),1899,1914,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,6
-GCO-1884-2025,German colonies Oceania,1884,2025,none,,excluded,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-GCT-1919-1956,Gold Coast and British Togoland (1919-1956),1919,1956,cshapes-2.0,1938.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+GCO-1884-2025,German colonies Oceania,1884,2025,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+GCT-1919-1956,Gold Coast and British Togoland (1919-1956),1919,1956,cshapes-2.0,1938.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),55
 GEO-1991-2025,Georgia,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 GHA-1821-1888,Ghana (to 1888),1821,1888,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 67y span (1821-1888); borders may have changed,0
-GHA-1888-1898,Ghana (1888-1898),1888,1898,cshapes-2.0,1888.0,assigned,True,measured,False,False,vintage 1888 faithful to period 1888-1898,3
-GHA-1898-1956,Ghana (1898-1956),1898,1956,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,False,single 1898 polygon held across a 58y span (1898-1956); borders may have changed,369
+GHA-1888-1898,Ghana (1888-1898),1888,1898,cshapes-2.0,1888.0,assigned,True,measured,False,False,vintage 1888 faithful to period 1888-1898,2
+GHA-1898-1956,Ghana (1898-1956),1898,1956,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,True,single 1898 polygon held across a 58y span (1898-1956); borders may have changed,315
 GHA-1957-2025,Ghana,1957,2025,cshapes-2.0,1957.0,assigned,True,assumed_constant,True,False,single 1957 polygon held across a 68y span (1957-2025); borders may have changed,29
-GIN-1894-1958,Guinea (1894-1958),1894,1958,cshapes-2.0,1894.0,assigned,True,assumed_constant,True,False,single 1894 polygon held across a 64y span (1894-1958); borders may have changed,263
-GIN-1958-2025,Guinea,1958,2025,cshapes-2.0,1958.0,assigned,True,assumed_constant,True,False,single 1958 polygon held across a 67y span (1958-2025); borders may have changed,11
-GKM-1884-1912,German Kamerun (1884-1912),1884,1912,cshapes-2.0,1901.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),13
-GKM-1884-1916,German Kamerun,1884,1916,cshapes-2.0,1912.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),4
-GKM-1912-1916,German Kamerun (1912-1916),1912,1916,cshapes-2.0,1912.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-GLP-1816-2025,Guadeloupe,1816,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 209y span (1816-2025); borders may have changed,462
-GMB-1800-2025,Gambia,1800,2025,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,True,single 1889 polygon held across a 225y span (1800-2025); borders may have changed,82
+GIN-1894-1958,Guinea (1894-1958),1894,1958,cshapes-2.0,1894.0,assigned,True,assumed_constant,True,False,single 1894 polygon held across a 64y span (1894-1958); borders may have changed,262
+GIN-1958-2025,Guinea,1958,2025,cshapes-2.0,1958.0,assigned,True,assumed_constant,True,False,single 1958 polygon held across a 67y span (1958-2025); borders may have changed,12
+GKM-1884-1912,German Kamerun (1884-1912),1884,1912,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,True,single 1905 polygon held across a 28y span (1884-1912); borders may have changed,12
+GKM-1884-1916,German Kamerun,1884,1916,cshapes-2.0,1912.0,assigned,True,assumed_constant,True,False,single 1912 polygon held across a 32y span (1884-1916); borders may have changed,0
+GKM-1912-1916,German Kamerun (1912-1916),1912,1916,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1912-1916,5
+GLP-1816-2025,Guadeloupe,1816,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 209y span (1816-2025); borders may have changed,462
+GMB-1800-2025,Gambia,1800,2025,cshapes-2.0,1889.0,assigned,True,assumed_constant,True,False,single 1889 polygon held across a 225y span (1800-2025); borders may have changed,82
 GNB-1879-1886,Guinea-Bissau,1879,1886,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1879-1886,0
 GNB-1886-1974,Guinea-Bissau (1886-1974),1886,1974,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 88y span (1886-1974); borders may have changed,56
 GNB-1974-2025,Guinea-Bissau (1974-2025),1974,2025,cshapes-2.0,1974.0,assigned,False,assumed_constant,True,False,single 1974 polygon held across a 51y span (1974-2025); borders may have changed,0
 GNQ-1886-1968,Equatorial Guinea (1886-1968),1886,1968,cshapes-2.0,1900.0,assigned,True,assumed_constant,True,False,single 1900 polygon held across a 82y span (1886-1968); borders may have changed,105
 GNQ-1968-2025,Equatorial Guinea,1968,2025,cshapes-2.0,1900.0,assigned,False,back_projected,True,False,polygon vintage 1900 is BEFORE the period starts (1968),0
 GOB-1800-1808,Kingdom of Gobir,1800,1808,paine-2024,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
-GRC-1830-1881,Greece (1830–1881),1830,1881,cliopatria,1830.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),5
-GRC-1830-1913,Greece (to 1913),1830,1913,cshapes-europe,1835.0,assigned,True,assumed_constant,True,False,single 1835 polygon held across a 83y span (1830-1913); borders may have changed,60
-GRC-1881-1913,Greece (1881–1913),1881,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 32y span (1881-1913); borders may have changed,0
-GRC-1913-1919,Greece (1913-1919),1913,1919,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1919,194
-GRC-1919-1947,Greece (1919-1947),1919,1947,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 28y span (1919-1947); borders may have changed,1255
-GRC-1919-2025,Greece,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,True,single 1919 polygon held across a 106y span (1919-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),1038
-GRC-1947-2025,Greece (1947-2025),1947,2025,cshapes-2.0,1944.0,assigned,True,back_projected,True,False,polygon vintage 1944 is BEFORE the period starts (1947),0
+GRC-1830-1881,Greece (1830–1881),1830,1881,cliopatria,1830.0,assigned,True,assumed_constant,True,False,single 1830 polygon held across a 51y span (1830-1881); borders may have changed,5
+GRC-1830-1913,Greece (to 1913),1830,1913,cshapes-europe,1835.0,assigned,True,assumed_constant,True,False,single 1835 polygon held across a 83y span (1830-1913); borders may have changed,0
+GRC-1881-1913,Greece (1881–1913),1881,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 32y span (1881-1913); borders may have changed,60
+GRC-1913-1919,Greece (1913-1919),1913,1919,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1919,170
+GRC-1919-1947,Greece (1919-1947),1919,1947,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,False,single 1919 polygon held across a 28y span (1919-1947); borders may have changed,1230
+GRC-1919-2025,Greece,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,True,single 1919 polygon held across a 106y span (1919-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),0
+GRC-1947-2025,Greece (1947-2025),1947,2025,cshapes-2.0,1944.0,assigned,True,back_projected,True,False,polygon vintage 1944 is BEFORE the period starts (1947),1087
 GRD-1800-2025,Grenada,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,163
 GRL-1800-2025,Greenland,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,5
-GTM-1821-2025,Guatemala,1821,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 204y span (1821-2025); borders may have changed,1597
+GTM-1821-2025,Guatemala,1821,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 204y span (1821-2025); borders may have changed,1597
 GUF-1816-1946,French Guiana (Colony),1816,1946,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 130y span (1816-1946); borders may have changed,41
 GUF-1946-2025,French Guiana (Overseas Department),1946,2025,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,False,single 1946 polygon held across a 79y span (1946-2025); borders may have changed,44
-GUM-1898-1950,Territory of Guam,1898,1950,gadm-4.1,2023.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),29
-GUM-1950-2025,Guam (US Territory),1950,2025,gadm-4.1,2023.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),18
+GUM-1898-1950,Territory of Guam,1898,1950,gadm-4.1-adm0,2023.0,assigned,True,back_projected,True,False,polygon vintage 2023 is AFTER the period ends (1950) — later/modern border applied back,29
+GUM-1950-2025,Guam (US Territory),1950,2025,gadm-4.1-adm0,2023.0,assigned,True,assumed_constant,True,False,single 2023 polygon held across a 75y span (1950-2025); borders may have changed,18
 GUY-1800-2025,Guyana,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,548
 HATAY-1938-1939,Sanjak of Alexandretta / Hatay State,1938,1939,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-HAWI-1898-1959,Territory of Hawaii,1898,1959,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,True,single 1898 polygon held across a 61y span (1898-1959); borders may have changed,102
+HAWI-1898-1959,Territory of Hawaii,1898,1959,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,False,single 1898 polygon held across a 61y span (1898-1959); borders may have changed,102
 HKG-1842-2025,Hong Kong,1842,2025,gadm-4.1-adm1,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,70
-HND-1800-2025,Honduras,1800,2025,cshapes-2.0,1886.0,approximate,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,899
+HND-1800-2025,Honduras,1800,2025,cshapes-2.0,1886.0,polygon_vintage_drift,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,899
 HRV-1992-2025,Croatia,1992,2025,cshapes-2.0,1992.0,assigned,False,assumed_constant,True,False,single 1992 polygon held across a 33y span (1992-2025); borders may have changed,0
-HTI-1800-2025,Haiti,1800,2025,cshapes-2.0,1934.0,assigned,True,assumed_constant,True,True,single 1934 polygon held across a 225y span (1800-2025); borders may have changed,657
-HUN-1800-1918,Kingdom of Hungary (Transleithania),1800,1918,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1135
-HUN-1918-1919,Hungary (1918-1919),1918,1919,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,27
-HUN-1920-1938,Hungary (1920-1938),1920,1938,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1938,954
-HUN-1938-1940,Hungary (1938-1940),1938,1940,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1940,106
-HUN-1938-1947,Hungary (1938-1947),1938,1947,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1947,339
-HUN-1940-1944,Hungary (1940-1944),1940,1944,composed-union,1940.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-HUN-1944-1947,Hungary (1944-1947),1944,1947,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1944-1947,0
-HUN-1947-2025,Hungary (1947-2025),1947,2025,cshapes-2.0,1947.0,assigned,True,assumed_constant,True,True,single 1947 polygon held across a 78y span (1947-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),615
+HTI-1800-2025,Haiti,1800,2025,cshapes-2.0,1934.0,assigned,True,assumed_constant,True,False,single 1934 polygon held across a 225y span (1800-2025); borders may have changed,657
+HUN-1800-1918,Kingdom of Hungary (Transleithania),1800,1918,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1103
+HUN-1918-1919,Hungary (1918-1919),1918,1919,histogis-1860-habsburg,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,59
+HUN-1920-1938,Hungary (1920-1938),1920,1938,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1938,835
+HUN-1938-1940,Hungary (1938-1940),1938,1940,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1940,173
+HUN-1938-1947,Hungary (1938-1947),1938,1947,cshapes-2.0,1938.0,assigned,True,measured,False,False,vintage 1938 faithful to period 1938-1947,0
+HUN-1940-1944,Hungary (1940-1944),1940,1944,constructed,1940.0,proxy,True,measured,False,False,vintage 1940 faithful to period 1940-1944,201
+HUN-1944-1947,Hungary (1944-1947),1944,1947,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1944-1947,132
+HUN-1947-2025,Hungary (1947-2025),1947,2025,cshapes-2.0,1947.0,assigned,True,assumed_constant,True,True,single 1947 polygon held across a 78y span (1947-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),673
 HYD-1724-1948,Hyderabad State,1724,1948,cliopatria,1947.0,assigned,True,assumed_constant,True,False,single 1947 polygon held across a 224y span (1724-1948); borders may have changed,0
 IBD-1829-1893,Ibadan City-State,1829,1893,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 ICN-1800-2025,Canary Islands,1800,2025,gadm-4.1-adm1,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-IDN-1800-1889,Indonesia (to 1889),1800,1889,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 89y span (1800-1889); borders may have changed,132
-IDN-1889-1945,Indonesia (1889-1945),1889,1945,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,False,single 1914 polygon held across a 56y span (1889-1945); borders may have changed,1085
-IDN-1945-1949,Indonesia (1945-1949),1945,1949,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1949,151
-IDN-1949-1969,Indonesia (1949-1969),1949,1969,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1949-1969,358
+IDN-1800-1889,Indonesia (to 1889),1800,1889,cshapes-2.0,1886.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+IDN-1800-1945,Dutch East Indies (1800-1945),1800,1945,cshapes-2.0,1900.0,polygon_vintage_drift,True,assumed_constant,True,False,single 1900 polygon held across a 145y span (1800-1945); borders may have changed,1208
+IDN-1889-1945,Indonesia (1889-1945),1889,1945,cshapes-2.0,1900.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+IDN-1945-1949,Indonesia (1945-1949),1945,1949,cshapes-2.0,1945.0,assigned,True,measured,False,False,vintage 1945 faithful to period 1945-1949,90
+IDN-1949-1969,Indonesia (1949-1969),1949,1969,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1949-1969,362
 IDN-1969-1976,Indonesia (1969-1976),1969,1976,cshapes-2.0,1969.0,assigned,False,measured,False,False,vintage 1969 faithful to period 1969-1976,0
 IDN-1976-2002,Indonesia (1976-2002),1976,2002,cshapes-2.0,1976.0,assigned,False,assumed_constant,True,False,single 1976 polygon held across a 26y span (1976-2002); borders may have changed,0
 IDN-2002-2025,Indonesia,2002,2025,cshapes-2.0,2002.0,assigned,False,measured,False,False,vintage 2002 faithful to period 2002-2025,0
-IDN-BLB-1949-1951,"Bali and Lombok (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-IDN-JVM-1949-1951,"Java and Madura (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-IDN-OTH-1949-1951,"Other islands (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+IDN-BLB-1949-1951,"Bali and Lombok (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),24
+IDN-JVM-1949-1951,"Java and Madura (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),27
+IDN-OTH-1949-1951,"Other islands (within Indonesia, 1949-1951)",1949,1951,gadm-4.1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),15
 IGL-1800-1901,Igala Kingdom,1800,1901,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 IJB-1800-1892,Ijebu Kingdom,1800,1892,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-IND-1800-1893,India (to 1893),1800,1893,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 93y span (1800-1893); borders may have changed,49
+IND-1800-1886,British India (to 1886),1800,1886,cliopatria,1880.0,polygon_vintage_drift,True,assumed_constant,True,False,single 1880 polygon held across a 86y span (1800-1886); borders may have changed,3
+IND-1800-1893,India (to 1893),1800,1893,cshapes-2.0,1886.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+IND-1886-1893,British India (1886-1893),1886,1893,cshapes-2.0,1890.0,assigned,True,measured,False,False,vintage 1890 faithful to period 1886-1893,46
 IND-1893-1914,India (1893-1914),1893,1914,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1893-1914,469
-IND-1914-1937,India (1914-1937),1914,1937,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1937,869
-IND-1937-1947,India (1937-1947),1937,1947,cshapes-2.0,1937.0,assigned,True,measured,False,False,vintage 1937 faithful to period 1937-1947,292
-IND-1947-1949,India (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,121
-IND-1949-2025,India,1949,2025,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 76y span (1949-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),427
-IRL-1800-1921,Ireland (within United Kingdom),1800,1921,gadm-composed-union,2024.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),1069
-IRL-1921-2025,Ireland,1921,2025,cshapes-2.0,1921.0,assigned,True,assumed_constant,True,False,single 1921 polygon held across a 104y span (1921-2025); borders may have changed,1350
-IRN-1800-1828,Persia (Qajar to 1828),1800,1828,cliopatria,1815.0,assigned,False,assumed_constant,True,False,single 1815 polygon held across a 28y span (1800-1828); borders may have changed,0
+IND-1914-1937,India (1914-1937),1914,1937,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1937,865
+IND-1937-1947,India (1937-1947),1937,1947,cshapes-2.0,1937.0,assigned,True,measured,False,False,vintage 1937 faithful to period 1937-1947,296
+IND-1947-1949,India (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,37
+IND-1949-2025,India,1949,2025,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 76y span (1949-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),511
+IRL-1800-1921,Ireland (within United Kingdom),1800,1921,constructed,2024.0,assigned,True,back_projected,True,False,polygon vintage 2024 is AFTER the period ends (1921) — later/modern border applied back,1049
+IRL-1921-2025,Ireland,1921,2025,cshapes-2.0,1921.0,assigned,True,assumed_constant,True,False,single 1921 polygon held across a 104y span (1921-2025); borders may have changed,1370
+IRN-1800-1828,Persia (Qajar to 1828),1800,1828,cliopatria,1800.0,assigned,False,assumed_constant,True,False,single 1800 polygon held across a 28y span (1800-1828); borders may have changed,0
 IRN-1828-2025,Iran,1828,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 197y span (1828-2025); borders may have changed,626
-IRQ-1921-1932,Iraq (British Mandate for Mesopotamia),1921,1932,cshapes-2.0,1932.0,assigned,True,measured,False,False,vintage 1932 faithful to period 1921-1932,53
-IRQ-1921-2025,Iraq,1921,2025,cshapes-2.0,1932.0,assigned,True,assumed_constant,True,True,single 1932 polygon held across a 104y span (1921-2025); borders may have changed,336
-IRQ-1932-2025,Iraq,1932,2025,cshapes-2.0,1932.0,assigned,True,assumed_constant,True,False,single 1932 polygon held across a 93y span (1932-2025); borders may have changed,0
-ISL-1800-2025,Iceland,1800,2025,cshapes-2.0,1944.0,assigned,True,assumed_constant,True,True,single 1944 polygon held across a 225y span (1800-2025); borders may have changed,905
-ISR-1948-1967,Israel (1948-1967),1948,1967,cshapes-2.0,1948.0,assigned,True,measured,False,False,vintage 1948 faithful to period 1948-1967,226
+IRQ-1921-1932,Iraq (British Mandate for Mesopotamia),1921,1932,cshapes-2.0,1932.0,assigned,True,measured,False,False,vintage 1932 faithful to period 1921-1932,45
+IRQ-1921-2025,Iraq,1921,2025,cshapes-2.0,1932.0,assigned,True,assumed_constant,True,True,single 1932 polygon held across a 104y span (1921-2025); borders may have changed,0
+IRQ-1932-2025,Iraq,1932,2025,cshapes-2.0,1932.0,assigned,True,assumed_constant,True,False,single 1932 polygon held across a 93y span (1932-2025); borders may have changed,344
+ISL-1800-2025,Iceland,1800,2025,cshapes-2.0,1944.0,assigned,True,assumed_constant,True,False,single 1944 polygon held across a 225y span (1800-2025); borders may have changed,905
+ISR-1948-1967,Israel (1948-1967),1948,1967,cshapes-2.0,1948.0,assigned,True,measured,False,False,vintage 1948 faithful to period 1948-1967,233
 ISR-1967-1979,Israel (1967-1979),1967,1979,cshapes-2.0,1967.0,assigned,False,measured,False,False,vintage 1967 faithful to period 1967-1979,0
 ISR-1979-2025,Israel,1979,2025,cshapes-2.0,1979.0,assigned,False,assumed_constant,True,False,single 1979 polygon held across a 46y span (1979-2025); borders may have changed,0
-ITA-1861-1866,Italy (1861-1866),1861,1866,cshapes-europe,1886.0,estimate,True,back_projected,True,False,polygon vintage 1886 is AFTER the period ends (1866) — later/modern border applied back,144
-ITA-1861-1919,Italy (to 1919),1861,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 58y span (1861-1919); borders may have changed,2020
-ITA-1866-1870,Italy (1866-1870),1866,1870,cshapes-europe,1886.0,estimate,True,back_projected,True,False,polygon vintage 1886 is AFTER the period ends (1870) — later/modern border applied back,0
-ITA-1870-1919,Italy (1870-1919),1870,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 49y span (1870-1919); borders may have changed,0
+ITA-1861-1866,Italy (1861-1866),1861,1866,cshapes-europe,1886.0,estimate,True,back_projected,True,False,polygon vintage 1886 is AFTER the period ends (1866) — later/modern border applied back,120
+ITA-1861-1919,Italy (to 1919),1861,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 58y span (1861-1919); borders may have changed,0
+ITA-1866-1870,Italy (1866-1870),1866,1870,cshapes-europe,1886.0,estimate,True,back_projected,True,True,polygon vintage 1886 is AFTER the period ends (1870) — later/modern border applied back,123
+ITA-1870-1919,Italy (1870-1919),1870,1919,cshapes-europe,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 49y span (1870-1919); borders may have changed,1921
 ITA-1919-2025,Italy,1919,2025,cshapes-2.0,1919.0,assigned,True,assumed_constant,True,True,single 1919 polygon held across a 106y span (1919-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),4949
 ITAEG-1912-1947,Italian Islands of the Aegean (Dodecanese),1912,1947,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-ITS-1908-1960,Italian Somaliland (1908-1960),1908,1960,cshapes-2.0,1924.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),103
+ITS-1908-1960,Italian Somaliland (1908-1960),1908,1960,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year,103
 JAM-1800-2025,Jamaica,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,958
 JOL-1800-1890,Kingdom of Jolof,1800,1890,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 JOR-1918-1920,Jordan (to 1920),1918,1920,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1918-1920,0
 JOR-1920-1923,Jordan (1920-1923),1920,1923,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1923,0
-JOR-1923-1946,Jordan (1923-1946),1923,1946,cshapes-2.0,1925.0,assigned,True,measured,False,False,vintage 1925 faithful to period 1923-1946,75
-JOR-1946-2025,Jordan,1946,2025,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,True,single 1946 polygon held across a 79y span (1946-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),97
-JPN-1800-1895,Japan (to 1895),1800,1895,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 95y span (1800-1895); borders may have changed,247
-JPN-1895-1945,Japanese Empire,1895,1945,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1918
-JPN-1945-1952,Japan (occupied),1945,1952,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1945),445
+JOR-1923-1946,Jordan (1923-1946),1923,1946,cshapes-2.0,1925.0,assigned,True,measured,False,False,vintage 1925 faithful to period 1923-1946,73
+JOR-1946-2025,Jordan,1946,2025,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,True,single 1946 polygon held across a 79y span (1946-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),99
+JPN-1800-1895,Japan (to 1895),1800,1895,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 95y span (1800-1895); borders may have changed,231
+JPN-1895-1945,Japanese Empire,1895,1945,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year,1910
+JPN-1945-1952,Japan (occupied),1945,1952,cshapes-2.0,1886.0,assigned,True,back_projected,True,True,polygon vintage 1886 is BEFORE the period starts (1945),464
 JPN-1952-2025,Japan,1952,2025,cshapes-2.0,1886.0,assigned,True,back_projected,True,True,polygon vintage 1886 is BEFORE the period starts (1952); footnote coverage caveat (FAO/IIA yearbook),199
 KAZ-1991-2025,Kazakhstan,1991,2025,cshapes-2.0,1997.0,assigned,False,assumed_constant,True,False,single 1997 polygon held across a 34y span (1991-2025); borders may have changed,0
 KEN-1888-1891,Kenya (1888-1891),1888,1891,cshapes-2.0,1888.0,assigned,True,measured,False,False,vintage 1888 faithful to period 1888-1891,0
 KEN-1891-1894,Kenya (1891-1894),1891,1894,cshapes-2.0,1891.0,assigned,True,measured,False,False,vintage 1891 faithful to period 1891-1894,0
-KEN-1894-1902,Kenya (1894-1902),1894,1902,cshapes-2.0,1894.0,assigned,True,measured,False,False,vintage 1894 faithful to period 1894-1902,1
-KEN-1902-1906,Kenya (1902-1906),1902,1906,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1906,3
-KEN-1907-1924,Kenya (1907-1924),1907,1924,cshapes-2.0,1907.0,assigned,True,measured,False,False,vintage 1907 faithful to period 1907-1924,80
-KEN-1924-1926,Kenya (1924-1926),1924,1926,cshapes-2.0,1924.0,assigned,True,measured,False,False,vintage 1924 faithful to period 1924-1926,12
-KEN-1926-1963,Kenya (1926-1963),1926,1963,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 37y span (1926-1963); borders may have changed,509
+KEN-1894-1902,Kenya (1894-1902),1894,1902,cshapes-2.0,1894.0,assigned,True,measured,False,False,vintage 1894 faithful to period 1894-1902,0
+KEN-1902-1906,Kenya (1902-1906),1902,1906,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1906,4
+KEN-1907-1924,Kenya (1907-1924),1907,1924,cshapes-2.0,1907.0,assigned,True,measured,False,False,vintage 1907 faithful to period 1907-1924,67
+KEN-1924-1926,Kenya (1924-1926),1924,1926,cshapes-2.0,1924.0,assigned,True,measured,False,False,vintage 1924 faithful to period 1924-1926,20
+KEN-1926-1963,Kenya (1926-1963),1926,1963,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 37y span (1926-1963); borders may have changed,514
 KEN-1963-2025,Kenya,1963,2025,cshapes-2.0,1963.0,assigned,False,assumed_constant,True,False,single 1963 polygon held across a 62y span (1963-2025); borders may have changed,0
 KGZ-1991-2025,Kyrgyzstan,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 KHM-1800-1904,Cambodia (to 1904),1800,1904,cshapes-2.0,1893.0,assigned,True,assumed_constant,True,False,single 1893 polygon held across a 104y span (1800-1904); borders may have changed,0
 KHM-1904-1907,Cambodia (1904-1907),1904,1907,cshapes-2.0,1904.0,assigned,True,measured,False,False,vintage 1904 faithful to period 1904-1907,0
-KHM-1907-1953,Cambodia (1907-1953),1907,1953,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,False,single 1907 polygon held across a 46y span (1907-1953); borders may have changed,150
-KHM-1953-2025,Cambodia,1953,2025,cshapes-2.0,1953.0,assigned,True,assumed_constant,True,False,single 1953 polygon held across a 72y span (1953-2025); borders may have changed,48
+KHM-1907-1953,Cambodia (1907-1953),1907,1953,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,False,single 1907 polygon held across a 46y span (1907-1953); borders may have changed,143
+KHM-1953-2025,Cambodia,1953,2025,cshapes-2.0,1953.0,assigned,True,assumed_constant,True,False,single 1953 polygon held across a 72y span (1953-2025); borders may have changed,55
 KIR-1800-2025,Kiribati,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,5
 KJM-1947-1972,Jammu and Kashmir (disputed territory),1947,1972,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,False,single 1948 polygon held across a 25y span (1947-1972); borders may have changed,0
 KNA-1800-2025,Saint Kitts and Nevis,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,168
-KOR-1800-1945,Korea (to 1945),1800,1945,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,963
-KOR-1945-1948,Korea (occupied),1945,1948,cshapes-2.0,1910.0,assigned,True,back_projected,True,False,polygon vintage 1910 is BEFORE the period starts (1945),56
-KOR-1948-2025,South Korea,1948,2025,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,False,single 1948 polygon held across a 77y span (1948-2025); borders may have changed,337
+KOR-1800-1945,Korea (to 1945),1800,1945,constructed,,assigned,True,assumed_constant,True,True,polygon present but no recorded vintage year,920
+KOR-1945-1948,Korea (occupied),1945,1948,cshapes-2.0,1910.0,assigned,True,back_projected,True,False,polygon vintage 1910 is BEFORE the period starts (1945),63
+KOR-1948-2025,South Korea,1948,2025,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,False,single 1948 polygon held across a 77y span (1948-2025); borders may have changed,346
 KOS-2008-2025,Kosovo,2008,2025,cshapes-2.0,2008.0,assigned,False,measured,False,False,vintage 2008 faithful to period 2008-2025,0
-KRS-1910-1945,Korea South (within Japanese Chosen),1910,1945,cshapes-2.0,1948.0,assigned,True,back_projected,True,False,polygon vintage 1948 is AFTER the period ends (1945) — later/modern border applied back,0
+KRS-1910-1945,Korea South (within Japanese Chosen),1910,1945,cshapes-2.0,1948.0,assigned,True,back_projected,True,True,polygon vintage 1948 is AFTER the period ends (1945) — later/modern border applied back,27
 KSJ-1800-1911,Kingdom of Kasanje,1800,1911,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-KWT-1800-2025,Kuwait,1800,2025,cshapes-2.0,1961.0,assigned,True,assumed_constant,True,True,single 1961 polygon held across a 225y span (1800-2025); borders may have changed,4
+KWT-1800-2025,Kuwait,1800,2025,cshapes-2.0,1961.0,assigned,True,assumed_constant,True,False,single 1961 polygon held across a 225y span (1800-2025); borders may have changed,4
 KZM-1800-1899,Kingdom of Kazembe,1800,1899,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 LAO-1893-1953,Laos (1893-1953),1893,1953,cshapes-2.0,1896.0,assigned,True,assumed_constant,True,False,single 1896 polygon held across a 60y span (1893-1953); borders may have changed,89
 LAO-1954-2025,Laos,1954,2025,cshapes-2.0,1954.0,assigned,True,assumed_constant,True,False,single 1954 polygon held across a 71y span (1954-2025); borders may have changed,23
 LBA-1800-1885,Luba Empire,1800,1885,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-LBN-1920-1944,Lebanon (1920-1944),1920,1944,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1944,154
-LBN-1944-2025,Lebanon,1944,2025,cshapes-2.0,1944.0,assigned,True,assumed_constant,True,False,single 1944 polygon held across a 81y span (1944-2025); borders may have changed,175
-LBR-1847-2025,Liberia,1847,2025,cshapes-2.0,1892.0,assigned,True,assumed_constant,True,True,single 1892 polygon held across a 178y span (1847-2025); borders may have changed,89
+LBN-1920-1944,Lebanon (1920-1944),1920,1944,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1944,132
+LBN-1944-2025,Lebanon,1944,2025,cshapes-2.0,1944.0,assigned,True,assumed_constant,True,False,single 1944 polygon held across a 81y span (1944-2025); borders may have changed,197
+LBR-1847-2025,Liberia,1847,2025,cshapes-2.0,1892.0,assigned,True,assumed_constant,True,False,single 1892 polygon held across a 178y span (1847-2025); borders may have changed,89
 LBY-1912-1919,Libya (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,0
-LBY-1919-1925,Libya (1919-1925),1919,1925,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1925,9
-LBY-1925-1934,Libya (1925-1934),1925,1934,cshapes-2.0,1925.0,assigned,True,measured,False,False,vintage 1925 faithful to period 1925-1934,79
-LBY-1934-1943,Libya (1934-1943),1934,1943,cshapes-2.0,1934.0,assigned,True,measured,False,False,vintage 1934 faithful to period 1934-1943,65
-LBY-1943-1949,Libya (1943-1949),1943,1949,cshapes-2.0,1943.0,assigned,True,measured,False,False,vintage 1943 faithful to period 1943-1949,10
-LBY-1950-1951,Libya under UN Transitional Administration (1950-1951),1950,1951,cshapes-2.0,1943.0,assigned,True,back_projected,True,False,polygon vintage 1943 is BEFORE the period starts (1950),0
-LBY-1951-2025,Libya,1951,2025,cshapes-2.0,1951.0,assigned,True,assumed_constant,True,True,single 1951 polygon held across a 74y span (1951-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),25
+LBY-1919-1925,Libya (1919-1925),1919,1925,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1925,3
+LBY-1925-1934,Libya (1925-1934),1925,1934,cshapes-2.0,1925.0,assigned,True,measured,False,False,vintage 1925 faithful to period 1925-1934,77
+LBY-1934-1943,Libya (1934-1943),1934,1943,cshapes-2.0,1934.0,assigned,True,measured,False,False,vintage 1934 faithful to period 1934-1943,73
+LBY-1943-1949,Libya (1943-1949),1943,1949,cshapes-2.0,1943.0,assigned,True,measured,False,False,vintage 1943 faithful to period 1943-1949,23
+LBY-1950-1951,Libya under UN Transitional Administration (1950-1951),1950,1951,cshapes-2.0,1943.0,assigned,True,back_projected,True,True,polygon vintage 1943 is BEFORE the period starts (1950),25
+LBY-1951-2025,Libya,1951,2025,cshapes-2.0,1951.0,assigned,True,assumed_constant,True,True,single 1951 polygon held across a 74y span (1951-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),27
 LCA-1800-1838,Saint Lucia (to 1838),1800,1838,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
 LCA-1838-2025,Saint Lucia,1838,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,158
 LIE-1800-2025,Liechtenstein,1800,2025,cshapes-europe,1806.0,assigned,True,assumed_constant,True,True,single 1806 polygon held across a 225y span (1800-2025); borders may have changed,43
@@ -416,38 +430,39 @@ LSO-1886-1966,Lesotho (1886-1966),1886,1966,cshapes-2.0,1886.0,assigned,True,ass
 LSO-1966-2025,Lesotho,1966,2025,cshapes-2.0,1966.0,assigned,False,assumed_constant,True,False,single 1966 polygon held across a 59y span (1966-2025); borders may have changed,0
 LST-1822-1868,Basotho Kingdom,1822,1868,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 LTU-1800-1918,Lithuania (Russian governorate),1800,1918,cshapes-2.0,1918.0,assigned,True,assumed_constant,True,False,single 1918 polygon held across a 118y span (1800-1918); borders may have changed,10
-LTU-1918-1940,Lithuania (interwar republic),1918,1940,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1918-1940,493
-LTU-1940-1991,Lithuanian SSR,1940,1991,cshapes-2.0,1939.0,assigned,True,back_projected,True,False,polygon vintage 1939 is BEFORE the period starts (1940),5
+LTU-1918-1940,Lithuania (interwar republic),1918,1940,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1918-1940,481
+LTU-1940-1991,Lithuanian SSR,1940,1991,cshapes-2.0,1939.0,assigned,True,back_projected,True,False,polygon vintage 1939 is BEFORE the period starts (1940),17
 LTU-1991-2025,Lithuania,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 LUX-1839-2025,Luxembourg,1839,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 186y span (1839-2025); borders may have changed,1332
 LVA-1800-1918,Latvia (Livonia and Courland),1800,1918,cshapes-2.0,1918.0,assigned,True,assumed_constant,True,False,single 1918 polygon held across a 118y span (1800-1918); borders may have changed,10
-LVA-1918-1940,Latvia (interwar republic),1918,1940,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1940,514
-LVA-1940-1991,Latvian SSR,1940,1991,cshapes-2.0,1918.0,assigned,True,back_projected,True,False,polygon vintage 1918 is BEFORE the period starts (1940),5
+LVA-1918-1940,Latvia (interwar republic),1918,1940,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1940,512
+LVA-1940-1991,Latvian SSR,1940,1991,cshapes-2.0,1918.0,assigned,True,back_projected,True,False,polygon vintage 1918 is BEFORE the period starts (1940),7
 LVA-1991-2025,Latvia,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 LZI-1800-1890,Lozi Kingdom (Barotseland),1800,1890,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 MAC-1800-2025,"China, Macao SAR",1800,2025,gadm-4.1-adm1,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-MAN-1932-1945,Manchukuo (1932-1945),1932,1945,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,101
-MAR-1911-1958,Morocco (to 1958),1911,1958,cshapes-2.0,1912.0,assigned,True,assumed_constant,True,False,single 1912 polygon held across a 47y span (1911-1958); borders may have changed,1294
-MAR-1958-1975,Morocco (1958-1975),1958,1975,cshapes-2.0,1958.0,assigned,True,measured,False,False,vintage 1958 faithful to period 1958-1975,29
+MAN-1932-1945,Manchukuo (1932-1945),1932,1945,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,100
+MAN-1945-1950,"Manchuria (region, 1945-1950)",1945,1950,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,10
+MAR-1911-1958,Morocco (to 1958),1911,1958,cshapes-2.0,1912.0,assigned,True,assumed_constant,True,False,single 1912 polygon held across a 47y span (1911-1958); borders may have changed,1283
+MAR-1958-1975,Morocco (1958-1975),1958,1975,cshapes-2.0,1958.0,assigned,True,measured,False,False,vintage 1958 faithful to period 1958-1975,40
 MAR-1975-1979,Morocco (1975-1979),1975,1979,cshapes-2.0,1975.0,assigned,False,measured,False,False,vintage 1975 faithful to period 1975-1979,0
 MAR-1979-2025,Morocco,1979,2025,cshapes-2.0,1979.0,assigned,False,assumed_constant,True,False,single 1979 polygon held across a 46y span (1979-2025); borders may have changed,0
 MASG-1946-1963,Malaya and Singapore,1946,1963,constructed,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-MCO-1800-2025,Monaco,1800,2025,cshapes-europe,1861.0,assigned,True,assumed_constant,True,True,single 1861 polygon held across a 225y span (1800-2025); borders may have changed,5
+MCO-1800-2025,Monaco,1800,2025,gadm-4.1-adm0,1861.0,assigned,True,assumed_constant,True,True,single 1861 polygon held across a 225y span (1800-2025); borders may have changed,5
 MDA-1991-2025,Moldova,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 MDG-1882-2025,Madagascar,1882,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 143y span (1882-2025); borders may have changed,1079
-MDV-1800-2025,Maldives,1800,2025,cshapes-2.0,1887.0,assigned,True,assumed_constant,True,False,single 1887 polygon held across a 225y span (1800-2025); borders may have changed,0
+MDV-1800-2025,Maldives,1800,2025,gadm-4.1-adm0,1887.0,assigned,True,assumed_constant,True,False,single 1887 polygon held across a 225y span (1800-2025); borders may have changed,0
 MEX-1800-1848,Mexico (to 1848),1800,1848,cliopatria,1825.0,assigned,False,assumed_constant,True,False,single 1825 polygon held across a 48y span (1800-1848); borders may have changed,0
 MEX-1848-2025,Mexico,1848,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 177y span (1848-2025); borders may have changed,4253
 MHL-1874-2025,Marshall Islands,1874,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 MKD-1991-2025,North Macedonia,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
-MKY-1918-1962,Mutawakkilite Kingdom of Yemen (1918-1962),1918,1962,cshapes-2.0,1920.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),28
-MLI-1890-1960,French Sudan (1890-1960),1890,1960,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 70y span (1890-1960); borders may have changed,374
-MLI-1960-2025,Mali,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+MKY-1918-1962,Mutawakkilite Kingdom of Yemen (1918-1962),1918,1962,cshapes-2.0,1930.0,assigned,True,assumed_constant,True,True,single 1930 polygon held across a 44y span (1918-1962); borders may have changed,28
+MLI-1890-1960,French Sudan (1890-1960),1890,1960,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 70y span (1890-1960); borders may have changed,367
+MLI-1960-2025,Mali,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,7
 MLT-1800-2025,Malta,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,1033
 MMR-1800-1826,Konbaung Burma (to 1826),1800,1826,cliopatria,1822.0,assigned,False,assumed_constant,True,False,single 1822 polygon held across a 26y span (1800-1826); borders may have changed,0
 MMR-1826-1852,Burma (1826-1852),1826,1852,cliopatria,1842.0,assigned,False,assumed_constant,True,False,single 1842 polygon held across a 26y span (1826-1852); borders may have changed,0
-MMR-1852-1885,Upper Burma (1852-1885),1852,1885,cliopatria,1859.0,assigned,True,assumed_constant,True,False,single 1859 polygon held across a 33y span (1852-1885); borders may have changed,25
-MMR-1885-2025,Myanmar,1885,2025,cliopatria,1967.0,approximate,True,assumed_constant,True,False,single 1967 polygon held across a 140y span (1885-2025); borders may have changed,532
+MMR-1852-1885,Upper Burma (1852-1885),1852,1885,cliopatria,1859.0,assigned,True,assumed_constant,True,False,single 1859 polygon held across a 33y span (1852-1885); borders may have changed,24
+MMR-1885-2025,Myanmar,1885,2025,cliopatria,1967.0,polygon_vintage_drift,True,assumed_constant,True,False,single 1967 polygon held across a 140y span (1885-2025); borders may have changed,533
 MMR-LWR-1852-1885,British Lower Burma (1852-1885),1852,1885,gadm-4.1,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
 MNE-1878-1913,Montenegro (to 1913),1878,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 35y span (1878-1913); borders may have changed,0
 MNE-1913-1915,Montenegro (1913-1915),1913,1915,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1913),0
@@ -462,53 +477,55 @@ MOS-1800-1897,Mossi Kingdoms,1800,1897,paine-2024,,assigned,True,assumed_constan
 MOZ-1800-1891,Mozambique (to 1891),1800,1891,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 91y span (1800-1891); borders may have changed,0
 MOZ-1891-1975,Mozambique (1891-1975),1891,1975,cshapes-2.0,1891.0,assigned,True,assumed_constant,True,False,single 1891 polygon held across a 84y span (1891-1975); borders may have changed,493
 MOZ-1975-2025,Mozambique (1975-2025),1975,2025,cshapes-2.0,1975.0,assigned,False,assumed_constant,True,False,single 1975 polygon held across a 50y span (1975-2025); borders may have changed,0
-MRT-1920-1960,French Mauritania,1920,1960,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 40y span (1920-1960); borders may have changed,216
-MRT-1960-1975,Mauritania (1960-1975),1960,1975,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1960-1975,0
+MRT-1920-1960,French Mauritania,1920,1960,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 40y span (1920-1960); borders may have changed,212
+MRT-1960-1975,Mauritania (1960-1975),1960,1975,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1960-1975,4
 MRT-1975-1979,Mauritania (1975-1979),1975,1979,cshapes-2.0,1975.0,assigned,False,measured,False,False,vintage 1975 faithful to period 1975-1979,0
 MRT-1979-2025,Mauritania,1979,2025,cshapes-2.0,1979.0,assigned,False,assumed_constant,True,False,single 1979 polygon held across a 46y span (1979-2025); borders may have changed,0
 MSR-1800-2025,Montserrat,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,166
 MTQ-1816-2025,Martinique,1816,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 209y span (1816-2025); borders may have changed,282
 MUS-1800-2025,Mauritius,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,455
-MWI-1891-1953,Nyasaland (1891-1953),1891,1953,cshapes-2.0,1891.0,assigned,True,assumed_constant,True,False,single 1891 polygon held across a 62y span (1891-1953); borders may have changed,667
-MWI-1953-1964,Nyasaland within Federation of Rhodesia and Nyasaland,1953,1964,cshapes-2.0,1891.0,assigned,True,back_projected,True,False,polygon vintage 1891 is BEFORE the period starts (1953),35
+MWI-1891-1953,Nyasaland (1891-1953),1891,1953,cshapes-2.0,1891.0,assigned,True,assumed_constant,True,False,single 1891 polygon held across a 62y span (1891-1953); borders may have changed,662
+MWI-1953-1964,Nyasaland within Federation of Rhodesia and Nyasaland,1953,1964,cshapes-2.0,1891.0,assigned,True,back_projected,True,False,polygon vintage 1891 is BEFORE the period starts (1953),40
 MWI-1964-2025,Malawi,1964,2025,cshapes-2.0,1964.0,assigned,False,assumed_constant,True,False,single 1964 polygon held across a 61y span (1964-2025); borders may have changed,0
-MYS-1946-1957,Malayan Union / Federation of Malaya (1946-1957),1946,1957,cshapes-2.0,1946.0,assigned,True,measured,False,True,vintage 1946 faithful to period 1946-1957; footnote coverage caveat (FAO/IIA yearbook),0
+MYS-1946-1957,Malayan Union / Federation of Malaya (1946-1957),1946,1957,cshapes-2.0,1946.0,assigned,True,measured,False,True,vintage 1946 faithful to period 1946-1957; footnote coverage caveat (FAO/IIA yearbook),101
 MYS-1957-1963,Malaysia (1957-1963),1957,1963,cshapes-2.0,1957.0,assigned,True,measured,False,True,vintage 1957 faithful to period 1957-1963; footnote coverage caveat (FAO/IIA yearbook),0
 MYS-1963-1965,Malaysia (1963-1965),1963,1965,cshapes-2.0,1963.0,assigned,False,measured,False,False,vintage 1963 faithful to period 1963-1965,0
 MYS-1965-2025,Malaysia,1965,2025,cshapes-2.0,1965.0,assigned,False,assumed_constant,True,False,single 1965 polygon held across a 60y span (1965-2025); borders may have changed,0
 NAM-1884-1886,Namibia,1884,1886,cshapes-2.0,1920.0,assigned,True,back_projected,True,False,polygon vintage 1920 is AFTER the period ends (1886) — later/modern border applied back,0
-NAM-1886-1915,Namibia (1886-1915),1886,1915,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 29y span (1886-1915); borders may have changed,21
-NAM-1915-1920,Namibia (1915-1920),1915,1920,cshapes-2.0,1915.0,assigned,True,measured,False,False,vintage 1915 faithful to period 1915-1920,3
-NAM-1920-1990,Namibia (1920-1990),1920,1990,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 70y span (1920-1990); borders may have changed,189
+NAM-1886-1915,Namibia (1886-1915),1886,1915,cshapes-2.0,1887.0,assigned,True,assumed_constant,True,False,single 1887 polygon held across a 29y span (1886-1915); borders may have changed,21
+NAM-1915-1920,Namibia (1915-1920),1915,1920,cshapes-2.0,1915.0,assigned,True,measured,False,False,vintage 1915 faithful to period 1915-1920,0
+NAM-1920-1990,Namibia (1920-1990),1920,1990,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 70y span (1920-1990); borders may have changed,192
 NAM-1990-2025,Namibia (1990-2025),1990,2025,cshapes-2.0,1990.0,assigned,False,assumed_constant,True,False,single 1990 polygon held across a 35y span (1990-2025); borders may have changed,0
-NAT-1843-1895,Natal (to 1895),1843,1895,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 52y span (1843-1895); borders may have changed,313
-NAT-1895-1910,Natal (1895-1910),1895,1910,cshapes-2.0,1895.0,assigned,True,measured,False,False,vintage 1895 faithful to period 1895-1910,102
+NAT-1843-1895,Natal (to 1895),1843,1895,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 52y span (1843-1895); borders may have changed,305
+NAT-1895-1910,Natal (1895-1910),1895,1910,cshapes-2.0,1895.0,assigned,True,measured,False,False,vintage 1895 faithful to period 1895-1910,110
 NCL-1800-2025,New Caledonia,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,125
 NDB-1823-1894,Ndebele Kingdom,1823,1894,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-NER-1911-1922,"Niger (Military Territory, 1911-1922)",1911,1922,cshapes-2.0,1926.0,assigned,True,back_projected,True,False,polygon vintage 1926 is AFTER the period ends (1922) — later/modern border applied back,15
-NER-1922-1947,Colonial Niger (1922-1947),1922,1947,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 25y span (1922-1947); borders may have changed,287
-NER-1947-1960,Niger (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,85
-NER-1960-2025,Niger,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
-NFK-1914-2025,Norfolk Island (Australian Territory),1914,2025,gadm-4.1,2023.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),9
+NER-1911-1922,"Niger (Military Territory, 1911-1922)",1911,1922,cshapes-2.0,1926.0,assigned,True,back_projected,True,True,polygon vintage 1926 is AFTER the period ends (1922) — later/modern border applied back,15
+NER-1922-1947,Colonial Niger (1922-1947),1922,1947,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 25y span (1922-1947); borders may have changed,281
+NER-1947-1960,Niger (1947-1960),1947,1960,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1960,82
+NER-1960-2025,Niger,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,9
+NFK-1914-2025,Norfolk Island (Australian Territory),1914,2025,gadm-4.1-adm0,2023.0,assigned,True,assumed_constant,True,True,single 2023 polygon held across a 111y span (1914-2025); borders may have changed,9
 NFL-1907-1949,Dominion of Newfoundland,1907,1949,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 42y span (1907-1949); borders may have changed,0
-NGA-1886-1914,Colonial Nigeria,1886,1914,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,False,single 1914 polygon held across a 28y span (1886-1914); borders may have changed,61
-NGA-1914-1960,Nigeria (1914-1960),1914,1960,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,True,single 1914 polygon held across a 46y span (1914-1960); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),514
-NGA-1960-1961,Nigeria (1960-1961),1960,1961,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1960-1961,0
+NGA-1886-1914,Colonial Nigeria,1886,1914,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,False,single 1914 polygon held across a 28y span (1886-1914); borders may have changed,58
+NGA-1914-1960,Nigeria (1914-1960),1914,1960,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,True,single 1914 polygon held across a 46y span (1914-1960); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),501
+NGA-1960-1961,Nigeria (1960-1961),1960,1961,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1960-1961,16
 NGA-1961-2025,Nigeria,1961,2025,cshapes-2.0,1961.0,assigned,True,assumed_constant,True,False,single 1961 polygon held across a 64y span (1961-2025); borders may have changed,0
 NIC-1800-2025,Nicaragua,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,835
+NIU-1800-2025,Niue,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,2
 NKR-1800-1901,Kingdom of Nkore (Ankole),1800,1901,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 NLD-1800-1830,United Kingdom of the Netherlands,1800,1830,cliopatria,1820.0,assigned,False,assumed_constant,True,False,single 1820 polygon held across a 30y span (1800-1830); borders may have changed,0
 NLD-1830-2025,Netherlands,1830,2025,cliopatria,1950.0,assigned,True,assumed_constant,True,False,single 1950 polygon held across a 195y span (1830-2025); borders may have changed,2925
+NNG-1949-1963,Netherlands New Guinea / West Irian (1949-1969),1949,1969,cshapes-2.0,1955.0,assigned,True,measured,False,False,vintage 1955 faithful to period 1949-1969,3
 NNI-1899-1904,Northern Nigeria (1899-1904),1899,1904,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1904,0
 NNI-1904-1913,Northern Nigeria (1904-1913),1904,1913,cshapes-2.0,1905.0,assigned,True,measured,False,False,vintage 1905 faithful to period 1904-1913,0
 NOR-1800-2025,Norway,1800,2025,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,True,single 1905 polygon held across a 225y span (1800-2025); borders may have changed,1637
 NPL-1800-1816,Greater Nepal,1800,1816,cliopatria,1800.0,assigned,False,measured,False,False,vintage 1800 faithful to period 1800-1816,0
 NPL-1816-2025,Nepal,1816,2025,cliopatria,1929.0,assigned,True,assumed_constant,True,False,single 1929 polygon held across a 209y span (1816-2025); borders may have changed,34
-NRH-1911-1953,Northern Rhodesia (1911-1953),1911,1953,,,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),246
+NRH-1911-1953,Northern Rhodesia (1911-1953),1911,1953,cshapes-2.0,1911.0,assigned,True,assumed_constant,True,True,single 1911 polygon held across a 42y span (1911-1953); borders may have changed,246
 NRH-1953-1964,Northern Rhodesia within Federation of Rhodesia and Nyasaland (1953-1964),1953,1964,cshapes-2.0,1953.0,assigned,True,measured,False,False,vintage 1953 faithful to period 1953-1964,8
 NRU-1888-2025,Nauru,1888,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,29
 NSW-1800-1900,New South Wales (to 1900),1800,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 100y span (1800-1900); borders may have changed,195
-NUP-1800-1897,Nupe Kingdom (Bida Emirate),1800,1897,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+NUP-1800-1897,Nupe Kingdom (Bida Emirate),1800,1897,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
 NWR-1900-1905,Northwestern Rhodesia (1900-1905),1900,1905,cshapes-2.0,1900.0,assigned,True,measured,False,False,vintage 1900 faithful to period 1900-1905,0
 NZL-1840-2025,New Zealand,1840,2025,cshapes-2.0,1907.0,assigned,True,assumed_constant,True,True,single 1907 polygon held across a 185y span (1840-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),1924
 OMN-1800-1856,Omani Empire,1800,1856,cliopatria,1840.0,assigned,False,assumed_constant,True,False,single 1840 polygon held across a 56y span (1800-1856); borders may have changed,0
@@ -517,71 +534,80 @@ OTT-1800-1886,Ottoman Empire (to 1886),1800,1886,cliopatria,1857.0,assigned,True
 OTT-1886-1908,Ottoman Empire (1886–1908),1886,1908,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1886-1908,0
 OTT-1908-1912,Ottoman Empire (1908–1912),1908,1912,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1908),0
 OYO-1800-1836,Oyo Empire,1800,1836,paine-2024,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
-PAK-1937-1947,"Pakistan (territory within British India, 1937–1947)",1937,1947,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1937-1947,40
-PAK-1947-1949,Pakistan (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,75
-PAK-1949-1971,Pakistan (1949-1971),1949,1971,cshapes-2.0,1949.0,assigned,True,measured,False,True,vintage 1949 faithful to period 1949-1971; footnote coverage caveat (FAO/IIA yearbook),313
+PAK-1937-1947,"Pakistan (territory within British India, 1937–1947)",1937,1947,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1937-1947,31
+PAK-1947-1949,Pakistan (1947-1949),1947,1949,cshapes-2.0,1947.0,assigned,True,measured,False,False,vintage 1947 faithful to period 1947-1949,27
+PAK-1949-1971,Pakistan (1949-1971),1949,1971,cshapes-2.0,1949.0,assigned,True,measured,False,True,vintage 1949 faithful to period 1949-1971; footnote coverage caveat (FAO/IIA yearbook),370
 PAK-1971-2025,Pakistan,1971,2025,cshapes-2.0,1971.0,assigned,False,assumed_constant,True,False,single 1971 polygon held across a 54y span (1971-2025); borders may have changed,0
-PAL-1920-1948,Palestine (1920-1948),1920,1948,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 28y span (1920-1948); borders may have changed,447
-PAN-1903-1979,"Panama (1903-1979, before Canal Zone return)",1903,1979,cshapes-2.0,1903.0,assigned,True,assumed_constant,True,False,single 1903 polygon held across a 76y span (1903-1979); borders may have changed,609
+PAL-1920-1948,Palestine (1920-1948),1920,1948,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 28y span (1920-1948); borders may have changed,345
+PAN-1903-1979,"Panama (1903-1979, before Canal Zone return)",1903,1979,cshapes-2.0,1903.0,assigned,True,assumed_constant,True,True,single 1903 polygon held across a 76y span (1903-1979); borders may have changed,604
 PAN-1979-2025,Panama (post-Canal Zone),1979,2025,cshapes-2.0,1903.0,assigned,False,back_projected,True,False,polygon vintage 1903 is BEFORE the period starts (1979),0
 PAP-1800-1870,Papal States,1800,1870,cliopatria,1814.0,assigned,True,assumed_constant,True,False,single 1814 polygon held across a 70y span (1800-1870); borders may have changed,0
 PER-1825-1884,Peru (to 1884),1825,1884,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is AFTER the period ends (1884) — later/modern border applied back,11
-PER-1825-1909,Peru (to 1909),1825,1909,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 84y span (1825-1909); borders may have changed,45
+PER-1825-1909,Peru (to 1909),1825,1909,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 84y span (1825-1909); borders may have changed,32
 PER-1884-1909,Peru (1884-1909),1884,1909,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 25y span (1884-1909); borders may have changed,0
-PER-1909-1922,Peru (1909-1922),1909,1922,cshapes-2.0,1909.0,assigned,True,measured,False,False,vintage 1909 faithful to period 1909-1922,189
-PER-1922-1942,Peru (1922-1942),1922,1942,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1922-1942,451
-PER-1942-2025,Peru,1942,2025,cshapes-2.0,1942.0,assigned,True,assumed_constant,True,False,single 1942 polygon held across a 83y span (1942-2025); borders may have changed,1082
+PER-1909-1922,Peru (1909-1922),1909,1922,cshapes-2.0,1909.0,assigned,True,measured,False,False,vintage 1909 faithful to period 1909-1922,181
+PER-1922-1942,Peru (1922-1942),1922,1942,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1922-1942,452
+PER-1942-2025,Peru,1942,2025,cshapes-2.0,1942.0,assigned,True,assumed_constant,True,False,single 1942 polygon held across a 83y span (1942-2025); borders may have changed,1102
 PHL-1800-2025,Philippines,1800,2025,cshapes-2.0,1898.0,assigned,True,assumed_constant,True,False,single 1898 polygon held across a 225y span (1800-2025); borders may have changed,1424
-PLW-1991-2025,Palau,1991,2025,none,,missing,False,unassigned,True,False,no polygon (honest gap; never a false territory),0
-PNG-1949-1975,Territory of Papua and New Guinea,1949,1975,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,False,single 1949 polygon held across a 26y span (1949-1975); borders may have changed,30
+PLW-1991-2025,Palau,1991,2025,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
+PNG-1949-1975,Territory of Papua and New Guinea,1949,1975,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 26y span (1949-1975); borders may have changed,25
 PNG-1975-2025,Papua New Guinea,1975,2025,cshapes-2.0,1975.0,assigned,False,assumed_constant,True,False,single 1975 polygon held across a 50y span (1975-2025); borders may have changed,0
 PNV-1800-1882,Kingdom of Porto-Novo,1800,1882,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 POL-1815-1918,Congress Poland (1815-1918),1815,1918,cshapes-2.0,1918.0,assigned,True,assumed_constant,True,False,single 1918 polygon held across a 103y span (1815-1918); borders may have changed,17
-POL-1918-1919,Poland (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,19
-POL-1919-1920,Poland (1919-1920),1919,1920,cshapes-2.0,1919.0,polygon_vintage_drift,True,measured,False,False,vintage 1919 faithful to period 1919-1920,27
-POL-1920-1921,Poland (1920-1921),1920,1921,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1921,32
-POL-1921-1945,Poland (1921-1945),1921,1945,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1921-1945,852
-POL-1945-2025,Poland (1945-2025),1945,2025,cshapes-2.0,1945.0,assigned,True,assumed_constant,True,False,single 1945 polygon held across a 80y span (1945-2025); borders may have changed,617
+POL-1918-1919,Poland (1918-1919),1918,1919,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1919,0
+POL-1919-1920,Poland (1919-1920),1919,1920,cshapes-2.0,1919.0,polygon_vintage_drift,True,measured,False,False,vintage 1919 faithful to period 1919-1920,19
+POL-1920-1921,Poland (1920-1921),1920,1921,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1921,27
+POL-1921-1945,Poland (1921-1945),1921,1945,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1921-1945,857
+POL-1945-2025,Poland (1945-2025),1945,2025,cshapes-2.0,1945.0,assigned,True,assumed_constant,True,False,single 1945 polygon held across a 80y span (1945-2025); borders may have changed,644
 PRI-1800-2025,Puerto Rico,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,936
 PRK-1948-2025,North Korea,1948,2025,cshapes-2.0,1948.0,assigned,True,assumed_constant,True,False,single 1948 polygon held across a 77y span (1948-2025); borders may have changed,30
 PRT-1800-2025,Portugal,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,1816
 PRY-1811-1870,Paraguay (pre-Triple Alliance),1811,1870,ESTIMATE,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-PRY-1811-1938,Paraguay (to 1938),1811,1938,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 127y span (1811-1938); borders may have changed,421
-PRY-1870-1932,Paraguay (post-Triple Alliance),1870,1932,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 62y span (1870-1932); borders may have changed,0
-PRY-1932-1938,Paraguay (Chaco War period),1932,1938,cshapes-2.0,1886.0,assigned,True,back_projected,True,True,polygon vintage 1886 is BEFORE the period starts (1932),0
-PRY-1938-2025,Paraguay,1938,2025,cshapes-2.0,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 87y span (1938-2025); borders may have changed,666
-PTIND-1816-1961,Portuguese India (Estado da India Portuguesa),1816,1961,gadm-4.1,,estimate,True,unassigned,True,False,no polygon (honest gap; never a false territory),7
+PRY-1811-1938,Paraguay (to 1938),1811,1938,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 127y span (1811-1938); borders may have changed,0
+PRY-1870-1932,Paraguay (post-Triple Alliance),1870,1932,cshapes-2.0,1886.0,estimate,True,assumed_constant,True,False,single 1886 polygon held across a 62y span (1870-1932); borders may have changed,271
+PRY-1932-1938,Paraguay (Chaco War period),1932,1938,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1932),115
+PRY-1938-2025,Paraguay,1938,2025,cshapes-2.0,1938.0,assigned,True,assumed_constant,True,False,single 1938 polygon held across a 87y span (1938-2025); borders may have changed,701
+PSE-1948-2025,Palestine (West Bank and Gaza),1948,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,1
+PTIND-1816-1961,Portuguese India (Estado da India Portuguesa),1816,1961,constructed,,estimate,True,assumed_constant,True,False,polygon present but no recorded vintage year,7
 PYF-1800-2025,French Polynesia,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,107
 QAT-1800-2025,Qatar,1800,2025,cshapes-2.0,1916.0,assigned,True,assumed_constant,True,True,single 1916 polygon held across a 225y span (1800-2025); borders may have changed,4
-QUE-1859-1900,Queensland (to 1900),1859,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 41y span (1859-1900); borders may have changed,190
-RAFR-1850-2021,Africa Other,1850,2021,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-RASI-1850-2021,Asia Other,1850,2021,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+QUE-1859-1900,Queensland (to 1900),1859,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 41y span (1859-1900); borders may have changed,190
+RAFR-1850-2021,Africa Other,1850,2021,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RAFR-1850-2025,Africa Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+RASI-1850-2021,Asia Other,1850,2021,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RASI-1850-2025,Asia Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 REU-1816-1946,Réunion (French Colony),1816,1946,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 130y span (1816-1946); borders may have changed,68
-REU-1946-2025,Réunion (French Overseas Department),1946,2025,cshapes-2.0,1886.0,assigned,True,back_projected,True,True,polygon vintage 1886 is BEFORE the period starts (1946),47
-REUR-1850-2021,Europe Other,1850,2021,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-RLAM-1850-2013,Latin America Other,1850,2013,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-RNAM-1850-2021,North America Other,1850,2021,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-ROCE-1850-2021,Oceania Other,1850,2021,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-ROU-1859-1913,Romania (to 1913),1859,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 54y span (1859-1913); borders may have changed,709
-ROU-1913-1918,Romania (1913-1918),1913,1918,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1918,126
-ROU-1918-1919,Romania (1918-1919),1918,1919,cshapes-2.0,1920.0,assigned,True,back_projected,True,False,polygon vintage 1920 is AFTER the period ends (1919) — later/modern border applied back,39
+REU-1946-2025,Réunion (French Overseas Department),1946,2025,cshapes-2.0,1886.0,assigned,True,back_projected,True,False,polygon vintage 1886 is BEFORE the period starts (1946),47
+REUR-1850-2021,Europe Other,1850,2021,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+REUR-1850-2025,Europe Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+RLAM-1850-2013,Latin America Other,1850,2013,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RLAM-1850-2025,Latin America Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+RNAM-1850-2021,North America Other,1850,2021,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RNAM-1850-2025,North America Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+ROCE-1850-2021,Oceania Other,1850,2021,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+ROCE-1850-2025,Oceania Other,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+ROU-1859-1913,Romania (to 1913),1859,1913,cshapes-europe,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 54y span (1859-1913); borders may have changed,657
+ROU-1913-1918,Romania (1913-1918),1913,1918,cshapes-2.0,1913.0,assigned,True,measured,False,False,vintage 1913 faithful to period 1913-1918,147
+ROU-1918-1919,Romania (1918-1919),1918,1919,cshapes-2.0,1921.0,assigned,True,back_projected,True,False,polygon vintage 1921 is AFTER the period ends (1919) — later/modern border applied back,70
 ROU-1919-1920,Romania (1919-1920),1919,1920,cshapes-2.0,1919.0,assigned,True,measured,False,False,vintage 1919 faithful to period 1919-1920,39
-ROU-1920-1940,Romania (1920-1940),1920,1940,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1940,1087
-ROU-1940-1947,Romania (1940-1947),1940,1947,cshapes-2.0,1940.0,assigned,True,measured,False,False,vintage 1940 faithful to period 1940-1947,350
-ROU-1940-2025,Romania (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,589
-ROU-1947-2025,Romania (1947-2025),1947,2025,cshapes-2.0,1946.0,assigned,True,back_projected,True,False,polygon vintage 1946 is BEFORE the period starts (1947),0
-ROW-1850-2023,Rest of World,1850,2023,reporting-areas,,derived,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-RSFSR-1917-1991,Russian SFSR (1917-1991),1917,1991,cshapes-2.0,1991.0,proxy,True,assumed_constant,True,False,single 1991 polygon held across a 74y span (1917-1991); borders may have changed,0
-RUS-1991-2014,Russia (1991-2014),1991,2014,cshapes-2.0,1991.0,assigned,False,measured,False,False,vintage 1991 faithful to period 1991-2014,0
+ROU-1920-1940,Romania (1920-1940),1920,1940,cshapes-2.0,1921.0,assigned,True,measured,False,False,vintage 1921 faithful to period 1920-1940,1031
+ROU-1940-1947,Romania (1940-1947),1940,1947,constructed,1940.0,proxy,True,measured,False,False,vintage 1940 faithful to period 1940-1947,406
+ROU-1940-2025,Romania (1940-2025),1940,2025,cshapes-2.0,1940.0,assigned,True,assumed_constant,True,False,single 1940 polygon held across a 85y span (1940-2025); borders may have changed,0
+ROU-1947-2025,Romania (1947-2025),1947,2025,cshapes-2.0,1946.0,assigned,True,back_projected,True,True,polygon vintage 1946 is BEFORE the period starts (1947),589
+ROW-1850-2023,Rest of World,1850,2023,reporting-areas,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+ROW-1850-2025,Rest of World,1850,2025,reporting-areas,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
+RSFSR-1917-1991,Russian SFSR (1917-1991),1917,1991,cshapes-2.0,1991.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RUS-1991-2014,Russia (1991-2014),1991,2014,cshapes-2.0,1992.0,assigned,False,measured,False,False,vintage 1992 faithful to period 1991-2014,0
 RUS-2014-2025,Russia,2014,2025,cshapes-2.0,2014.0,assigned,False,measured,False,False,vintage 2014 faithful to period 2014-2025,0
 RVN-1954-1975,Republic of Vietnam (South Vietnam),1954,1975,cshapes-2.0,1960.0,assigned,True,measured,False,False,vintage 1960 faithful to period 1954-1975,93
+RWA-1922-1962,Rwanda (within Ruanda-Urundi),1922,1962,cshapes-2.0,1962.0,assigned,True,assumed_constant,True,False,single 1962 polygon held across a 40y span (1922-1962); borders may have changed,0
 RWA-1962-2025,Rwanda,1962,2025,cshapes-2.0,1962.0,assigned,False,assumed_constant,True,False,single 1962 polygon held across a 63y span (1962-2025); borders may have changed,0
-RWB-1919-1922,Rwanda and Burundi,1919,1922,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
+RWB-1919-1922,Rwanda and Burundi,1919,1922,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
 RWB-1922-1962,Ruanda-Urundi (1922-1962),1922,1962,cshapes-2.0,1922.0,assigned,True,assumed_constant,True,False,single 1922 polygon held across a 40y span (1922-1962); borders may have changed,368
 RWK-1800-1890,Kingdom of Rwanda,1800,1890,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
-RYU-1937-1945,Ryukyu Islands / Okinawa Prefecture (Japanese),1937,1945,gadm-4.1-adm1,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-RYU-1945-1972,Ryukyu Islands (US Administration),1945,1972,gadm-4.1-adm1,,proxy,True,unassigned,True,True,no polygon (honest gap; never a false territory); footnote coverage caveat (FAO/IIA yearbook),53
-SAA-1947-1957,Saar Protectorate,1947,1957,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),132
+RYU-1937-1945,Ryukyu Islands / Okinawa Prefecture (Japanese),1937,1945,gadm-4.1-adm1,,proxy,True,assumed_constant,True,True,polygon present but no recorded vintage year,5
+RYU-1945-1972,Ryukyu Islands (US Administration),1945,1972,gadm-4.1-adm1,,proxy,True,assumed_constant,True,True,polygon present but no recorded vintage year; footnote coverage caveat (FAO/IIA yearbook),53
+SAA-1947-1957,Saar Protectorate,1947,1957,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),132
 SAB-1920-1935,Saar Basin Territory (League of Nations),1920,1935,,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
 SAC-1935-1947,"Saar (German incorporation, 1935-1947)",1935,1947,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),14
 SAR-1800-1860,Sardinia,1800,1860,cliopatria,1815.0,assigned,True,assumed_constant,True,False,single 1815 polygon held across a 60y span (1800-1860); borders may have changed,0
@@ -589,18 +615,19 @@ SAU-1924-2025,Saudi Arabia,1924,2025,cshapes-2.0,1935.0,assigned,True,assumed_co
 SBZ-1938-1949,Eastern Germany / Soviet Occupation Zone,1938,1949,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1938-1949,36
 SCG-1992-2006,Serbia and Montenegro,1992,2006,cshapes-2.0,1992.0,assigned,False,measured,False,False,vintage 1992 faithful to period 1992-2006,0
 SDN-2011-2025,Sudan,2011,2025,cshapes-2.0,2011.0,assigned,False,measured,False,False,vintage 2011 faithful to period 2011-2025,0
-SEN-1854-1886,Senegal (colony),1854,1886,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 32y span (1854-1886); borders may have changed,1
-SEN-1886-1959,Senegal (1886-1959),1886,1959,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1886-1959); borders may have changed,470
+SEN-1854-1886,Senegal (colony),1854,1886,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 32y span (1854-1886); borders may have changed,0
+SEN-1886-1959,Senegal (1886-1959),1886,1959,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 73y span (1886-1959); borders may have changed,471
 SEN-1960-2025,Senegal,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,14
 SER-1816-1878,Principality of Serbia (1816-1878),1816,1878,cliopatria,1830.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-SER-1816-1913,Serbia (1816-1913),1816,1913,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 97y span (1816-1913); borders may have changed,370
-SER-1878-1913,Kingdom of Serbia (1878-1913),1878,1913,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 35y span (1878-1913); borders may have changed,0
-SER-1913-1918,Serbia (1913-1918),1913,1918,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1913-1918,2
-SER-1918-1945,Serbia within Yugoslavia (1918-1945),1918,1945,composed-estimate,1920.0,estimate,True,unassigned,True,False,no polygon (honest gap; never a false territory),568
+SER-1816-1913,Serbia (1816-1913),1816,1913,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 97y span (1816-1913); borders may have changed,0
+SER-1878-1913,Kingdom of Serbia (1878-1913),1878,1913,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 35y span (1878-1913); borders may have changed,355
+SER-1913-1918,Serbia (1913-1918),1913,1918,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1913-1918,17
+SER-1918-1945,Serbia within Yugoslavia (1918-1945),1918,1945,composed-estimate,1920.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),561
 SER-2006-2008,Serbia (2006-2008),2006,2008,cshapes-2.0,1992.0,assigned,False,back_projected,True,False,polygon vintage 1992 is BEFORE the period starts (2006),0
 SGP-1946-1963,Singapore (Crown Colony),1946,1963,cshapes-2.0,1953.0,assigned,True,measured,False,False,vintage 1953 faithful to period 1946-1963,59
+SGP-1963-1965,Singapore (State of Singapore in Malaysia),1963,1965,cshapes-2.0,1962.0,assigned,False,back_projected,True,False,polygon vintage 1962 is BEFORE the period starts (1963),0
 SGP-1965-2025,Singapore,1965,2025,cshapes-2.0,1965.0,assigned,False,assumed_constant,True,False,single 1965 polygon held across a 60y span (1965-2025); borders may have changed,0
-SHN-1834-1967,Saint Helena (Crown Colony),1834,1967,gadm-4.1,2024.0,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),15
+SHN-1834-1967,Saint Helena (Crown Colony),1834,1967,gadm-4.1-adm1,2024.0,proxy,True,back_projected,True,True,polygon vintage 2024 is AFTER the period ends (1967) — later/modern border applied back,15
 SLB-1800-2025,Solomon Islands,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,28
 SLE-1800-1886,Sierra Leone,1800,1886,cshapes-2.0,1895.0,assigned,True,back_projected,True,False,polygon vintage 1895 is AFTER the period ends (1886) — later/modern border applied back,0
 SLE-1886-1889,Sierra Leone (1886-1889),1886,1889,cshapes-2.0,1886.0,assigned,True,measured,False,False,vintage 1886 faithful to period 1886-1889,0
@@ -609,72 +636,73 @@ SLE-1961-2025,Sierra Leone (1961-2025),1961,2025,cshapes-2.0,1961.0,assigned,Tru
 SLM-1800-1887,Kingdom of Saloum,1800,1887,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 SLV-1821-2025,El Salvador,1821,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 204y span (1821-2025); borders may have changed,1041
 SMO-1912-1956,Spanish Morocco (1912-1956),1912,1956,cshapes-2.0,1912.0,assigned,True,assumed_constant,True,True,single 1912 polygon held across a 44y span (1912-1956); borders may have changed,55
-SMR-1800-2025,San Marino,1800,2025,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 225y span (1800-2025); borders may have changed,4
+SMR-1800-2025,San Marino,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,True,polygon present but no recorded vintage year,4
 SNE-1800-1887,Kingdom of Sine,1800,1887,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 SNI-1899-1906,Southern Nigeria (1899-1906),1899,1906,cshapes-2.0,1899.0,assigned,True,measured,False,False,vintage 1899 faithful to period 1899-1906,0
-SNI-1906-1913,Southern Nigeria (1906-1913),1906,1913,cshapes-2.0,1899.0,assigned,True,back_projected,True,False,polygon vintage 1899 is BEFORE the period starts (1906),0
+SNI-1906-1913,Southern Nigeria (1906-1913),1906,1913,cshapes-2.0,1906.0,assigned,True,measured,False,False,vintage 1906 faithful to period 1906-1913,0
 SNW-1814-1905,"Sweden-Norway (Union, 1814-1905)",1814,1905,cshapes-europe,1816.0,assigned,True,assumed_constant,True,False,single 1816 polygon held across a 91y span (1814-1905); borders may have changed,0
 SOK-1804-1903,Sokoto Caliphate,1804,1903,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 SOM-1960-2025,Somalia,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,4
-SPM-1816-2025,Saint Pierre and Miquelon,1816,2025,gadm-4.1-adm0,2024.0,proxy,True,assumed_constant,True,False,single 2024 polygon held across a 209y span (1816-2025); borders may have changed,8
-SRB-2008-2025,Serbia,2008,2025,cshapes-2.0,2006.0,assigned,False,back_projected,True,False,polygon vintage 2006 is BEFORE the period starts (2008),0
+SPM-1816-2025,Saint Pierre and Miquelon,1816,2025,gadm-4.1-adm0,2024.0,proxy,True,assumed_constant,True,True,single 2024 polygon held across a 209y span (1816-2025); borders may have changed,8
+SRB-2006-2008,Serbia (including Kosovo),2006,2008,cshapes-2.0,2007.0,assigned,False,measured,False,False,vintage 2007 faithful to period 2006-2008,0
+SRB-2008-2025,Serbia,2008,2025,cshapes-2.0,2008.0,assigned,False,measured,False,False,vintage 2008 faithful to period 2008-2025,0
 SRH-1953-1964,"Southern Rhodesia (within Federation, 1953-1964)",1953,1964,cshapes-2.0,1953.0,assigned,True,measured,False,False,vintage 1953 faithful to period 1953-1964,72
 SSD-2011-2025,South Sudan,2011,2025,cshapes-2.0,2011.0,assigned,False,measured,False,False,vintage 2011 faithful to period 2011-2025,0
-STP-1800-2025,Sao Tome and Principe,1800,2025,cshapes-2.0,1900.0,assigned,True,assumed_constant,True,True,single 1900 polygon held across a 225y span (1800-2025); borders may have changed,84
-SUD-1899-1934,"Sudan (Anglo-Egyptian Condominium, to 1934)",1899,1934,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,False,single 1914 polygon held across a 35y span (1899-1934); borders may have changed,102
-SUD-1934-1956,Sudan (1934-1956),1934,1956,cshapes-2.0,1914.0,assigned,True,back_projected,True,False,polygon vintage 1914 is BEFORE the period starts (1934),272
+STP-1800-2025,Sao Tome and Principe,1800,2025,gadm-4.1-adm0,,proxy,True,assumed_constant,True,True,polygon present but no recorded vintage year,84
+SUD-1899-1934,"Sudan (Anglo-Egyptian Condominium, to 1934)",1899,1934,cshapes-2.0,1914.0,assigned,True,assumed_constant,True,False,single 1914 polygon held across a 35y span (1899-1934); borders may have changed,97
+SUD-1934-1956,Sudan (1934-1956),1934,1956,cshapes-2.0,1914.0,assigned,True,back_projected,True,False,polygon vintage 1914 is BEFORE the period starts (1934),277
 SUD-1956-2011,Sudan (1956-2011),1956,2011,cshapes-2.0,1956.0,assigned,True,assumed_constant,True,False,single 1956 polygon held across a 55y span (1956-2011); borders may have changed,41
-SUR-1886-1954,Dutch Guiana,1886,1954,cshapes-2.0,1886.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),356
-SUR-1954-1975,Surinam (Autonomous),1954,1975,cshapes-2.0,1954.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),12
-SUR-1975-2025,Suriname,1975,2025,cshapes-2.0,1975.0,assigned,False,unassigned,True,False,no polygon (honest gap; never a false territory),0
+SUR-1886-1954,Dutch Guiana,1886,1954,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 68y span (1886-1954); borders may have changed,356
+SUR-1954-1975,Surinam (Autonomous),1954,1975,cshapes-2.0,1954.0,assigned,True,measured,False,False,vintage 1954 faithful to period 1954-1975,12
+SUR-1975-2025,Suriname,1975,2025,cshapes-2.0,1975.0,assigned,False,assumed_constant,True,False,single 1975 polygon held across a 50y span (1975-2025); borders may have changed,0
 SVK-1993-2025,Slovakia,1993,2025,cshapes-2.0,1993.0,assigned,False,assumed_constant,True,False,single 1993 polygon held across a 32y span (1993-2025); borders may have changed,0
 SVN-1992-2025,Slovenia,1992,2025,cshapes-2.0,1992.0,assigned,False,assumed_constant,True,False,single 1992 polygon held across a 33y span (1992-2025); borders may have changed,0
 SWA-1884-1912,Spanish West Africa (to 1912),1884,1912,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 28y span (1884-1912); borders may have changed,0
-SWA-1912-1958,Spanish West Africa (1912-1958),1912,1958,cshapes-2.0,1900.0,assigned,True,back_projected,True,False,polygon vintage 1900 is BEFORE the period starts (1912),2
+SWA-1912-1958,Spanish West Africa (1912-1958),1912,1958,cshapes-2.0,1912.0,assigned,True,assumed_constant,True,False,single 1912 polygon held across a 46y span (1912-1958); borders may have changed,2
 SWE-1800-1809,Sweden (with Finland to 1809),1800,1809,gadm-4.1-adm0,,proxy,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
 SWE-1809-1814,Sweden (1809-1814),1809,1814,gadm-4.1-adm0,,proxy,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
-SWE-1814-1905,Sweden (1814-1905),1814,1905,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,846
-SWE-1905-2025,Sweden,1905,2025,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 120y span (1905-2025); borders may have changed,1881
+SWE-1814-1905,Sweden (1814-1905),1814,1905,gadm-4.1-adm0,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,821
+SWE-1905-2025,Sweden,1905,2025,cshapes-2.0,1905.0,assigned,True,assumed_constant,True,False,single 1905 polygon held across a 120y span (1905-2025); borders may have changed,1906
 SWK-1800-1894,Swazi Kingdom,1800,1894,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 SWZ-1894-2025,Eswatini,1894,2025,cshapes-2.0,1902.0,assigned,True,assumed_constant,True,True,single 1902 polygon held across a 131y span (1894-2025); borders may have changed,155
 SYC-1903-2025,Seychelles,1903,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,35
-SYL-1944-1953,Syria and Lebanon (combined statistical unit),1944,1953,cshapes-2.0,1949.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),6
-SYR-1920-1922,Syria (French Mandate),1920,1922,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1922,26
-SYR-1922-1945,Syria (1922-1945),1922,1945,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1922-1945,668
+SYL-1944-1953,Syria and Lebanon (combined statistical unit),1944,1953,constructed,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1944-1953,6
+SYR-1920-1922,Syria (French Mandate),1920,1922,cshapes-2.0,1920.0,assigned,True,measured,False,False,vintage 1920 faithful to period 1920-1922,4
+SYR-1922-1945,Syria (1922-1945),1922,1945,cshapes-2.0,1922.0,assigned,True,measured,False,False,vintage 1922 faithful to period 1922-1945,690
 SYR-1946-1967,Syrian Arab Republic (1946-1967),1946,1967,cshapes-2.0,1946.0,assigned,True,measured,False,True,vintage 1946 faithful to period 1946-1967; footnote coverage caveat (FAO/IIA yearbook),294
 SYR-1967-2025,Syrian Arab Republic,1967,2025,cshapes-2.0,1967.0,assigned,False,assumed_constant,True,False,single 1967 polygon held across a 58y span (1967-2025); borders may have changed,0
-TAN-1891-1920,Tanzania (1891-1920),1891,1920,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),48
-TAN-1920-1922,Tanzania (1920-1922),1920,1922,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),16
-TAN-1922-1964,Tanzania (1922-1964),1922,1961,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,True,single 1946 polygon held across a 39y span (1922-1961); borders may have changed,647
-TAS-1825-1900,Van Diemen's Land (Tasmania) (to 1900),1825,1900,none,,missing,True,unassigned,True,False,no polygon (honest gap; never a false territory),195
+TAN-1891-1920,Tanzania (1891-1920),1891,1920,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),46
+TAN-1920-1922,Tanzania (1920-1922),1920,1922,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),18
+TAN-1922-1964,Tanzania (1922-1964),1922,1961,cshapes-2.0,1946.0,assigned,True,assumed_constant,True,False,single 1946 polygon held across a 39y span (1922-1961); borders may have changed,647
+TAS-1825-1900,Van Diemen's Land (Tasmania) (to 1900),1825,1900,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),195
 TCD-1900-1912,Chad (1900-1912),1900,1912,cshapes-2.0,1900.0,assigned,True,measured,False,False,vintage 1900 faithful to period 1900-1912,0
-TCD-1912-1919,Chad (1912-1919),1912,1919,cshapes-2.0,1900.0,assigned,True,back_projected,True,False,polygon vintage 1900 is BEFORE the period starts (1912),0
-TCD-1920-1960,Chad (1920-1960),1920,1960,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 40y span (1920-1960); borders may have changed,48
-TCD-1960-2025,Chad,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
-TGO-1960-2025,Togo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,0
+TCD-1912-1919,Chad (1912-1919),1912,1919,cshapes-2.0,1912.0,assigned,True,measured,False,False,vintage 1912 faithful to period 1912-1919,0
+TCD-1920-1960,Chad (1920-1960),1920,1960,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,False,single 1920 polygon held across a 40y span (1920-1960); borders may have changed,46
+TCD-1960-2025,Chad,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,2
+TGO-1960-2025,Togo,1960,2025,cshapes-2.0,1960.0,assigned,True,assumed_constant,True,False,single 1960 polygon held across a 65y span (1960-2025); borders may have changed,6
 THA-1800-1893,Thailand (to 1893),1800,1893,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 93y span (1800-1893); borders may have changed,0
 THA-1893-1904,Thailand (1893-1904),1893,1904,cshapes-2.0,1893.0,assigned,True,measured,False,False,vintage 1893 faithful to period 1893-1904,0
-THA-1904-1907,Thailand (1904-1907),1904,1907,cshapes-2.0,1904.0,assigned,True,measured,False,False,vintage 1904 faithful to period 1904-1907,4
+THA-1904-1907,Thailand (1904-1907),1904,1907,cshapes-2.0,1904.0,assigned,True,measured,False,False,vintage 1904 faithful to period 1904-1907,2
 THA-1907-1909,Thailand (1907-1909),1907,1909,cshapes-2.0,1907.0,assigned,True,measured,False,False,vintage 1907 faithful to period 1907-1909,4
-THA-1909-2025,Thailand,1909,2025,cshapes-2.0,1909.0,assigned,True,assumed_constant,True,False,single 1909 polygon held across a 116y span (1909-2025); borders may have changed,765
+THA-1909-2025,Thailand,1909,2025,cshapes-2.0,1909.0,assigned,True,assumed_constant,True,False,single 1909 polygon held across a 116y span (1909-2025); borders may have changed,767
 TJK-1991-2025,Tajikistan,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 TKM-1991-2025,Turkmenistan,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 TLS-1800-2025,Timor-Leste,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,30
-TNGU-1920-1949,Territory of New Guinea,1920,1949,cshapes-2.0,1920.0,assigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),37
+TNGU-1920-1949,Territory of New Guinea,1920,1949,cshapes-2.0,1930.0,assigned,True,assumed_constant,True,True,single 1930 polygon held across a 29y span (1920-1949); borders may have changed,6
 TON-1800-2025,Tonga,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,53
-TPAP-1906-1949,Territory of Papua,1906,1949,cshapes-2.0,1920.0,assigned,True,assumed_constant,True,True,single 1920 polygon held across a 43y span (1906-1949); borders may have changed,24
-TRP-1943-1951,British Military Administration of Tripolitania,1943,1951,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),0
-TRS-1947-1954,Free Territory of Trieste,1947,1954,constructed,1947.0,estimate,True,unassigned,True,False,no polygon (honest gap; never a false territory),78
+TPAP-1906-1949,Territory of Papua,1906,1949,cshapes-2.0,1910.0,assigned,True,assumed_constant,True,True,single 1910 polygon held across a 43y span (1906-1949); borders may have changed,60
+TRP-1943-1951,British Military Administration of Tripolitania,1943,1951,none,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),39
+TRS-1947-1954,Free Territory of Trieste,1947,1954,constructed,1947.0,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),78
 TTO-1800-2025,Trinidad and Tobago,1800,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 225y span (1800-2025); borders may have changed,404
-TTPI-1947-1994,Trust Territory of the Pacific Islands,1947,1994,gadm-4.1-adm0,,proxy,True,unassigned,True,False,no polygon (honest gap; never a false territory),40
+TTPI-1947-1994,Trust Territory of the Pacific Islands,1947,1994,constructed,,proxy,True,assumed_constant,True,False,polygon present but no recorded vintage year,40
 TUN-1800-1881,Beylik of Tunis,1800,1881,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 TUN-1881-2025,Tunisia,1881,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 144y span (1881-2025); borders may have changed,1294
-TUR-1800-1913,"Turkey (Anatolia, to 1913)",1800,1913,cshapes-2.0,1923.0,estimate,True,back_projected,True,True,polygon vintage 1923 is AFTER the period ends (1913) — later/modern border applied back,44
-TUR-1913-1914,Türkiye (1913-1914),1913,1914,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1913-1914,4
-TUR-1914-1918,Türkiye (1914-1918),1914,1918,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1918,4
-TUR-1918-1920,Türkiye (1918-1920),1918,1920,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1920,3
-TUR-1920-2025,Türkiye (1920-2025),1920,2025,cshapes-2.0,1923.0,assigned,True,assumed_constant,True,False,single 1923 polygon held across a 105y span (1920-2025); borders may have changed,1656
-TUS-1800-1860,Tuscany,1800,1860,cliopatria,1815.0,assigned,True,assumed_constant,True,False,single 1815 polygon held across a 60y span (1800-1860); borders may have changed,0
+TUR-1800-1913,"Turkey (Anatolia, to 1913)",1800,1913,cshapes-2.0,1923.0,estimate,True,back_projected,True,True,polygon vintage 1923 is AFTER the period ends (1913) — later/modern border applied back,36
+TUR-1913-1914,Türkiye (1913-1914),1913,1914,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1913-1914,12
+TUR-1914-1918,Türkiye (1914-1918),1914,1918,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1914-1918,3
+TUR-1918-1920,Türkiye (1918-1920),1918,1920,cshapes-2.0,1918.0,assigned,True,measured,False,False,vintage 1918 faithful to period 1918-1920,2
+TUR-1920-2025,Türkiye (1920-2025),1920,2025,cshapes-2.0,1923.0,assigned,True,assumed_constant,True,True,single 1923 polygon held across a 105y span (1920-2025); borders may have changed,1658
+TUS-1800-1860,Tuscany,1800,1860,cliopatria,1848.0,assigned,True,assumed_constant,True,False,single 1848 polygon held across a 60y span (1800-1860); borders may have changed,0
 TUV-1800-2025,Tuvalu,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
 TWN-1895-1945,Formosa (Japanese Taiwan),1895,1945,cshapes-2.0,1949.0,assigned,True,back_projected,True,False,polygon vintage 1949 is AFTER the period ends (1945) — later/modern border applied back,719
 TWN-1945-2025,Taiwan,1945,2025,cshapes-2.0,1949.0,assigned,True,assumed_constant,True,True,single 1949 polygon held across a 80y span (1945-2025); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),443
@@ -682,17 +710,17 @@ TWO-1800-1860,Two Sicilies,1800,1860,cliopatria,1820.0,assigned,True,assumed_con
 TZA-1961-1964,Tanzania (1961-1964),1961,1964,cshapes-2.0,1961.0,assigned,True,measured,False,False,vintage 1961 faithful to period 1961-1964,0
 TZA-1964-2025,Tanzania,1964,2025,cshapes-2.0,1964.0,assigned,False,assumed_constant,True,False,single 1964 polygon held across a 61y span (1964-2025); borders may have changed,0
 UGA-1894-1902,Uganda (1894-1902),1894,1902,cshapes-2.0,1894.0,assigned,True,measured,False,False,vintage 1894 faithful to period 1894-1902,0
-UGA-1902-1910,Uganda (1902-1910),1902,1910,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1910,15
-UGA-1910-1926,Uganda (1910-1926),1910,1926,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1910-1926,86
-UGA-1926-1962,Uganda (1926-1962),1926,1962,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 36y span (1926-1962); borders may have changed,400
+UGA-1902-1910,Uganda (1902-1910),1902,1910,cshapes-2.0,1902.0,assigned,True,measured,False,False,vintage 1902 faithful to period 1902-1910,11
+UGA-1910-1926,Uganda (1910-1926),1910,1926,cshapes-2.0,1914.0,assigned,True,measured,False,False,vintage 1914 faithful to period 1910-1926,84
+UGA-1926-1962,Uganda (1926-1962),1926,1962,cshapes-2.0,1926.0,assigned,True,assumed_constant,True,False,single 1926 polygon held across a 36y span (1926-1962); borders may have changed,406
 UGA-1962-2025,Uganda,1962,2025,cshapes-2.0,1962.0,assigned,False,assumed_constant,True,False,single 1962 polygon held across a 63y span (1962-2025); borders may have changed,0
 UKR-1991-2014,Ukraine (1991-2014),1991,2014,cshapes-2.0,1991.0,assigned,False,measured,False,False,vintage 1991 faithful to period 1991-2014,0
 UKR-2014-2025,Ukraine,2014,2025,cshapes-2.0,2014.0,assigned,False,measured,False,False,vintage 2014 faithful to period 2014-2025,0
 URY-1828-2025,Uruguay,1828,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,False,single 1886 polygon held across a 197y span (1828-2025); borders may have changed,2223
 USA-1800-1803,United States (original),1800,1803,cliopatria,1800.0,assigned,False,measured,False,False,vintage 1800 faithful to period 1800-1803,0
 USA-1803-1848,United States (1803-1848),1803,1848,cliopatria,1815.0,assigned,False,assumed_constant,True,False,single 1815 polygon held across a 45y span (1803-1848); borders may have changed,0
-USA-1848-1867,United States (1848-1867),1848,1867,cliopatria,1849.0,assigned,True,measured,False,False,vintage 1849 faithful to period 1848-1867,46
-USA-1867-1959,United States (1867-1959),1867,1959,cliopatria,1880.0,assigned,True,assumed_constant,True,True,single 1880 polygon held across a 92y span (1867-1959); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),331
+USA-1848-1867,United States (1848-1867),1848,1867,cliopatria,1849.0,assigned,True,measured,False,False,vintage 1849 faithful to period 1848-1867,66
+USA-1867-1959,United States (1867-1959),1867,1959,cliopatria,1880.0,assigned,True,assumed_constant,True,True,single 1880 polygon held across a 92y span (1867-1959); borders may have changed; footnote coverage caveat (FAO/IIA yearbook),8350
 USA-1959-2025,United States of America,1959,2025,cshapes-2.0,1959.0,assigned,True,assumed_constant,True,False,single 1959 polygon held across a 66y span (1959-2025); borders may have changed,133
 UZB-1991-2025,Uzbekistan,1991,2025,cshapes-2.0,1991.0,assigned,False,assumed_constant,True,False,single 1991 polygon held across a 34y span (1991-2025); borders may have changed,0
 VCT-1800-1833,Saint Vincent (to 1833),1800,1833,gadm-4.1-adm0,,assigned,False,assumed_constant,True,False,polygon present but no recorded vintage year,0
@@ -700,8 +728,8 @@ VCT-1833-2025,Saint Vincent and the Grenadines,1833,2025,gadm-4.1-adm0,,assigned
 VEN-1821-2025,Venezuela,1821,2025,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 204y span (1821-2025); borders may have changed,1050
 VGB-1800-2025,British Virgin Islands,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,35
 VIC-1851-1900,Victoria (to 1900),1851,1900,cshapes-2.0,1886.0,assigned,True,assumed_constant,True,True,single 1886 polygon held across a 49y span (1851-1900); borders may have changed,195
-VIR-1917-2025,United States Virgin Islands,1917,2025,gadm-4.1-adm0,2023.0,assigned,True,assumed_constant,True,False,single 2023 polygon held across a 108y span (1917-2025); borders may have changed,64
-VNM-1887-1954,Vietnam (French Indochina),1887,1954,cshapes-2.0,1893.0,assigned,True,assumed_constant,True,False,single 1893 polygon held across a 67y span (1887-1954); borders may have changed,384
+VIR-1917-2025,United States Virgin Islands,1917,2025,gadm-4.1-adm0,2023.0,assigned,True,assumed_constant,True,True,single 2023 polygon held across a 108y span (1917-2025); borders may have changed,65
+VNM-1887-1954,Vietnam (French Indochina),1887,1954,cshapes-2.0,1894.0,assigned,True,assumed_constant,True,False,single 1894 polygon held across a 67y span (1887-1954); borders may have changed,384
 VNM-1975-2025,Vietnam,1975,2025,cshapes-2.0,1975.0,assigned,False,assumed_constant,True,False,single 1975 polygon held across a 50y span (1975-2025); borders may have changed,0
 VUT-1800-2025,Vanuatu,1800,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,140
 WAD-1800-1912,Wadai Empire,1800,1912,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0
@@ -711,7 +739,7 @@ WLO-1800-1855,Kingdom of Waalo,1800,1855,paine-2024,,assigned,False,assumed_cons
 WSM-1900-2025,Samoa,1900,2025,gadm-4.1-adm0,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,59
 WZO-1938-1949,Western Germany / Western Occupation Zones,1938,1949,cshapes-2.0,1949.0,assigned,True,measured,False,False,vintage 1949 faithful to period 1938-1949,44
 YEM-1990-2025,Yemen (1990-2025),1990,2025,cshapes-2.0,2000.0,assigned,False,assumed_constant,True,False,single 2000 polygon held across a 35y span (1990-2025); borders may have changed,0
-ZAF-1910-2025,South Africa (Union and Republic),1910,2025,cshapes-2.0,1910.0,assigned,True,assumed_constant,True,True,single 1910 polygon held across a 115y span (1910-2025); borders may have changed,1585
+ZAF-1910-2025,South Africa (Union and Republic),1910,2025,cshapes-2.0,1910.0,assigned,True,assumed_constant,True,False,single 1910 polygon held across a 115y span (1910-2025); borders may have changed,1585
 ZMB-1964-2025,Zambia,1964,2025,cshapes-2.0,1964.0,assigned,False,assumed_constant,True,False,single 1964 polygon held across a 61y span (1964-2025); borders may have changed,0
 ZNZ-1890-1963,Zanzibar Protectorate,1890,1963,cshapes-2.0,,unassigned,True,unassigned,True,False,no polygon (honest gap; never a false territory),71
 ZUL-1816-1879,Zulu Kingdom,1816,1879,paine-2024,,assigned,True,assumed_constant,True,False,polygon present but no recorded vintage year,0


### PR DESCRIPTION
The file that answers *"is WHEP carrying 1860-1961 data on borders that were not the real territory"* was **28 polities short** of the database it describes.

```
committed rows                                        721
polities in the database                              749
MISSING from the file                                  28
commits to wiki/ or data/final/ since it was synced    122
```

A derived file with no freshness check silently stops describing its input. Here the failure was worse than a missing row: `territory_basis` classifies each polity as `measured`, `assumed_constant`, `back_projected` or `unassigned` — so **28 absent polities read as 28 polities with nothing to worry about**. The output is a risk assessment, and absence looked like safety.

Regenerated — 749 rows, full coverage both directions:

```
assumed_constant 458   measured 188   back_projected 52   unassigned 51
```

## `--check`

Added to `04_territory_basis.py`, mirroring the `write_*.py` convention already used by six scripts. It regenerates in memory, compares, and on drift **names which polity codes are missing in each direction** rather than only reporting inequality. Registered in README and CI, so staleness is a build failure instead of something a reader has to notice.

Mutation-tested both ways, not assumed: truncating the file exits 1 and names the three dropped codes (`ZWE-1900-1953`, `ZWE-1964-1980`, `ZWE-1980-2025`); restoring it exits 0. **The exit codes were checked directly rather than through a pipe**, which had been masking them.

## Also assessed and deliberately not changed

**M4, "case-only alias collisions"** — 8 alias keys do have labels differing only in case, but **zero disagree on the target polity**. No routing hazard, nothing to fix, and #53 should stay closed. Recorded as a negative result so the next sweep spotting the pattern doesn't re-open it.

**#37, "rows unassigned while carrying geometry"** — 53 rows carry geometry with a non-`assigned` status, but **48 are legitimately `proxy`, `estimate` or `polygon_vintage_drift`** — meaningful statuses, not defects. Only 5 say `unassigned` while holding a polygon, and **all five are dead rows** (`BRA-1800-2025`, `IDN-1800-1889`, `IDN-1889-1945`, `IND-1800-1893` superseded; `RSFSR-1917-1991` retired), which no consumer reads. Real inconsistency, no consequence; not worth churning four wiki pages over.

**31 gates, 7 `--check` modes and the extdata self-test pass.** Refs #37, #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ