### PR TITLE
Count the area comparisons that cannot fail, and fix a harness trap found doing it

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -494,7 +494,10 @@ def mutate_area_read_off_its_own_polygon(root, gpd, make_valid, affinity):
             hit, newval = r.polity_code, round(r.km2)
             break
     assert hit, "no row with a >5% divergence to overwrite"
-    g.loc[g.polity_code == hit, "polygon_area_km2"] = newval
+    # STRING, not int. The column's dtype is str, and newer pandas raises
+    # "Invalid value '795' for dtype 'str'" on an int assignment while older pandas
+    # silently accepts it -- so this passed locally and failed in CI.
+    g.loc[g.polity_code == hit, "polygon_area_km2"] = str(newval)
     write_gpkg(g, root)
     return f"rewrote {hit}'s declared area to {newval:,}, exactly what its polygon measures"
 

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -444,6 +444,61 @@ def mutate_wiki_without_rebuilding(root, gpd, make_valid, affinity):
 
 
 
+def write_gpkg(gdf, root):
+    """Write a mutated GeoDataFrame over the staged GeoPackage, replacing it.
+
+    USE THIS RATHER THAN gdf.to_file(...) WHENEVER THE GEOPACKAGE IS IN THIS GATE'S `WRITABLE`.
+    `to_file` on a path that ALREADY EXISTS appends a new layer named after the file stem instead
+    of overwriting the existing one, and `read_file` returns the FIRST layer -- so the mutation is
+    written, reported, and completely invisible to the gate:
+
+        layers after to_file over existing:  ['polities', 'polities_database']
+        value re-read from dest:             the ORIGINAL, unmutated
+
+    Measured on 2026-08-10 while adding the check-A2 case. The existing gpkg-mutating cases escape
+    this only because their gates do not list the GeoPackage in WRITABLE, so stage() never creates
+    it and their write lands on a fresh path. Any future case that stages it would silently pass --
+    which is the one failure mode this harness exists to prevent, occurring inside the harness.
+    """
+    dest = os.path.join(root, "data/final/polities_database.gpkg")
+    if os.path.exists(dest):
+        os.unlink(dest)
+    gdf.to_file(dest, driver="GPKG", layer="polities")
+
+
+def mutate_area_read_off_its_own_polygon(root, gpd, make_valid, affinity):
+    """Rewrite a declared area to exactly what its own polygon measures, which is the
+    tautology check A2 counts.
+
+    THIS MUTATION MAKES CHECK A PASS, and that is the point. The row it targets is
+    chosen for having a genuine divergence: overwriting the declared figure with the
+    measured one silences check A's disagreement and raises A2's count in the same
+    edit. A gate that only reported disagreements would score this as an improvement.
+
+    THE DECLARED AREA IS READ FROM THE GEOPACKAGE, not the CSV -- validate_polygons
+    takes `claimed` from `have`, which comes from the .gpkg attribute table. The first
+    version of this case rewrote the CSV and the gate did not notice, which is worth
+    knowing before writing another case against this gate.
+    """
+    g = gpd.read_file(GPKG)
+    live = g[g.geometry.notna() & ~g.geometry.is_empty].copy()
+    live["km2"] = live.to_crs("ESRI:54034").geometry.area / 1e6
+    hit = None
+    for r in live.itertuples():
+        dec = r.polygon_area_km2
+        try:
+            dec = float(dec)
+        except (TypeError, ValueError):
+            continue
+        if dec > 0 and abs(r.km2 / dec - 1) > 0.05:      # a real divergence to overwrite
+            hit, newval = r.polity_code, round(r.km2)
+            break
+    assert hit, "no row with a >5% divergence to overwrite"
+    g.loc[g.polity_code == hit, "polygon_area_km2"] = newval
+    write_gpkg(g, root)
+    return f"rewrote {hit}'s declared area to {newval:,}, exactly what its polygon measures"
+
+
 def mutate_site_shows_withdrawn(root, gpd, make_valid, affinity):
     """Put a retired polity back into site/polities.geojson, which is how the site
     drew Argentina twice.
@@ -842,6 +897,12 @@ CASES = (
         "silently becomes the route",
     ),
     (
+        "validate_polygons.py",
+        mutate_area_read_off_its_own_polygon,
+        "self-referential",
+        "a declared area overwritten with its own polygon's measurement, which silences check A",
+    ),
+    (
         "validate_site_outputs.py",
         mutate_site_shows_withdrawn,
         "ARG-1800-2025",
@@ -968,6 +1029,13 @@ WRITABLE = {
     # signal it targets reads the CSV. A gate staged without its inputs is a gate whose other
     # checks are being self-tested vacuously.
     "validate_chain_integrity.py": ("polities_database.csv", "wiki/polities"),
+    # Only the GeoPackage: validate_polygons reads BOTH the declared area and the geometry from
+    # it, so that is the file the case mutates. CShapes is not staged, so check B prints "skipped"
+    # -- fine, since the case targets A2.
+    #
+    # NOTE FOR THE NEXT AUTHOR: this is the ONLY gate that both stages the GeoPackage and mutates
+    # it, and that combination is a trap -- see write_gpkg(). Use that helper, not to_file().
+    "validate_polygons.py": ("polities_database.gpkg",),
     # Needs the GeoPackage (to know which rows are live AND polygonal) and both site files,
     # writable because the case mutates the geojson. The master CSV must be a real copy too,
     # not stage()'s symlink: signal A compares it against site/polities.csv byte for byte, and

--- a/scripts/validate_polygons.py
+++ b/scripts/validate_polygons.py
@@ -147,6 +147,60 @@ for r in documented.itertuples():
     print(f"   ok   {r.divergence*100:6.0f}%  {r.polity_code:18s} claims {r.claimed:>12,.0f} km2 vs "
           f"{r.measured_km2:>12,.0f} km2 — declared '{r.polygon_status}', divergence documented")
 
+# ---------- A2: how many of check A's comparisons cannot fail ----------
+#
+# CHECK A COMPARES A DECLARED AREA AGAINST THE GEOMETRY IT WAS OFTEN COPIED FROM.
+#
+# `polygon_area_km2` has no recorded provenance. Some pages declare an official land area or a
+# yearbook figure -- TKL-1800-2025 declares 12 km2 against a GADM 15.95, deliberately -- and some
+# declare what their own polygon measures. For the second kind, check A is a no-op: a polygon
+# cannot disagree with a number read off it, and the row reports PASS whatever is wrong with it.
+#
+# THAT TAUTOLOGY HID THREE REAL ERRORS, each of which agreed to under 1%:
+#
+#     IDN-OTH-1949-1951   declared 1,757,495 vs measured 1,747,408   0.6%    both included West Papua
+#     IND-1800-1886       declared 4,209,917 vs measured 4,209,869   0.001%  both included Ceylon
+#     CAN-1800-1866       declared 1,209,852, recipe 2,735,024       -       declared = recipe minus Quebec
+#
+# The right fix is provenance metadata -- a `polygon_area_source` field distinguishing
+# measured-from-polygon / source-stated / official-gazetteer / derived-arithmetic -- which is
+# issue 195 and a schema change. This is the cheap half: COUNT the comparisons that cannot fail,
+# so the number is visible on every run and can only be argued down.
+#
+# NOT BIDIRECTIONAL, unlike every other baseline in this repo, and the reason is specific. A
+# DECREASE here does not mean the provenance improved; it means the GEOMETRY MOVED -- PR 189
+# changed 42 geometries and would have pushed rows out of the tight band without anyone sourcing
+# a single figure. Failing on a decrease would print "lock in the improvement" when nothing
+# improved. A row can only ENTER the band by someone re-deriving a declared figure from a
+# polygon, which is a human act and worth failing on. So this is a ceiling.
+SELF_REF_TOLERANCE = 0.001          # 0.1%: closer than any independent source would land
+BASELINE_SELF_REFERENTIAL = 103     # measured 2026-08-10 over 197 rows carrying both
+
+# Live rows only, matching the population check A actually judges -- `have` includes the
+# retired and superseded rows that still carry geometry, and check A exempts those.
+with_both = have[
+    have.claimed.notna() & (have.claimed > 0) & have.measured_km2.notna()
+    & ~have.get("wiki_status").isin(DEAD_STATUS)
+].copy()
+with_both["dev"] = (with_both.measured_km2 / with_both.claimed - 1).abs()
+selfref = with_both[with_both.dev <= SELF_REF_TOLERANCE]
+exact = with_both[with_both.dev <= 0.000005]
+print(f"\nA2. SELF-REFERENTIAL AREAS — {len(selfref)} of {len(with_both)} declared areas agree with "
+      f"their own geometry within {SELF_REF_TOLERANCE:.1%}, so check A cannot fail for them "
+      f"({len(exact)} agree to every digit)")
+for r in exact.sort_values("polity_code").itertuples():
+    print(f"   exact  {r.polity_code:18s} {r.claimed:>12,.0f} km2   ({r.polygon_source})")
+selfref_over = len(selfref) - BASELINE_SELF_REFERENTIAL
+if selfref_over > 0:
+    print(f"   FAIL: {len(selfref)} is above the pinned ceiling of {BASELINE_SELF_REFERENTIAL}. "
+          f"A declared area within {SELF_REF_TOLERANCE:.1%} of its own polygon is not evidence "
+          f"about the territory -- source it from a yearbook or an official gazetteer, or say in "
+          f"polygon_method that it was measured from the geometry.")
+elif selfref_over < 0:
+    print(f"   note: {len(selfref)} is BELOW the pinned {BASELINE_SELF_REFERENTIAL}. Lower the pin "
+          f"to keep the ratchet tight -- but check first whether a figure was actually sourced, or "
+          f"whether the geometry simply moved.")
+
 # ---------- C: status claims a polygon that was never attached ----------
 # `assigned`/`proxy`/`estimate` all assert a polygon exists. When the build
 # cannot resolve polygon_feature_id it attaches nothing and says so only in a
@@ -279,9 +333,11 @@ else:
 
 fail = (len(bad_area) > 0 or len(declared_none) > 0 or len(new_claim_no_geom) > 0
         or len(stale_baseline) > 0 or len(undoc) > 0 or len(off_vocab) > 0
+        or selfref_over > 0
         or (A.strict and mismatch))
 print(f"\n{'FAIL' if fail else 'PASS'}: {len(off_vocab)} off-vocabulary status(es), "
       f"{len(bad_area)} area disagreement(s), "
+      f"{max(selfref_over, 0)} self-referential area(s) above the ceiling, "
       f"{len(declared_none)} declares-none-but-has-one, "
       f"{len(new_claim_no_geom)} NEW claimed-but-absent polygon(s), {len(undoc)} undocumented-but-reviewed"
       + (f", {len(mismatch)} identity mismatch(es)" if A.strict else ""))


### PR DESCRIPTION
> *Filed by Claude (Claude Code). Every figure measured. Two of my own mistakes are described because they are the reason the second half of this exists.*

The cheap half of #195. Check A compares each row's declared `polygon_area_km2` against the geometry attached to it — and for half the database that comparison **cannot fail**, because the declared figure was read off that geometry.

```
A2. SELF-REFERENTIAL AREAS — 103 of 200 declared areas agree with their own
    geometry within 0.1%, so check A cannot fail for them (10 agree to every digit)
```

The ten exact ones agree to **every digit**: `EGY-1820-1885`, `FID-1887-1954`, `FRA-1871-1919`, `HUN-1800-1918`, `HUN-1918-1919`, `HYD-1724-1948`, `MAN-1932-1945`, `MAN-1945-1950`, `POL-1919-1920`, `SRB-2008-2025`.

That tautology hid three real errors this week, each agreeing to under 1% — `IDN-OTH-1949-1951` (both figures included West Papua), `IND-1800-1886` (both included Ceylon), `CAN-1800-1866` (the declared figure was the page's own recipe *minus Québec*).

## It is a ceiling, not a bidirectional baseline

Deliberately unlike every other baseline here. **A decrease in this count does not mean the provenance improved — it means the geometry moved.** #189 changed 42 geometries and would have pushed rows out of the band without anyone sourcing a figure; failing on that would print "lock in the improvement" when nothing improved.

A row can only *enter* the band by someone re-deriving a declared area from a polygon, which is a human act worth failing on. So: **103, and it can only be argued down.**

The expensive half — a `polygon_area_source` field distinguishing `measured-from-polygon` / `source-stated` / `official-gazetteer` / `derived-arithmetic` — stays on #195. This makes the number visible without a schema change.

## The selftest case found a trap in the harness itself

This is the more important half.

`gdf.to_file(path, driver="GPKG")` on a path that **already exists** appends a **new layer** named after the file stem rather than overwriting, and `read_file` returns the **first** layer:

```
layers after to_file over existing:  ['polities', 'probe']
value re-read from dest:             960, the original -- mutation invisible
```

So a mutation is written, reported by the harness as applied, and completely ignored by the gate. **My first two attempts at this case "failed to be caught" for exactly that reason, and I concluded the gate was wrong twice before I measured the write.**

The ten existing gpkg-mutating cases escape it only because their gates do not list the GeoPackage in `WRITABLE`, so `stage()` never creates it and their write lands on a fresh path. `validate_polygons` is the **first gate that both stages the GeoPackage and mutates it**. Any future case in that position would **silently pass** — the one failure mode this harness exists to prevent, occurring inside the harness.

Fixed with a `write_gpkg()` helper that unlinks first and names the layer explicitly, documented at the helper and at the `WRITABLE` entry.

## Verification

`selftest_gates` **22 → 23**. The new case is deliberately chosen to make check A *pass*: it overwrites a row with a >5% divergence, silencing A's disagreement and raising A2's count in one edit — so a gate that only reported disagreements would score it as an improvement.

All CI gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ