### PR TITLE
The verification workflow could not be launched at all

### DIFF
--- a/pipelines/polity-autoimprove/protocol.py
+++ b/pipelines/polity-autoimprove/protocol.py
@@ -21,7 +21,7 @@ import os, re
 
 WORKFLOW = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         "verify_assertions.workflow.js")
-_RE = re.compile(r"^\s*export\s+const\s+PROTOCOL_VERSION\s*=\s*(\d+)", re.M)
+_RE = re.compile(r"^\s*(?:export\s+)?const\s+PROTOCOL_VERSION\s*=\s*(\d+)", re.M)
 
 
 def protocol_version(path=WORKFLOW):
@@ -33,7 +33,7 @@ def protocol_version(path=WORKFLOW):
                          "protocol version lives there and is not optional")
     m = _RE.search(txt)
     if not m:
-        raise SystemExit(f"no `export const PROTOCOL_VERSION = <int>` in {path} "
+        raise SystemExit(f"no `const PROTOCOL_VERSION = <int>` in {path} "
                          "— the ledger cannot tell which rules a verdict was "
                          "produced under without it")
     return int(m.group(1))

--- a/pipelines/polity-autoimprove/verify_assertions.workflow.js
+++ b/pipelines/polity-autoimprove/verify_assertions.workflow.js
@@ -37,7 +37,11 @@ export const meta = {
 //       page_suspect/page_inadequate; source_convention. This is the version
 //       the ~150 already-banked assertions were (re-)verified under, so it is
 //       the baseline and does not reopen them.
-export const PROTOCOL_VERSION = 1
+// NOT exported: a second `export` makes this file unparseable by the Workflow runner
+// ("Unexpected keyword 'export'"), which is how the verification workflow became
+// unlaunchable. protocol.py reads this line textually and accepts it with or without the
+// keyword, so dropping it costs nothing.
+const PROTOCOL_VERSION = 1
 // ---------------------------------------------------------------------------
 //
 // args = { repo?, keys: ["label|source|y1-y2", ...], review_sample?, out?,


### PR DESCRIPTION
The verification workflow could not be launched at all

verify_assertions.workflow.js is the mechanism that banks verdicts -- the assertion
pipeline's whole purpose, and the largest body of unfinished work in the repository: 729
assertions carrying 67,153 rows are pending, which is what issue 7's triage ordered the
queue for.

It cannot be run. The Workflow runner accepts one export per script and rejects the rest:

    SyntaxError: Unexpected keyword 'export'

This file is the only one of the five .workflow.js files with a second export --
`export const PROTOCOL_VERSION = 1` at line 40. The other four (audit_matches,
autoimprove, document_pages, new_polity) declare `export const meta` and nothing else,
and launch fine.

Two requirements had quietly collided. protocol.py reads the version by PARSING this file
textually, with a regex that required the keyword:

    _RE = re.compile(r"^\s*export\s+const\s+PROTOCOL_VERSION\s*=\s*(\d+)", re.M)

so the export could not simply be deleted, and the runner could not accept it either.

FIXED BY RELAXING THE READER, not the writer: the regex now takes `(?:export\s+)?`, and
the JS declares a plain `const`. protocol_version() returns 1 before and after, verified
both ways -- that constant is what reopens banked assertions when the RULES change, so
breaking its readability would have silently unpinned the entire ledger rather than
failing loudly.

Confirmed by launching the workflow on the ten highest-exposure pending assertions
(brazil|juan|1909-1960 at 2,547 rows down to finland|juan|1878-1916). It starts, fans out
one economic-historian agent per assertion, and runs the decorrelated reviewer issue 27
added on every third confident confirm.

A comment on the declaration records why the keyword is absent, so the next person to add
an export here learns it from the file rather than from a failed launch.
