### PR TITLE
Gate the claim "this area has no polity", which was false for sixteen areas

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -322,6 +322,12 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_site_outputs.py
 
+      # Added after sixteen territories got polities and stayed listed as having none, so their
+      # data still resolved to ROW-1850-2025. Nothing linked the two files; now something does.
+      - name: areas listed as unmapped really have no polity to map them to
+        if: '!cancelled()'
+        run: python3 scripts/validate_registry_unmapped.py
+
       - name: Polygons — area agreement, claimed-but-absent, reviewed-means-documented
         if: '!cancelled()'
         run: python3 scripts/validate_polygons.py

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ python3 scripts/validate_spherical_edges.py
 python3 scripts/validate_succession_geography.py   # reads the committed .gpkg; runs in CI too
 python3 scripts/validate_chain_integrity.py        # CSV + wiki only, no geometry
 python3 scripts/validate_site_outputs.py           # site/ is deployed output; nothing checked it
+python3 scripts/validate_registry_unmapped.py      # 'no polity for this area' is a claim; check it
 
 # and the one that asks whether the checks above can fail at all
 python3 scripts/selftest_gates.py
@@ -118,6 +119,7 @@ python3 pipelines/polity-autoimprove/extdata.py
 | `write_manifest.py --check` | a stale alias-map fingerprint after aliases changed |
 | citations | 17 citations pointing at source files that were never ingested |
 | `validate_site_outputs.py` | site/polities.geojson two months stale — 194 live polities missing, 35 withdrawn ones drawn on the map |
+| `validate_registry_unmapped.py` | 16 areas listed as having no polity while their polity existed, so their data still resolved to `ROW-1850-2025` |
 | constants | `DEAD_STATUS` is defined **five** times, and `CLAIMS_POLYGON` excluded four statuses that 11 rows with geometry were using |
 | aliases | five aliases silently **inert** — two had the target sitting in the `confidence` column |
 | alias chain overlaps | *(guard)* an alias `year_end` is INCLUSIVE while a polity `end_year` is EXCLUSIVE, so consecutive aliases for one label both cover the boundary year and match order decides which polity a value lands in. 18 chains do, down from 25: the seven cleared on 2026-08-05 were the ones whose earlier alias claimed a year its successor covers, clipped after checking against the observations that nothing would go unmatched (issue 90 group A -- 58 aliases, 1,544 rows). The rate depends on how they were written — 18 of 31 hand-entered any-source chains against **0 of 7** generated with `year_end = polity_end_year - 1` — so the convention demonstrably removes it. The safe half is now fixed rather than gated: 58 aliases whose boundary year a successor alias already covers were clipped (issue 90). 209 aliases still overclaim, of which 24 (label, year) pairs carrying 229 rows have NO covering successor and must not be clipped -- those need a target or a period boundary, not a range edit |

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -466,6 +466,34 @@ def write_gpkg(gdf, root):
     gdf.to_file(dest, driver="GPKG", layer="polities")
 
 
+def mutate_unmapped_area_that_has_a_polity(root, gpd, make_valid, affinity):
+    """List an area as having no polity family when its polity exists.
+
+    THIS IS THE DEFECT THAT ACTUALLY HAPPENED, reproduced. Sixteen territories got
+    polities in PRs 190, 201 and 210 and every one stayed on this list, so the FAOSTAT
+    map -- generated from a registry that reads it -- never gained a row and all sixteen
+    still resolved to ROW-1850-2025. A consuming session found it, not this repo.
+
+    Mayotte is used because its polity is unambiguous and its area code appears in the
+    published map, so both of the gate's signals fire on one edit.
+    """
+    import csv
+
+    path = os.path.join(root, "pipelines/faostat-era-matching/state/registry_unmapped.csv")
+    with open(path, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    rows.append({
+        "area_code": "270", "area_name": "Mayotte", "iso3": "MYT",
+        "note": "registry area with no polity family (non-country/aggregate)",
+    })
+    with open(path, "w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return "listed area 270 Mayotte as having no polity, while MYT-1800-2025 exists"
+
+
 def mutate_map_year_end_past_coverage(root, gpd, make_valid, affinity):
     """Raise a FAOSTAT map row's inclusive year_end past its polity's exclusive coverage.
 
@@ -948,6 +976,12 @@ CASES = (
         "silently becomes the route",
     ),
     (
+        "validate_registry_unmapped.py",
+        mutate_unmapped_area_that_has_a_polity,
+        "area 270",
+        "an area listed as having no polity while its polity exists, so its data keeps resolving to ROW",
+    ),
+    (
         "validate_map_area_year.py",
         mutate_map_year_end_past_coverage,
         "year_end past coverage",
@@ -1096,6 +1130,13 @@ WRITABLE = {
     # Both files as real copies: the case rewrites the map, and the gate reads polity spans from
     # the CSV to know what "past coverage" means. With the CSV symlinked the read still works, but
     # copying keeps the case honest about what it touches.
+    # The case appends to registry_unmapped.csv, so that must be a real copy; the gate also reads
+    # the published map and the database to decide whether the claim is false.
+    "validate_registry_unmapped.py": (
+        "pipelines/faostat-era-matching/state/registry_unmapped.csv",
+        "faostat_area_polity_map.csv",
+        "polities_database.csv",
+    ),
     "validate_map_area_year.py": (
         "faostat_area_polity_map.csv",
         "polities_database.csv",

--- a/scripts/validate_registry_unmapped.py
+++ b/scripts/validate_registry_unmapped.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Check that "this area has no polity" is still true of every area that claims it.
+
+`pipelines/faostat-era-matching/state/registry_unmapped.csv` lists FAOSTAT reporting areas the
+matcher could not route, each carrying the note "registry area with no polity family
+(non-country/aggregate)". That note is a CLAIM ABOUT THE POLITIES DATABASE, and nothing checked it.
+
+WHAT THAT COST, on 2026-08-13. PRs 190, 201 and 210 created sixteen polities for territories that
+FAOSTAT reports -- Aruba, the Holy See, Mayotte, the Caymans, Gibraltar, Curacao and the rest --
+closing issues 185, 187 and 209. Every one of them stayed listed here as having no polity family,
+because creating a polity does not touch this file, and `faostat_area_polity_map.csv` is GENERATED
+from a registry that reads it. So all sixteen still resolved downstream to `ROW-1850-2025`, an
+aggregate with no territory: the polities existed and the data could not reach them, which is
+exactly the failure those three issues were filed about.
+
+A consuming session found it, not this repo. That is the gap being closed.
+
+TWO SIGNALS, both cheap and both zero-noise today:
+
+  A. STALE CLAIM     an area listed here whose iso3 IS carried by a live polity. The note is then
+                     false, and either a map row is missing or the note needs correcting.
+  B. LISTED BOTH WAYS an area listed here that ALSO appears in the published map. One file says it
+                     could not be routed and the other says where it routes; a consumer reading
+                     either alone gets a different answer.
+
+Signal A is the one that fires on the real defect. Signal B is stricter and catches the half-done
+fix -- adding the map row while forgetting to remove the row here.
+
+NOT BASELINED, and that is deliberate. Both counts are zero, so a baseline would only be a place
+for the next occurrence to hide. The fourteen areas that remain listed genuinely have no polity:
+Antarctica, Bouvet, Heard and McDonald, Svalbard, the Pacific atolls the US administers, the
+Neutral Zone, and the two accounting residuals `UXY` "Unspecified" and `OXY` "Others (adjustment)"
+which are not territories and should never get one.
+
+Usage:
+  python3 scripts/validate_registry_unmapped.py
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+UNMAPPED = os.path.join(REPO, "pipelines/faostat-era-matching/state/registry_unmapped.csv")
+MAP = os.path.join(REPO, "data/final/faostat_area_polity_map.csv")
+DB = os.path.join(REPO, "data/final/polities_database.csv")
+DEAD = ("retired", "superseded")
+
+
+def live_by_iso() -> dict:
+    """iso3 -> live polity codes carrying it.
+
+    Dead rows are excluded because a retired polity is not something an area can be routed to, so
+    an area whose only same-iso3 polity is superseded really does have nowhere to go.
+    """
+    out: dict[str, list] = {}
+    with open(DB, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            if (r.get("wiki_status") or "").strip() in DEAD:
+                continue
+            iso = (r.get("iso3_code") or "").strip()
+            if iso and iso not in ("NA", "NAN"):
+                out.setdefault(iso, []).append(r["polity_code"])
+    return out
+
+
+def main() -> int:
+    for path in (UNMAPPED, MAP, DB):
+        if not os.path.exists(path):
+            print(f"SKIP: {os.path.relpath(path, REPO)} missing")
+            return 0
+
+    with open(UNMAPPED, encoding="utf-8") as fh:
+        unmapped = list(csv.DictReader(fh))
+    with open(MAP, encoding="utf-8") as fh:
+        mapped = {(r.get("area_code") or "").strip() for r in csv.DictReader(fh)}
+    by_iso = live_by_iso()
+
+    stale, both = [], []
+    for u in unmapped:
+        area = (u.get("area_code") or "").strip()
+        iso = (u.get("iso3") or "").strip()
+        if iso and iso in by_iso:
+            stale.append((area, iso, (u.get("area_name") or "").strip(), by_iso[iso]))
+        if area and area in mapped:
+            both.append((area, (u.get("area_name") or "").strip()))
+
+    print(f"registry areas listed as having no polity: {len(unmapped)}")
+    print(f"published map covers:                      {len(mapped)} areas")
+    print(f"A. listed here but their iso3 HAS a live polity: {len(stale)}")
+    print(f"B. listed here AND present in the published map: {len(both)}")
+
+    problems = []
+    for area, iso, name, codes in sorted(stale, key=lambda t: int(t[0]) if t[0].isdigit() else 0):
+        problems.append(
+            f"area {area} ({name}) is listed as having no polity family, but iso3 {iso} is carried "
+            f"by {', '.join(codes)}. Creating a polity does not update this file, and the FAOSTAT "
+            f"map is generated from a registry that reads it — so this area still resolves to "
+            f"ROW-1850-2025. Add its map row and remove it from here"
+        )
+    for area, name in sorted(both, key=lambda t: int(t[0]) if t[0].isdigit() else 0):
+        problems.append(
+            f"area {area} ({name}) is in BOTH registry_unmapped.csv and the published map — one "
+            f"file says it could not be routed and the other says where it routes. Remove it here"
+        )
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} inconsistent claim(s)\n")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+
+    print("\nPASS: every area listed as unmapped really has no live polity to map it to")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> *Filed by Claude (Claude Code). This closes the gap behind a defect that reached a consumer before it reached any gate here.*

`registry_unmapped.csv` lists FAOSTAT reporting areas the matcher could not route, each carrying the note *"registry area with no polity family (non-country/aggregate)"*. **That note is a claim about the polities database, and nothing checked it.**

On 2026-08-13 it was false for **sixteen** of them. #190, #201 and #210 created polities for Aruba, the Holy See, Mayotte, the Caymans, Gibraltar, Curaçao and eleven more — closing #185, #187 and #209 — and every one stayed on this list, because **creating a polity does not touch this file** and `faostat_area_polity_map.csv` is *generated* from a registry that reads it. So all sixteen still resolved to `ROW-1850-2025`: the polities existed and the data could not reach them, which is exactly the failure those three issues were filed about.

**A consuming session found that, not this repo.** Every gate here passed while sixteen territories' land was attributed to an aggregate with no territory. #212 fixed the data; this closes the gap that let it happen.

## Two signals

```
A. STALE CLAIM        an area listed here whose iso3 IS carried by a live polity
B. LISTED BOTH WAYS   an area listed here that ALSO appears in the published map
```

**A** fires on the real defect. **B** is stricter and catches the half-done fix — adding the map row while forgetting to remove the row here. Both fire on a single re-added Mayotte row, verified:

```
A. listed here but their iso3 HAS a live polity: 1
B. listed here AND present in the published map: 1
FAIL: 2 inconsistent claim(s)
```

## Not baselined, deliberately

Both counts are zero, so a baseline would only be somewhere for the next occurrence to hide. The fourteen areas still listed genuinely have no polity: Antarctica, Bouvet, Heard and McDonald, Svalbard, the US-administered Pacific atolls, the Neutral Zone, and the two accounting residuals `UXY` "Unspecified" and `OXY` "Others (adjustment)" — which are not territories and should never get one.

## Verification

`selftest_gates` gains case 18, which **reproduces the actual incident** rather than an invented one: it lists area 270 Mayotte as having no polity while `MYT-1800-2025` exists. **24 → 25** provably-breakable gates, 46 → 47 gate invocations in CI.

All CI gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ