### PR TITLE
Record that IIA's "serbia" appears to be Yugoslavia, which inverts this polity's rationale

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -22,7 +22,7 @@ double the real polity total.)
 | `status: superseded` / `retired` | 21 / 23 |
 | Pages with no source citation | 193 |
 | Pages citing biger-1995 | 411 |
-| Open questions (`### oq-`) | 857 |
+| Open questions (`### oq-`) | 858 |
 
 **By continent:** Africa 276 · Europe 175 · Asia 163 · North America 70 · South America 46 · Oceania 46 · World 2
 

--- a/wiki/polities/ser-1918-1945.md
+++ b/wiki/polities/ser-1918-1945.md
@@ -143,6 +143,42 @@ The 1929 banovina reorganization divided historical Serbia among multiple admini
 
 The ~88,000 km² estimate includes Kosovo (~10,908 km²) and Vojvodina (~21,506 km²). Vojvodina was acquired from Austria-Hungary in 1918 and may or may not be included in IIA's "serbia" label. If Vojvodina is reported separately, the territory would be ~66,500 km². Pending source verification.
 
+### oq-label-is-yugoslavia-not-serbia
+
+**This page's reason for existing may be backwards, and the measurement is not close.** Measured
+2026-08-18 against the raw IIA extract (see issue 315):
+
+    raw IIA `serbia`                                28 rows, ALL imports/exports, ZERO production
+    raw IIA `kingdom of serbs, croats and slovenes` 594 rows
+    raw IIA `yugoslavia`                          2,462 rows
+
+    layer B `iia/serbia`, 462 dated production values
+      explained by `yugoslavia`                     317   (69%)
+      explained by `kingdom of serbs, croats...`    111   (24%)
+      combined                                      428   (93%)
+      explained by raw `serbia`                       0   (0%)
+
+The rye series partitions exactly — 6 values from the Kingdom label (pre-1929), 16 from
+`yugoslavia` (after the state was renamed), 22 of 22, none from `serbia`. It is one Yugoslav
+series stitched across the 1929 renaming.
+
+If that holds, the "Why this polity was created" section above has it inverted. It says routing
+this data to F248-1920-1947 (all Yugoslavia, ~255,000 km2) "would overstate the territorial basis
+~3x". But the data appears to BE the all-Yugoslavia series, in which case routing it to this row's
+90,599 km2 polygon **understates** the territory by ~2.8x, and F248-1920-1947 was the right target
+all along.
+
+**Not acted on here, deliberately.** Retiring or re-routing a polity that 573 rows depend on is a
+judgement, and one measurement — however clean — is not sufficient grounds when the alternative
+reading is that the harmonisation deliberately extracted a Serbian sub-series that happens to
+share values with the Yugoslav one (which the exact partition makes unlikely, but not impossible).
+The remaining 7% is also unexplained.
+
+Note what this does to the other evidence on this page: the 2026-07-24 note argued from the absence
+of a discontinuity at the 1929 banovina reorganisation. If the label is Yugoslavia throughout, then
+there would be no discontinuity to find — the observation is equally consistent with the opposite
+conclusion, so it supports neither.
+
 ### oq-wwii-occupation-shrinkage
 
 **The one territorial discontinuity inside this row's own data span, and neither other open


### PR DESCRIPTION
Record that IIA's "serbia" appears to be Yugoslavia, which inverts this polity's rationale

Measured against the raw IIA extract while auditing label collapses for #315:

    raw IIA `serbia`                                28 rows, ALL imports/exports, ZERO production
    raw IIA `kingdom of serbs, croats and slovenes` 594 rows
    raw IIA `yugoslavia`                          2,462 rows

    layer B `iia/serbia`, 462 dated production values
      explained by `yugoslavia`                     317   (69%)
      explained by `kingdom of serbs, croats...`    111   (24%)
      combined                                      428   (93%)
      explained by raw `serbia`                       0   (0%)

The rye series partitions exactly: 6 values from the Kingdom label (pre-1929), 16 from `yugoslavia`
after the state was renamed, 22 of 22, none from `serbia`. One Yugoslav series stitched across a
rename.

SER-1918-1945 exists because routing this data to F248-1920-1947 "would overstate the territorial
basis ~3x". If the label is the all-Yugoslavia series, that is backwards -- the 90,599 km2 polygon
UNDERSTATES it by ~2.8x and F248-1920-1947 was right.

RECORDED, NOT ACTED ON. Retiring or re-routing a row that 573 data rows depend on is a judgement,
and one measurement is not enough on its own -- the competing reading is that the harmonisation
extracted a genuine Serbian sub-series whose values happen to coincide, which the exact partition
makes unlikely but not impossible. 7% stays unexplained either way.

The note also disarms an argument already on the page: the 2026-07-24 verification reasoned from the
ABSENCE of a discontinuity at the 1929 banovina reorganisation. If the label is Yugoslavia
throughout, there is no discontinuity to find, so that observation is equally consistent with either
conclusion and supports neither. Left in place with the pointer rather than deleted.

This is the second thing found on this page in one day that its own evidence could not have caught,
after the WWII occupation wording in #311. Both came from outside the database -- web research
there, the raw source extract here.

Index regenerated: 858 open questions.
