### PR TITLE
Assertion keys are not unique, and the carryover tool silently drops the loser (#308)

### DIFF
--- a/pipelines/polity-autoimprove/00_intake.py
+++ b/pipelines/polity-autoimprove/00_intake.py
@@ -30,7 +30,7 @@ pre-assertion-era bare-label row with no hash — see the legacy branch below) f
 the verification workflow.
 """
 import pandas as pd, numpy as np, json, csv, os, sys, argparse, hashlib, re
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from matchlib import Matcher, norm, eff_year
@@ -213,6 +213,15 @@ for (label_n, src, code), grp in mm.groupby(["label_n", "source", "code"]):
     variants = sorted({str(x) for x in grp["label"].unique()})
     yrs = grp.eff_year.dropna()
     y0, y1 = (int(yrs.min()), int(yrs.max())) if len(yrs) else (None, None)
+    # The GROUPING is (label_n, source, code) but the key omits `code`, so two candidates whose rows
+    # happen to span the same years collide. That is not hypothetical: `ethiopia|iia|None-None`
+    # shipped twice, once for ETH-1907-1936 and once for ETH-1936-1941, one row each -- both spans
+    # None-None because neither row carries a year. The comment above says a duplicate key "silently
+    # corrupts banking, since a key maps to one ledger row and one evidence bundle", and it does:
+    # 23_verdict_carryover.py builds `qstatus` as a dict keyed on `key`, so one of the two was simply
+    # dropped on every run. Disambiguated below, AFTER all entries are built, so that only the
+    # colliding keys change and the other 1,071 keep the names their banked verdicts are filed under
+    # -- renaming everything is exactly the orphaning disease of issue 308.
     key = f"{label_n}|{src}|{y0}-{y1}"
     pm = polmeta.get(code)
     ev = {
@@ -319,6 +328,32 @@ for (label, iso, how), grp in un.groupby([un.label, un.iso.fillna(""), un.status
         "years": (f"{int(yrs.min())}-{int(yrs.max())}" if len(yrs) else None),
         "sources": sorted({str(s) for s in grp.source.unique()}),
     })
+
+# ---------- key uniqueness ----------
+# A key maps to ONE ledger row and ONE evidence bundle, so a collision silently corrupts banking:
+# 23_verdict_carryover.py keys a dict on it and drops the loser. Disambiguate the colliding entries
+# ONLY, by appending the candidate code, so every non-colliding key keeps the name its banked verdict
+# is filed under. Sorted by candidate so the suffix a given entry receives is stable across runs --
+# an unstable suffix would orphan the verdict it was meant to protect on the very next intake.
+_by_key = defaultdict(list)
+for a in assertions:
+    _by_key[a["key"]].append(a)
+for k, group in sorted(_by_key.items()):
+    if len(group) < 2:
+        continue
+    for a in sorted(group, key=lambda a: str(a["candidate"])):
+        a["key"] = f"{k}|{a['candidate']}"
+    print(f"  disambiguated {len(group)} entries sharing key {k!r}: "
+          + ", ".join(a["key"] for a in sorted(group, key=lambda a: a["key"])))
+
+# Hard invariant, not a warning. assertions.json is gitignored, so no CI gate can ever read it --
+# this is the only place the guarantee can live, and a silent pass here is what issue 308 documents.
+_dupes = sorted(k for k, g in Counter(a["key"] for a in assertions).items() if g > 1)
+if _dupes:
+    raise SystemExit(
+        f"{len(_dupes)} assertion key(s) are still not unique after disambiguation: "
+        f"{_dupes[:5]}. A key maps to one ledger row and one evidence bundle, so banking would "
+        f"silently drop one of each pair (issue 308)")
 
 assertions.sort(key=lambda a: -a["rows"])
 counts = pd.Series([a["status"] for a in assertions]).value_counts().to_dict() if assertions else {}

--- a/pipelines/polity-autoimprove/23_verdict_carryover.py
+++ b/pipelines/polity-autoimprove/23_verdict_carryover.py
@@ -42,7 +42,7 @@ import os
 import re
 import sys
 import tempfile
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
@@ -105,7 +105,20 @@ def main() -> int:
     banked = applied_keys()
     q = json.load(open(QUEUE, encoding="utf-8"))
     q = q if isinstance(q, list) else q.get("assertions", [])
-    qstatus = {a.get("key"): str(a.get("status") or "") for a in q if a.get("key")}
+    # A dict keyed on `key` DROPS one entry of every colliding pair, which is not hypothetical:
+    # `ethiopia|iia|None-None` shipped twice with different candidates (ETH-1907-1936 and
+    # ETH-1936-1941) and this line silently discarded one of them on every run. 00_intake.py now
+    # disambiguates collisions and raises if any survive, so reaching this branch means the queue
+    # was produced by an intake predating that fix -- refuse it rather than quietly halving it.
+    _keys = [a["key"] for a in q if a.get("key")]
+    _dupes = sorted(k for k, n in Counter(_keys).items() if n > 1)
+    if _dupes:
+        print(f"FAIL: {len(_dupes)} assertion key(s) appear more than once in "
+              f"{os.path.relpath(QUEUE, REPO)}: {_dupes[:5]}. A key maps to one ledger row and one "
+              f"evidence bundle; carrying verdicts across a non-unique key drops one of each pair "
+              f"(issue 308). Re-run 00_intake.py, which disambiguates them.", file=sys.stderr)
+        return 1
+    qstatus = {a["key"]: str(a.get("status") or "") for a in q if a.get("key")}
 
     by_ls = defaultdict(list)
     for k in qstatus:


### PR DESCRIPTION
#308's second smaller defect — with a live consequence the issue did not name.

The queue groups on `(label_n, source, code)` but builds its key as `label_n|source|y0-y1`, **omitting `code`**. Two candidates whose rows span the same years therefore collide. `ethiopia|iia|None-None` ships twice today — ETH-1907-1936 and ETH-1936-1941, one row each, both spans null because neither row carries a year.

The comment already sitting above that line says a duplicate key *"silently corrupts banking, since a key maps to one ledger row and one evidence bundle"*. It does, and **the corruption is live**:

```python
# 23_verdict_carryover.py
qstatus = {a.get("key"): ... for a in q if a.get("key")}
```

One of the two entries has been discarded on every run since that tool was written.

## Producer

`00_intake.py` disambiguates **after** all entries are built, appending the candidate code to the colliding keys only. Verified against the real queue:

```
keys unchanged : 1071 of 1072
keys renamed   : 2  -> ethiopia|iia|None-None|ETH-1907-1936
                       ethiopia|iia|None-None|ETH-1936-1941
remaining dupes: 0        second pass renames: 0
```

That restraint **is** the fix. Renaming every key is precisely the orphaning disease this issue is about, so a fix that churned the keyspace would cost more than the defect it repairs. Entries sort by candidate so a given entry gets a stable suffix across runs — an unstable suffix would orphan the verdict it exists to protect on the very next intake.

Then a hard invariant: any duplicate surviving disambiguation **raises**. `assertions.json` is gitignored, so no CI gate can ever read it — the generator is the only place this guarantee can live, and a silent pass there is exactly what this issue documents.

## Consumer

`23_verdict_carryover.py` now refuses a queue with duplicate keys instead of halving it. Confirmed it bites on the current file:

```
FAIL: 1 assertion key(s) appear more than once in .../assertions.json:
['ethiopia|iia|None-None'] ... Re-run 00_intake.py, which disambiguates them.
```

**I did not re-run intake to clear it.** Re-running has silently re-banked confirms over hand retractions before, and that trade is not worth making for one row. The guard is there so the next legitimate intake fixes it and no run in between can pretend the queue is clean.

`23_verdict_carryover.py` is not invoked in CI (only its gate is, and that reads the committed CSV), so the new non-zero exit cannot break the build.

**67 gates, 77 selftest cases, all pass.**

*PR opened by Claude.*