### PR TITLE
Select verification tranches by what is banked, not by what the queue says

### DIFF
--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -236,6 +236,17 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        different model (opus vs sonnet) under a rotated lens —
                        see "Decorrelating the blind review".
                        Writes state/<args.out> (nothing applied).
+select_tranche.py      picks the next batch to verify: highest-exposure assertions
+                       that are pending AND have no banked verdict. Status alone is
+                       NOT the filter — apply_verdicts.py writes the ledger, and
+                       until 00_intake.py re-runs, a just-verified assertion still
+                       reads `pending` (49 do right now). The authority is
+                       verdicts_applied.jsonl, whose key is NESTED at
+                       record["verdict"]["key"] — reading it top-level yields None
+                       for every record, an empty exclusion set, and a re-run of the
+                       batch you just finished. Also reports, without selecting,
+                       assertions whose candidate no longer exists. --json emits the
+                       bare array for the workflow's `keys`. Not a gate.
 review_stats.py        measures the review itself out of the banked archive:
                        coverage, coverage of confident confirms (the class the
                        sampler can skip), agreement sliced by model pair and by
@@ -272,9 +283,11 @@ chunk the pending keys (~100/run) through the verify workflow, inspect
 banked assertions; an assertion reopens only when its evidence hash changes —
 or when the verification protocol does (next section).
 
-The workflow needs `args.keys` (compute from assertions.json status
-pending/reopened); the agent verdicts are DECISIONS — apply_verdicts.py never
-re-derives them, it only validates executability and records them.
+The workflow needs `args.keys`. Get them from `select_tranche.py --json` rather than
+filtering assertions.json yourself: `status` is stale between `apply_verdicts.py` and
+the next `00_intake.py`, so a status-only filter re-selects assertions that already
+have verdicts. The agent verdicts are DECISIONS — apply_verdicts.py never re-derives
+them, it only validates executability and records them.
 
 #### Sources onboarded so far
 

--- a/pipelines/polity-autoimprove/select_tranche.py
+++ b/pipelines/polity-autoimprove/select_tranche.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Pick the next verification tranche: the highest-exposure assertions not yet judged.
+
+WHY THIS IS A SCRIPT AND NOT A ONE-LINER. Selecting the next batch looks like `filter
+status == pending, sort by rows, take 12`, and that is wrong in two independent ways. Both
+were hit for real, and the second one silently re-selected a batch that had just been
+verified -- twelve agents' worth of work about to be spent re-deciding settled questions.
+
+  1. assertions.json GOES STALE THE MOMENT VERDICTS ARE APPLIED. apply_verdicts.py writes
+     the ledger; only a re-run of 00_intake.py re-reads the ledger and re-labels the queue.
+     Between those two events every just-verified assertion still reads `pending`. So
+     `status` is necessary but nowhere near sufficient, and the authority on what has been
+     judged is verdicts_applied.jsonl.
+
+  2. THE APPLIED-VERDICT KEY IS NESTED. Records are
+     {applied, verdict:{key, verdict, confidence, polity_code, checks, basis}, review,
+     quarantined}. A top-level `rec.get("key")` returns None for every record, so the
+     dedup set comes out EMPTY and nothing is excluded -- and an empty exclusion set looks
+     exactly like a clean queue. That is the failure that re-selected a finished batch.
+
+  3. A CANDIDATE CAN BE RETIRED OUT FROM UNDER THE QUEUE. Re-spans rename polity codes
+     (SEN-1886-1959 -> SEN-1886-1960 when issue 77 closed a one-year hole), and an assertion
+     derived before the rename still names the old code. Verifying a route to a polity that
+     does not exist cannot produce a usable verdict. Those are reported separately, because
+     a nonzero count is the signal to re-run 00_intake.py rather than something to ignore.
+
+Both failure modes are silent and both bias the SAME way -- toward looking like there is
+work to do when there is not -- which is why this prints its arithmetic rather than just
+emitting a list.
+
+Usage:
+  python3 pipelines/polity-autoimprove/select_tranche.py             # next 12
+  python3 pipelines/polity-autoimprove/select_tranche.py --limit 20
+  python3 pipelines/polity-autoimprove/select_tranche.py --json      # bare JSON array
+
+Feed the JSON array to the verification workflow as its `keys` argument.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATE = os.path.join(REPO, "pipelines/polity-autoimprove/state")
+ASSERTIONS = os.path.join(STATE, "assertions.json")
+APPLIED = os.path.join(STATE, "verdicts_applied.jsonl")
+DB = os.path.join(REPO, "data/final/polities_database.csv")
+
+PENDING = ("pending", "reopened")
+
+
+def judged_keys(path: str) -> set[str]:
+    """Keys with a banked verdict. The key is at record["verdict"]["key"], NOT top level."""
+    keys: set[str] = set()
+    if not os.path.exists(path):
+        return keys
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            verdict = rec.get("verdict")
+            if isinstance(verdict, str):  # tolerated: an older writer stored it repr()'d
+                try:
+                    verdict = json.loads(verdict)
+                except json.JSONDecodeError:
+                    continue
+            if isinstance(verdict, dict) and verdict.get("key"):
+                keys.add(verdict["key"])
+    return keys
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit", type=int, default=12, help="how many to select (default 12)")
+    ap.add_argument("--json", action="store_true", help="print only the JSON array")
+    args = ap.parse_args()
+
+    for path in (ASSERTIONS, APPLIED, DB):
+        if not os.path.exists(path):
+            print(f"MISSING: {os.path.relpath(path, REPO)}", file=sys.stderr)
+            if path is ASSERTIONS:
+                print("run 00_intake.py first -- see README, 'Intake from layer B'", file=sys.stderr)
+            return 2
+
+    with open(DB, encoding="utf-8") as fh:
+        known = {r["polity_code"] for r in csv.DictReader(fh)}
+
+    done = judged_keys(APPLIED)
+
+    with open(ASSERTIONS, encoding="utf-8") as fh:
+        blob = json.load(fh)
+    items = blob["assertions"] if isinstance(blob, dict) and "assertions" in blob else blob
+
+    unjudged = [a for a in items if a.get("status") in PENDING and a.get("key") not in done]
+    stale = [a for a in unjudged if a.get("candidate") not in known]
+    live = [a for a in unjudged if a.get("candidate") in known]
+    live.sort(key=lambda a: -(a.get("rows") or 0))
+    picked = live[: args.limit]
+
+    if args.json:
+        print(json.dumps([a["key"] for a in picked]))
+        return 0
+
+    print(f"assertions        {len(items)}")
+    print(f"  banked verdicts {len(done)}")
+    print(f"  still pending   {len(live)}")
+    if stale:
+        rows = sum(a.get("rows") or 0 for a in stale)
+        print(
+            f"  SKIPPED (stale) {len(stale)} carrying {rows:,} rows name a candidate that no "
+            f"longer exists -- re-run 00_intake.py to re-derive them"
+        )
+        for a in sorted(stale, key=lambda a: -(a.get("rows") or 0))[:5]:
+            print(f"      {a.get('rows'):>5}  {a['key'][:44]:46} -> {a.get('candidate')} (gone)")
+
+    print(f"\nnext {len(picked)} by exposure:")
+    for a in picked:
+        print(f"  {a.get('rows'):>5}  {a['key'][:44]:46} -> {a.get('candidate')}")
+    print()
+    print(json.dumps([a["key"] for a in picked]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Select verification tranches by what is banked, not by what the queue says

The README told you to compute the next batch from assertions.json status, and that
advice re-selected a batch that had just been verified. Twelve agents were about to
re-decide settled questions; the only reason they did not is that the returned list
looked familiar.

Two independent staleness bugs, both silent, both biased the same way -- toward
looking like there is work to do when there is not.

  apply_verdicts.py writes the LEDGER. Only a re-run of 00_intake.py re-reads the
  ledger and re-labels the queue. Between those two events a verified assertion still
  reads pending: 49 do right now, 42 `reopened` and 7 `pending`, all with banked
  verdicts.

  The applied-verdict key is NESTED at record["verdict"]["key"]. Read top-level it
  returns None for all 246 records, so the exclusion set comes out EMPTY -- and an
  empty exclusion set is indistinguishable from a clean queue.

select_tranche.py takes verdicts_applied.jsonl as the authority instead, and prints
its arithmetic rather than just emitting a list, because both failure modes are
invisible in the output they corrupt.

It also reports, without selecting, assertions whose candidate no longer exists -- a
re-span renames the code and the queue keeps the old one. That class is 0 today, so
the branch was tested against a doctored state: a 9,999-row fake naming ZZZ-1900-1910
would have topped the list by exposure and was excluded and named instead.

Not a gate: assertions.json is gitignored, so CI cannot see the input this reads.
