### PR TITLE
Catch the deployed pre-1961 set being emptied, not just stale

### DIFF
--- a/scripts/validate_site_outputs.py
+++ b/scripts/validate_site_outputs.py
@@ -110,7 +110,28 @@ def dead_codes_in_pre1961() -> list:
             for code in dead:
                 if code in text:
                     found.setdefault(code, set()).add(name)
+    # The mirror-image failure: build_wiki.sh does `rm -rf site/pre1961` and THEN copies, with
+    # `|| true` on every cp. If data/compiled/pre1961 exists but is empty or partial -- a failed
+    # or interrupted match.R run -- the tracked directory is emptied and the copies silently do
+    # nothing, and a dead-code scan of an empty directory passes. So assert the deployed set is
+    # still there. 138 files are tracked today; the two index files plus a non-empty by_item/ is
+    # the shape, and checking the shape rather than the count leaves room for the item list to
+    # change legitimately.
     out = []
+    for name in ("summary_by_polity.json", "by_item_index.json"):
+        if not os.path.exists(os.path.join(SITE_PRE1961, name)):
+            out.append(
+                f"site/pre1961/{name} is missing while the directory exists. build_wiki.sh "
+                f"deletes this directory before copying and ignores copy failures, so an empty "
+                f"or partial data/compiled/pre1961 silently empties the deployed set. "
+                f"Regenerate it (Rscript pipelines/pre1961-matching/match.R) before rebuilding"
+            )
+    by_item = os.path.join(SITE_PRE1961, "by_item")
+    if os.path.isdir(by_item) and not [f for f in os.listdir(by_item) if f.endswith(".json")]:
+        out.append(
+            "site/pre1961/by_item is empty while the directory exists — the deployed per-item "
+            "files were removed without being replaced (same cause as above)"
+        )
     for code in sorted(found):
         files = found[code]
         out.append(


### PR DESCRIPTION
#300 caught the stale direction -- the deployed pre-1961 files naming polities that had
been retired. This is the mirror image, and the dead-code scan cannot see it: an EMPTY
directory contains no dead codes and passes.

build_wiki.sh does

    if [ -d data/compiled/pre1961 ]; then
      rm -rf site/pre1961
      ...
      cp ... 2>/dev/null || true

so the tracked directory is deleted BEFORE the copies, and every copy failure is ignored.
An empty or partial data/compiled/pre1961 -- a failed or interrupted match.R run, which is
exactly the state a fresh clone reaches -- therefore empties 138 tracked, deployed files
and reports success. The  guard only protects the case where the source is absent
entirely, not where it exists and is empty.

The gate now asserts the deployed set is still shaped like itself: both index files
present, and by_item non-empty. Checking the SHAPE rather than the file count leaves room
for the item list to change legitimately, which it does whenever a source gains an item.

Proved it fires: removing by_item_index.json makes the gate exit 1 and name the file.