### PR TITLE
Apply the same co-occurrence and dominance tests in both modes

### DIFF
--- a/pipelines/polity-autoimprove/15_label_provenance.py
+++ b/pipelines/polity-autoimprove/15_label_provenance.py
@@ -84,6 +84,12 @@ NOISE_FLOOR = 0.25
 # `netherlands` as a co-contributor off one match.
 MIN_SPAN_VALUES = 8
 
+# A source is only DOMINANT if it is clearly above chance, not a hair above it. `equatorial guinea`
+# had `bulgaria` and `spanish spanish guinea including fernando po` TIED at 26% against a 25% floor,
+# and the alphabetical tiebreak crowned the noise -- reporting `bulgaria` as the dominant source for
+# Equatorial Guinea. Requiring a margin turns that into an honest "nothing explains this".
+DOMINANCE = NOISE_FLOOR * 1.5
+
 # A label whose best raw match explains at least this much is accounted for by ONE raw label, and
 # whatever it is called is then just a naming question. Below it, something else is contributing.
 EXPLAINED = 0.85
@@ -361,7 +367,31 @@ def main() -> int:
                         above.append((c, rl))
                         covered |= fp & raw_fp[rl]
             share = top / len(fp)
-            if share <= NOISE_FLOOR:
+            # CO-OCCURRENCE, the same test the label mode applies: two contributors are only
+            # genuinely concurrent if each supplies values UNIQUE to it in the SAME year. Without
+            # it, `samoa|iia|1910-1945` reads `mixed` when it is `british samoa` 1910-1916 followed
+            # by `new zealand western samoa` 1922-1945 -- one territory, renamed, one source at a
+            # time. The label mode had this test and the span mode did not, so the gate refused a
+            # sequential span on the strength of an inconsistency between two halves of one script.
+            if len(above) > 1:
+                years = sorted({y for y, _v in fp})
+                shared = 0
+                for yr in years:
+                    vals = {(y, v) for y, v in fp if y == yr}
+                    uniq = 0
+                    for _c, rl in above:
+                        others = set()
+                        for _c2, rl2 in above:
+                            if rl2 != rl:
+                                others |= raw_fp[rl2]
+                        if (vals & raw_fp[rl]) - others:
+                            uniq += 1
+                    if uniq >= 2:
+                        shared += 1
+                if years and shared / len(years) <= 0.25:
+                    above = above[:1]
+                    covered = fp & raw_fp[top_label]
+            if share <= DOMINANCE:
                 sig, note = "no_dominant_source", f"best {top_label} {share:.0%}"
             elif len(above) > 1:
                 sig = "mixed"
@@ -438,11 +468,11 @@ def main() -> int:
         print()
         # The top match is always kept so there is something to report, so emptiness cannot be the
         # test for "nothing explains this span" — ask whether the top match itself clears the floor.
-        if not above or top / len(fp) <= NOISE_FLOOR:
+        if not above or top / len(fp) <= DOMINANCE:
             print(f"   NO DOMINANT SOURCE: the best single match, {top_label}, explains only "
-                  f"{100 * top / len(fp):.0f}% and nothing clears the {NOISE_FLOOR:.0%} noise "
-                  f"floor. These years are assembled from several raw labels, none of which "
-                  f"accounts for them.")
+                  f"{100 * top / len(fp):.0f}%, short of the {DOMINANCE:.0%} needed to call "
+                  f"anything dominant against a {NOISE_FLOOR:.0%} chance floor. These years are "
+                  f"assembled from several raw labels, none of which accounts for them.")
         elif len(above) > 1:
             print(f"   SEVERAL SOURCES IN THIS SPAN: {', '.join(rl for _c, rl in above)} "
                   f"({len(covered) / len(fp):.0%} between them)")

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -268,7 +268,14 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        LABEL is mixed) and adds true ones the label view averaged away
                        (`china mainland|iia|1922-1931` is `china` + `japan: kwantung leased
                        territory`; `syrian arab republic|iia|1922-1945` is `french syria and
-                       lebanon` + `french syria` over 358 values).
+                       lebanon` + `french syria` over 358 values). Both modes apply the SAME
+                       co-occurrence and dominance tests: two sources count as concurrent only
+                       if each supplies values UNIQUE to it in the same year, and a source is
+                       DOMINANT only at 1.5x the chance floor. Without the first, `samoa` read
+                       `mixed` when it is `british samoa` then `new zealand western samoa` --
+                       one territory renamed. Without the second, `equatorial guinea` reported
+                       `bulgaria` as its dominant source, tied at 26% with the plausible one and
+                       crowned by an alphabetical tiebreak.
 select_tranche.py      picks the next batch to verify: highest-exposure assertions
                        that are pending AND have no banked verdict. Status alone is
                        NOT the filter — apply_verdicts.py writes the ledger, and

--- a/pipelines/polity-autoimprove/state/iia_assertion_provenance.csv
+++ b/pipelines/polity-autoimprove/state/iia_assertion_provenance.csv
@@ -63,8 +63,8 @@ ecuador|iia|1922-1941,ECU-1800-1942,15,clean,ecuador,1.00,ecuador 100%
 ecuador|iia|1942-1945,ECU-1942-2025,7,clean,ecuador,1.00,ecuador 100% [only 7 values — below the 8-value floor]
 egypt|iia|1909-1924,EGY-1899-1925,94,clean,egypt,0.73,egypt 73%
 egypt|iia|1925-1945,EGY-1925-1967,275,clean,egypt,0.65,egypt 65%
-el salvador|iia|1910-1944,SLV-1821-2025,29,mixed,el salvador,0.55,el salvador + el salvador: san salvador department (union 100%)
-equatorial guinea|iia|1910-1945,GNQ-1886-1968,23,mixed,bulgaria,0.26,bulgaria + spanish spanish guinea including fernando po (union 52%)
+el salvador|iia|1910-1944,SLV-1821-2025,29,clean,el salvador,0.55,el salvador 55%
+equatorial guinea|iia|1910-1945,GNQ-1886-1968,23,no_dominant_source,bulgaria,0.26,best bulgaria 26%
 eritrea|iia|1922-1937,ERI-1889-1952,87,clean,italian eritrea,1.00,italian eritrea 100%
 estonia|iia|1929-1939,EST-1918-1940,16,clean,estonia,1.00,estonia 100%
 estonia|iia|1940-1944,EST-1940-1991,2,redirected,british nigeria,1.00,british nigeria 100% [only 2 values — below the 8-value floor]
@@ -81,7 +81,7 @@ finland|iia|1940-1945,FIN-1940-2025,17,clean,finland,1.00,finland 100%
 france|iia|1909-1918,FRA-1871-1919,77,clean,france,0.87,france 87%
 france|iia|1919-1945,FRA-1919-2025,216,clean,france,0.83,france 83%
 french guiana|iia|1909-1945,GUF-1816-1946,29,clean,french guiana,1.00,french guiana 100%
-french polynesia|iia|1909-1937,PYF-1800-2025,41,mixed,french oceania,0.61,french oceania + french oceania: makatea island (union 100%)
+french polynesia|iia|1909-1937,PYF-1800-2025,41,redirected,french oceania,0.61,french oceania 61%
 gabon|iia|1909-1911,GAB-1839-1912,6,redirected,french equatorial africa: gabon,1.00,french equatorial africa: gabon 100% [only 6 values — below the 8-value floor]
 gabon|iia|1912-1918,GAB-1912-1919,22,redirected,french equatorial africa: gabon,1.00,french equatorial africa: gabon 100%
 gabon|iia|1919-1932,GAB-1919-1960,20,redirected,french equatorial africa: gabon,1.00,french equatorial africa: gabon 100%
@@ -145,7 +145,7 @@ lithuania|iia|1940-1945,LTU-1940-1991,6,redirected,british nigeria,1.00,british 
 luxembourg|iia|1909-1945,LUX-1839-2025,82,clean,luxembourg,0.61,luxembourg 61%
 madagascar|iia|1911-1945,MDG-1882-2025,193,clean,french madagascar,0.92,french madagascar 92%
 malawi|iia|1909-1945,MWI-1891-1953,219,redirected,british nyasaland,1.00,british nyasaland 100%
-malaysia|iia|1909-1944,BNB-1881-1963,96,mixed,british borneo,0.34,british borneo + british malaya + british federated malay states (union 92%)
+malaysia|iia|1909-1944,BNB-1881-1963,96,no_dominant_source,british borneo,0.34,best british borneo 34%
 mali|iia|1918-1937,MLI-1890-1960,42,redirected,french sudan,0.98,french sudan 98%
 malta|iia|1909-1945,MLT-1800-2025,88,clean,british malta,0.78,british malta 78%
 martinique|iia|1909-1945,MTQ-1816-2025,37,clean,french martinique,1.00,french martinique 100%
@@ -172,7 +172,7 @@ palau|iia|1909-1914,GCAR-1899-1914,6,redirected,japanese south pacific: palau-an
 palau|iia|1915-1918,JPN-1895-1945,4,redirected,japanese south pacific: palau-angaur,1.00,japanese south pacific: palau-angaur 100% [only 4 values — below the 8-value floor]
 palau|iia|1930-1932,CAR-1920-1945,3,redirected,japanese south pacific: palau-angaur,1.00,japanese south pacific: palau-angaur 100% [only 3 values — below the 8-value floor]
 panama|iia|1912-1945,PAN-1903-1979,30,clean,panama,0.93,panama 93%
-papua new guinea|iia|1910-1940,TPAP-1906-1949,46,mixed,dutch new guinea,0.72,dutch new guinea + australian papua and new guinea (union 100%)
+papua new guinea|iia|1910-1940,TPAP-1906-1949,46,redirected,dutch new guinea,0.72,dutch new guinea 72%
 paraguay|iia|1909-1931,PRY-1870-1932,40,clean,paraguay,1.00,paraguay 100%
 paraguay|iia|1932-1936,PRY-1932-1938,11,clean,paraguay,1.00,paraguay 100%
 paraguay|iia|1939-1945,PRY-1938-2025,25,clean,paraguay,1.00,paraguay 100%
@@ -194,7 +194,7 @@ romania|iia|1920-1939,ROU-1920-1940,109,clean,romania,0.87,romania 87%
 romania|iia|1940-1945,ROU-1940-1947,29,clean,romania,0.83,romania 83%
 russian federation|iia|1909-1913,F228-1905-1914,99,no_dominant_source,russia in europe,0.17,best russia in europe 17%
 russian federation|iia|1914-1916,F228-1914-1917,49,no_dominant_source,russia in asia,0.16,best russia in asia 16%
-russian federation|iia|1917-1917,F228-1917-1918,8,redirected,japan: karafuto prefecture,0.38,japan: karafuto prefecture 38%
+russian federation|iia|1917-1917,F228-1917-1918,8,no_dominant_source,japan: karafuto prefecture,0.38,best japan: karafuto prefecture 38%
 russian federation|iia|1918-1918,F228-1918-1920,8,redirected,japan: karafuto prefecture,1.00,japan: karafuto prefecture 100%
 russian federation|iia|1920-1920,F228-1920-1921,5,no_dominant_source,japan: karafuto prefecture,0.20,best japan: karafuto prefecture 20% [only 5 values — below the 8-value floor]
 russian federation|iia|1922-1939,F228-1921-1940,287,redirected,ussr,0.75,ussr 75%
@@ -203,7 +203,7 @@ russian federation|iia|1945-1945,F228-1945-1991,2,redirected,ussr,1.00,ussr 100%
 saint kitts and nevis|iia|1909-1945,KNA-1800-2025,116,redirected,british saint christopher and nevis,1.00,british saint christopher and nevis 100%
 saint lucia|iia|1909-1945,LCA-1838-2025,108,clean,british saint lucia,1.00,british saint lucia 100%
 saint vincent and the grenadines|iia|1909-1945,VCT-1833-2025,158,redirected,british saint vincent,1.00,british saint vincent 100%
-samoa|iia|1910-1945,WSM-1900-2025,39,mixed,new zealand western samoa,0.72,new zealand western samoa + british samoa (union 100%)
+samoa|iia|1910-1945,WSM-1900-2025,39,redirected,new zealand western samoa,0.72,new zealand western samoa 72%
 sao tome and principe|iia|1930-1944,STP-1800-2025,10,clean,portuguese sao tome and principe,1.00,portuguese sao tome and principe 100%
 senegal|iia|1922-1945,SEN-1886-1960,84,clean,french senegal,0.95,french senegal 95%
 serbia|iia|1909-1911,SER-1878-1913,14,redirected,"kingdom of serbs, croats and slovenes",0.86,"kingdom of serbs, croats and slovenes 86%"
@@ -228,7 +228,7 @@ tanzania|iia|1910-1913,TAN-1891-1920,12,redirected,british tanganyika,1.00,briti
 tanzania|iia|1921-1921,TAN-1920-1922,1,redirected,british tanganyika,1.00,british tanganyika 100% [only 1 values — below the 8-value floor]
 tanzania|iia|1922-1945,TAN-1922-1964,101,redirected,british tanganyika,1.00,british tanganyika 100%
 thailand|iia|1911-1944,THA-1909-2025,118,redirected,siam,1.00,siam 100%
-timor leste|iia|1909-1940,TLS-1800-2025,17,mixed,portuguese timor and kambing,0.53,portuguese timor and kambing + portuguese timor (union 100%)
+timor leste|iia|1909-1940,TLS-1800-2025,17,redirected,portuguese timor and kambing,0.53,portuguese timor and kambing 53%
 togo|iia|1945-1945,FTO-1920-1960,3,redirected,german togoland,1.00,german togoland 100% [only 3 values — below the 8-value floor]
 trinidad and tobago|iia|1909-1945,TTO-1800-2025,82,clean,british trinidad and tobago,1.00,british trinidad and tobago 100%
 tunisia|iia|1909-1945,TUN-1881-2025,253,clean,french tunisia,1.00,french tunisia 100%

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1174,35 +1174,25 @@ def mutate_retargeted_map_to_dead_polity(root, gpd, make_valid, affinity):
 
 
 def mutate_label_provenance_hides_mixing(root, gpd, make_valid, affinity):
-    """Mark a clean label as one whose values come from two raw territories at once.
+    """Mark a span whose values come from ONE territory as coming from two.
 
-    Inverse of the real defect, and deliberately so. The real defect was that the mapping was not
-    tracked at all, so `serbia` meaning Yugoslavia and `viet nam` meaning Tonkin were invisible;
-    that state cannot be re-injected once the file exists. What CAN regress is the provenance file
-    drifting so a mixed target reads as clean, at which point the gate stops refusing equality
-    claims on it and the blindness returns silently.
+    Inverse of the real defect, deliberately: the original state -- no provenance table at all, so
+    `serbia` meaning Yugoslavia was invisible -- cannot be re-injected once the file exists. What CAN
+    regress is a signal drifting so a mixed span reads clean, at which point the gate stops refusing
+    equality claims on it. This goes the other way and requires the ceiling to be breached.
 
-    So this goes the other way: it takes an IIA label that currently carries a `verified_equal`
-    verdict and is NOT flagged, and marks its target as assembled from a whole plus sub-labels.
-    The verdict is then an equality claim on a mixed label and the count must exceed its ceiling.
+    MUTATES THE SPAN TABLE, because that is what the gate reads. An earlier version perturbed
+    `territory_signal` in the LABEL table, and when the gate learned to prefer per-span signals the
+    mutation silently stopped biting -- the harness reported "PASSED a mutation it claims to catch",
+    which is exactly the state it exists to detect. A mutator has to target the file the gate
+    actually consults, and that changed under it.
 
-    Chosen by scanning rather than hard-coded, because which labels carry `verified_equal` changes
-    with every verification pass -- a pinned label would rot into a case that cannot fail.
-
-    Nothing else notices: no other gate reads this file, and the verdict itself is well-formed.
+    Picks its target by scanning for a banked `verified_equal` whose span currently reads clean,
+    rather than hard-coding one, since which assertions carry that verdict changes every pass.
     """
-    prov = os.path.join(root, "pipelines/polity-autoimprove/state/iia_label_provenance.csv")
+    span = os.path.join(root, "pipelines/polity-autoimprove/state/iia_assertion_provenance.csv")
     applied = os.path.join(root, "pipelines/polity-autoimprove/state/verdicts_applied.jsonl")
     ledger = os.path.join(root, "pipelines/polity-autoimprove/state/review_ledger.csv")
-
-    def _n(x):
-        return re.sub(r"[^a-z0-9]+", " ", str(x).lower()).strip()
-
-    with open(prov, newline="", encoding="utf-8") as fh:
-        rows = list(csv.DictReader(fh))
-        fields = list(rows[0])
-    mixed = {r.get("layer_b_label") for r in rows
-             if r.get("territory_signal") == "mixed"}
 
     retracted = set()
     with open(ledger, newline="", encoding="utf-8") as fh:
@@ -1210,7 +1200,7 @@ def mutate_label_provenance_hides_mixing(root, gpd, make_valid, affinity):
             if (r.get("status") or "") == "issue":
                 retracted.add((r.get("key") or "").strip())
 
-    target = None
+    equal_keys = []
     with open(applied, encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
@@ -1220,37 +1210,30 @@ def mutate_label_provenance_hides_mixing(root, gpd, make_valid, affinity):
             if not isinstance(v, dict):
                 continue
             key = v.get("key") or ""
-            if "|iia|" not in key or key in retracted:
-                continue
-            if v.get("confirm_kind") != "verified_equal":
-                continue
-            lab = _n(key.split("|")[0])
-            if lab not in mixed:
-                target = lab
-                break
-    assert target, "no unflagged IIA verified_equal verdict to build the case on"
+            if "|iia|" in key and key not in retracted and v.get("confirm_kind") == "verified_equal":
+                equal_keys.append(key)
 
-    hit = 0
+    with open(span, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+
+    hit = None
     for r in rows:
-        # Match on the RESOLVED layer-B label, the same key the gate joins on. Matching
-        # `assigned_modern` instead failed on `south korea`, because the mapping carries the long
-        # official name -- the same 10% miss the gate itself had.
-        if r.get("layer_b_label") == target and hit == 0:
-            # Mutate `territory_signal`, the field the gate READS. An earlier version set `kind`
-            # instead -- the spec's intent -- and after the gate moved to observed mixing the
-            # mutation stopped biting: the harness reported "PASSED a mutation it claims to catch",
-            # which is precisely the state it exists to detect.
-            r["territory_signal"] = "mixed"
-            r["fingerprint_note"] = "injected: two raw labels above the floor"
-            hit += 1
-    assert hit == 1, f"expected one provenance row for {target}, changed {hit}"
-    with open(prov, "w", newline="", encoding="utf-8") as fh:
+        if r["key"] in equal_keys and r["span_signal"] not in ("mixed", "no_dominant_source"):
+            if int(r["n_values"] or 0) >= 8:
+                hit = r
+                break
+    assert hit, "no banked verified_equal with a clean, well-sampled span to build the case on"
+    hit["span_signal"] = "mixed"
+    hit["note"] = "injected: two raw labels above the floor"
+
+    with open(span, "w", newline="", encoding="utf-8") as fh:
         w = csv.DictWriter(fh, fieldnames=fields)
         w.writeheader()
         w.writerows(rows)
-    return (f"marked `{target}` as a target assembled from a whole plus sub-labels, so the "
-            f"`verified_equal` verdict already banked against it is an equality claim on a label "
-            f"whose values come from two territories at once")
+    return (f"marked `{hit['key']}` as a span whose values come from two territories at once, so the "
+            f"`verified_equal` verdict already banked against it is an equality claim on a span with "
+            f"no single territory")
 
 def mutate_ledger_verdict_on_dead_polity(root, gpd, make_valid, affinity):
     """Re-point a banked verdict at a polity code that does not exist.
@@ -2403,8 +2386,9 @@ CASES = (
         "validate_iia_label_provenance.py",
         mutate_label_provenance_hides_mixing,
         "verified_equal",
-        "a provenance row that hides an observed whole-plus-parts merge, so equality claims on a "
-        "label with no single territory stop being refused",
+        "a per-SPAN provenance row that hides an observed whole-plus-parts merge, so equality "
+        "claims on a span with no single territory stop being refused — the gate reads the span "
+        "table in preference to the label table, and a mutator aimed at the wrong one passes",
     ),
     (
         "validate_review_ledger.py",
@@ -2870,6 +2854,7 @@ WRITABLE = {
     # its target by scanning them for an unflagged `verified_equal`, and the gate reads the ledger
     # to tell a retracted verdict from a live one.
     "validate_iia_label_provenance.py": (
+        "pipelines/polity-autoimprove/state/iia_assertion_provenance.csv",
         "pipelines/polity-autoimprove/state/iia_label_provenance.csv",
         "pipelines/polity-autoimprove/state/verdicts_applied.jsonl",
         "pipelines/polity-autoimprove/state/review_ledger.csv",

--- a/scripts/validate_iia_label_provenance.py
+++ b/scripts/validate_iia_label_provenance.py
@@ -66,24 +66,25 @@ MIXING = ("multi_country", "whole_with_sub_siblings")
 # CEILING on a known class, not an endorsement of any of them — each needs individual triage:
 #
 #   french polynesia|iia|1909-1938  n=51  makatea island alone, then the whole territory
-#   samoa|iia|1910-1945             n=39  `new zealand western samoa` + `british samoa`. PROBABLY a
-#                                         naming artefact -- both are Western Samoa -- so this one
-#                                         may be a false positive of the union-gain test on two
-#                                         names for one place.
 #   libya|iia|1922-1924             n=3   `italian libya: tripolitania` alone: a province, but three
 #   libya|iia|1943-1945             n=3   whole `italian libya`: looks CLEAN, but three values cannot
 #                                         establish that a span is the clean part of a mixed label,
 #                                         so it falls back to the label reading
 #   indonesia|iia|1945-1945         n=3   `dutch java and madura` at 67%, i.e. two values of three
-#   equatorial guinea|iia|1910-1945 n=23  `bulgaria` + `spanish spanish guinea including fernando
-#                                         po`. `bulgaria` is a chance collision that clears the floor
-#                                         at this sample size, so this is very likely a FALSE
-#                                         refusal -- listed here honestly rather than tuned away.
+#   equatorial guinea|iia|1910-1945 n=23  `no_dominant_source`: the best match is `bulgaria` at 26%,
+#                                         which is noise, and the plausible source
+#                                         (`spanish spanish guinea including fernando po`) TIES it at
+#                                         26%. So this span is UNMEASURABLE, which is not the same as
+#                                         refuted -- the routing to GNQ-1886-1968 is probably right
+#                                         and nothing here can confirm it. Kept in the ceiling on
+#                                         that basis.
 #
-# The count has moved seven times. Every previous move was a correction to the measurement, and this
-# one is a change of INSTRUMENT: from a per-label signal to a per-span one, which both removes
-# false refusals (a clean span inside a mixed label) and adds true ones the label view averaged away.
-BASELINE_VERIFIED_EQUAL_ON_MIXED = 6
+# EIGHTH move, 6 -> 5: `samoa|iia|1910-1945` left as a FALSE REFUSAL. The span mode lacked the
+# co-occurrence test the label mode already had, so `british samoa` (1910-1916) and
+# `new zealand western samoa` (1922-1945) -- one territory across a rename, one source at a time --
+# registered as concurrent. An inconsistency between two halves of one script, refusing a span with
+# nothing wrong with it. Both modes now apply the same test.
+BASELINE_VERIFIED_EQUAL_ON_MIXED = 5
 
 # The eight the mapping itself declares as spanning several modern countries. Pinned by name so a
 # change to the mapping surfaces here rather than silently shifting the count.


### PR DESCRIPTION
Apply the same co-occurrence and dominance tests in both modes

Triaging the mixed-span class surfaced two inconsistencies between the label mode and the span mode
of one script, and each produced a wrong answer.

CO-OCCURRENCE, missing from the span mode. Two contributors are only genuinely concurrent if each
supplies values UNIQUE to it in the SAME year. The label mode had that test; the span mode did not,
so `samoa|iia|1910-1945` read `mixed` when it is `british samoa` (1910-1916) followed by
`new zealand western samoa` (1922-1945) -- one territory across a rename, one source at a time. The
gate was refusing a span with nothing wrong with it, on the strength of two halves of one script
disagreeing.

DOMINANCE MARGIN, missing from both. `equatorial guinea|iia|1910-1945` had `bulgaria` and
`spanish spanish guinea including fernando po` TIED at 26% against a 25% noise floor, and the
alphabetical tiebreak crowned the noise -- the table reported `bulgaria` as the dominant source for
Equatorial Guinea. A source is now dominant only at 1.5x the floor, so that span reads
`no_dominant_source`: unmeasurable, which is honest and is NOT the same as refuted. The routing to
GNQ-1886-1968 is probably right and nothing here can confirm it.

    span_signal:  clean 138 · redirected 94 · mixed 6 · no_dominant_source 7 · unmeasured 2

CEILING 6 -> 5, the eighth move, and the first caused by a false refusal leaving rather than a true
one arriving.

THE CLASS IS NOW NEARLY TRIAGED. Of the 16 spans measuring mixed or unexplained with enough values
to be conclusive, 12 are quarantined, 1 is unmeasurable-but-probably-fine, and 3 had never been
verified at all -- `russian federation|iia|1909-1913`, `russian federation|iia|1914-1916` and
`china mainland|iia|1922-1931`. Those are now running, together with `azerbaijan|iia|1930-1940`
(100% `ussr: transcaucasian sfsr`, i.e. Azerbaijan plus Armenia plus Georgia on Azerbaijan alone)
and `lebanon|iia|1923-1943`, which is the other half of the Syria double count in #342.
