### PR TITLE
An unstable sort made validate_spatial_containment report different pairs on different machines

### DIFF
--- a/scripts/validate_spatial_containment.py
+++ b/scripts/validate_spatial_containment.py
@@ -290,7 +290,13 @@ discontinuous = []
 for _prefix, fam in eq.groupby("prefix"):
     if len(fam) < 2:
         continue
-    fam = fam.sort_values("start_year")
+    # Sort on (start_year, polity_code), NOT start_year alone. A tie makes the order arbitrary,
+    # and arbitrary order changes which rows are ADJACENT -- so the pairs this check reports differ
+    # between machines and any baseline of them is unpinnable. That is not hypothetical: the three
+    # IDN-*-1949-1951 rows all start in 1949, and on 2026-08-07 this gate passed locally while
+    # failing in CI with the SAME data, reporting IDN-JVM/IDN-BLB and IDN-BLB/IDN-OTH where the
+    # local run had reported IDN-BLB/IDN-JVM and IDN-JVM/IDN-OTH. Same three rows, two pairings.
+    fam = fam.sort_values(["start_year", "polity_code"])
     codes, geos, areas = list(fam.polity_code), list(fam.geometry), list(fam.area_km2)
     for i in range(len(fam) - 1):
         smaller = min(areas[i], areas[i + 1])


### PR DESCRIPTION
**`main` is red because I merged #180 while its CI was failing** — I read the install step's success and didn't check the run conclusion. Second time this session.

The underlying defect is also mine, and it's the exact class I've spent the session finding in other people's code.

## The bug

`validate_spatial_containment` sorted each family with

```python
fam.sort_values("start_year")
```

and the three `IDN-*-1949-1951` rows **all start in 1949**. A tie makes the order arbitrary; arbitrary order changes which rows are **adjacent**; and adjacency is what the check pairs. So with identical data:

```
local run reported   IDN-BLB / IDN-JVM   and   IDN-JVM / IDN-OTH
CI reported          IDN-JVM / IDN-BLB   and   IDN-BLB / IDN-OTH
```

Same three rows, two pairings. The baseline I pinned in #178 could only ever match one of them, so the gate failed **twice over**: two `NEW discontinuity` reports *and* two "tracked as discontinuous but now overlaps" for the entries that no longer matched.

## The fix

Sort on `(start_year, polity_code)` so ties break deterministically. Verified stable across three consecutive runs; the #178 baseline entries are correct as written and now match.

## Why it's worth a paragraph

This is the same shape as `find_feature`'s tie-break (#133), `matchlib.pick_by_year`'s family order (#136), and the shapefile row order behind `ROU-1920-1940` — a comparison that ties, followed by a consumer of the resulting order.

But **a gate having this bug is worse than data having it**: it makes CI a coin flip rather than a check. A green run stops being evidence.

**33 gates and 9 `--check` modes pass.** Refs #178, #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ