### PR TITLE
The polity-existence arm of #407's new gate shipped dead

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1437,6 +1437,36 @@ def mutate_spike_factor_rewritten(root, gpd, make_valid, affinity):
             f"rests on no longer describes the row it sits in")
 
 
+def mutate_overlap_code_not_a_polity(root, gpd, make_valid, affinity):
+    """Point an overlap row at a polity code that does not exist.
+
+    This exists because the arm it tests SHIPPED DEAD. `validate_same_polity_overlaps.py` guarded its
+    polity-existence check with `if os.path.exists(POLITIES)` and pointed POLITIES at
+    `data/final/polities.csv` -- a filename this repo does not have; the table is
+    `polities_database.csv`. So the guard was always False, the arm never ran, and the gate passed
+    green while checking nothing. That is issue 387's failure verbatim, in a gate whose own docstring
+    cites issue 387.
+
+    It mutates an `undetermined` row, not a supported one, so the identity pins stay quiet -- they
+    only cover rows with a supported verdict. The row count, the arithmetic and the directional floor
+    are all untouched. ONLY the polity-existence arm can catch it, which is the point: a case that
+    tripped some other signal would have passed against the dead version too.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/same_polity_overlaps.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = next(r for r in rows if r["relation"] == "undetermined")
+    before = victim["whep_code"]
+    victim["whep_code"] = "ZZZ-1800-1900"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"repointed an undetermined overlap from {before} to ZZZ-1800-1900, a code no polity "
+            f"has, leaving the row count, the arithmetic, the floor and every identity pin intact")
+
+
 def mutate_overlap_shrunk_below_floor(root, gpd, make_valid, affinity):
     """Shrink a pinned containment pair's cell count below the floor that made it sayable.
 
@@ -2738,6 +2768,14 @@ CASES = (
         "does not match its own values",
         "a recorded spike's factor column rewritten to look ordinary while its three values stay "
         "put, so the one number every judgement here rests on contradicts the row it describes",
+    ),
+    (
+        "validate_same_polity_overlaps.py",
+        mutate_overlap_code_not_a_polity,
+        "is not a polity in",
+        "an overlap row pointing at a code no polity has — the arm that catches this shipped DEAD, "
+        "guarded on a filename this repo does not contain, so the gate ran green while checking "
+        "nothing; the mutation leaves every other signal quiet so only that arm can see it",
     ),
     (
         "validate_same_polity_overlaps.py",

--- a/scripts/validate_same_polity_overlaps.py
+++ b/scripts/validate_same_polity_overlaps.py
@@ -55,7 +55,7 @@ import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/same_polity_overlaps.csv")
-POLITIES = os.path.join(REPO, "data/final/polities.csv")
+POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
 
 # Measured 2026-08-19 on the first run. BIDIRECTIONAL: rerouting a label must lower this, with a note
 # saying which pair was resolved, so a later regression cannot hide inside the old headroom.
@@ -140,12 +140,20 @@ def main() -> int:
                 f"{r['whep_code']} {r['label_a']!r}/{r['label_b']!r} claims {r['relation']} on {n} "
                 f"cells, under the floor of {MIN_DIRECTIONAL} where direction is a coin flip")
 
-    # Every code must be a real polity, or the pins above refer to nothing.
-    if os.path.exists(POLITIES):
+    # Every code must be a real polity, or the pins above refer to nothing. NOT conditional on the
+    # file existing: this check shipped pointing at `data/final/polities.csv`, which is not the name
+    # of anything in this repo, so `os.path.exists` was False and the whole arm silently no-opped --
+    # the exact failure this gate's own docstring cites from issue 387. An absent input is a FAILURE.
+    if not os.path.exists(POLITIES):
+        problems.append(f"{os.path.relpath(POLITIES, REPO)} is missing, so no code here can be "
+                        f"checked against a real polity")
+    else:
         with open(POLITIES, encoding="utf-8") as fh:
-            live = {r["whep_code"] for r in csv.DictReader(fh)}
+            live = {r["polity_code"] for r in csv.DictReader(fh)}
         for code in sorted({r["whep_code"] for r in rows} - live):
-            problems.append(f"{code} is not a polity in data/final/polities.csv")
+            problems.append(
+                f"{code} is not a polity in {os.path.relpath(POLITIES, REPO)} — every pinned pair "
+                f"above refers to it, so the pin is checking against nothing")
 
     for p in problems:
         print(f"FAIL: {p}", file=sys.stderr)


### PR DESCRIPTION
Self-caught, an hour after #407 merged.

`validate_same_polity_overlaps.py` guarded its final check with `if os.path.exists(POLITIES)` and pointed POLITIES at `data/final/polities.csv` — **a filename this repo does not have**. The table is `polities_database.csv`, and its column is `polity_code`, not `whep_code`. So the guard was always False, the arm never ran, and the gate reported green while checking nothing.

That is [#387](../../issues/387)'s failure verbatim, in a gate **whose own docstring cites #387** and whose commit message claims "the gate FAILS rather than skips when its table is missing". It does, for its table. It did not, for this input.

## Fixed three ways

- `POLITIES` points at `data/final/polities_database.csv` and reads `polity_code`
- **a missing file is now a FAILURE, not a skip.** There is no configuration of this repo in which the polity table is legitimately absent, so `exists()` had nothing to protect
- **a second selftest case pins the arm.** It repoints an `undetermined` row at `ZZZ-1800-1900` — undetermined because the identity pins only cover *supported* verdicts, so they stay quiet, as do the row count, the arithmetic and the directional floor. Only this arm can catch it, which is the point: a mutation that tripped some other signal would have passed against the dead version too

## Sweep

Checked every `os.path.join(REPO, "...")` in all 67 gates and 25 pipeline tools for the same bug. One other hit — `04_territory_basis.py` → `data/geodata/constructed/constructed.geojson`, which is gitignored and regenerable, so legitimately absent. This gate was the only real one.

**67 gates and 77 selftest cases pass.**

*PR opened by Claude.*