### PR TITLE
Index item provenance per raw (label, PRODUCT), not per raw label (#372)

### DIFF
--- a/pipelines/polity-autoimprove/20_item_provenance.py
+++ b/pipelines/polity-autoimprove/20_item_provenance.py
@@ -82,18 +82,60 @@ def norm(s) -> str:
 
 
 def raw_sets(raw_path):
+    """Fingerprint each raw (label, PRODUCT), not each raw label.
+
+    Indexing by label alone unions every product that label carries, and `french syria and lebanon`
+    carries 18. A layer-B `grapes` series could then be scored against values that belong to `wine`
+    or `olive: oil` -- the same class of error as matching a trade tonnage to a production tonnage,
+    which this method already had to correct for once. Per product removes it.
+
+    It also buys a free corroboration the label-level version could not have: the winning raw product
+    can be COMPARED to the layer-B item, and a match that respects commodity identity
+    (`cottonseed` -> cotton seed, `cacao: raw` -> cacao beans) is much harder to produce by chance
+    than one that only respects the numbers. The `product_agrees` column records it.
+
+    Raw product names do NOT resemble layer-B item names -- the raw vocabulary is `grapes: table`,
+    `citrus fruits: oranges, other`, `fertilizers: calcium cyanamide` -- so the comparison is on
+    shared word stems, and disagreement is reported rather than used to reject a match.
+    """
     import pandas as pd
     r = pd.read_excel(raw_path)
     r["c"] = r["country"].astype(str).str.strip().str.lower()
+    r["p"] = r["product"].astype(str).str.strip()
     r["v"] = pd.to_numeric(r["value"], errors="coerce")
     r["y"] = pd.to_numeric(r["year"], errors="coerce")
     r = r[r["variable"].isin(PRODUCTION)].dropna(subset=["v", "y"])
     out = {}
-    for c, g in r.groupby("c"):
+    for (c, prod), g in r.groupby(["c", "p"]):
         s = {(int(x.y), round(float(x.v), 1)) for x in g.itertuples()}
         if len(s) >= MIN_RAW_VALUES:
-            out[c] = s
+            out[(c, prod)] = s
     return out
+
+
+# Words that carry no commodity information, so their overlap must not count as agreement.
+_STOP = {"of", "and", "the", "other", "raw", "total", "true", "n", "e", "c", "in", "shell",
+         "unmanufactured", "green", "dry", "dried", "fibre", "fiber", "beans", "seed", "hen"}
+
+
+def product_agrees(item: str, product: str) -> str:
+    """Do the layer-B item and the winning raw product name a recognisably common commodity?
+
+    Reported, never used to filter: the vocabularies genuinely differ, so a disagreement is a
+    prompt to look rather than grounds to reject. `yes` where a non-stop word stem is shared.
+    """
+    a = {w for w in norm(item).split() if w not in _STOP and len(w) > 2}
+    b = {w for w in norm(product).split() if w not in _STOP and len(w) > 2}
+    if not a or not b:
+        return "unknown"
+    if a & b:
+        return "yes"
+    # stem-prefix match catches cottonseed/cotton, cacao/cacao
+    for x in a:
+        for y in b:
+            if x.startswith(y[:4]) or y.startswith(x[:4]):
+                return "yes"
+    return "no"
 
 
 def measure(panel_path, raw_path):
@@ -111,7 +153,8 @@ def measure(panel_path, raw_path):
             distinct = {v for _y, v in pairs}
             rec = {"layer_b_label": label, "item": item, "unit": unit,
                    "n_values": len(pairs), "n_distinct": len(distinct),
-                   "raw_label": "", "share": "", "status": "", "runner_up": ""}
+                   "raw_label": "", "raw_product": "", "product_agrees": "",
+                   "share": "", "status": "", "runner_up": ""}
             if len(pairs) < MIN_VALUES:
                 rec["status"] = "too_few_values"
             elif len(distinct) < MIN_DISTINCT:
@@ -119,23 +162,33 @@ def measure(panel_path, raw_path):
                 # round values collides with everything. Saying so is the point.
                 rec["status"] = "too_few_distinct"
             else:
-                ranked = sorted(((len(pairs & s) / len(pairs), c) for c, s in raw.items()),
-                                reverse=True)
-                over = [c for sh, c in ranked if sh >= SHARE_FLOOR]
-                if not over:
+                ranked = sorted(((len(pairs & s) / len(pairs), c, prod)
+                                 for (c, prod), s in raw.items()), reverse=True)
+                # Ambiguity is judged on the LABEL, not the (label, product) pair: two products of
+                # one raw label both clearing the floor is not a territorial ambiguity, which is the
+                # only kind this table is about.
+                over_labels = sorted({c for sh, c, _p in ranked if sh >= SHARE_FLOOR})
+                if not over_labels:
                     rec["status"] = "unattributable"
                     if ranked:
-                        rec["runner_up"] = f"{ranked[0][1]}={ranked[0][0]:.2f}"
-                elif len(over) > 1:
+                        rec["runner_up"] = f"{ranked[0][1]}/{ranked[0][2]}={ranked[0][0]:.2f}"
+                elif len(over_labels) > 1:
                     rec["status"] = "ambiguous"
-                    rec["runner_up"] = ";".join(f"{c}={sh:.2f}" for sh, c in ranked[:3]
-                                                if sh >= SHARE_FLOOR)
+                    seen, parts = set(), []
+                    for sh, c, prod in ranked:
+                        if sh >= SHARE_FLOOR and c not in seen:
+                            seen.add(c)
+                            parts.append(f"{c}/{prod}={sh:.2f}")
+                    rec["runner_up"] = ";".join(parts[:3])
                 else:
                     rec["status"] = "attributable"
                     rec["raw_label"] = ranked[0][1]
+                    rec["raw_product"] = ranked[0][2]
+                    rec["product_agrees"] = product_agrees(item, ranked[0][2])
                     rec["share"] = f"{ranked[0][0]:.4f}"
-                    if len(ranked) > 1:
-                        rec["runner_up"] = f"{ranked[1][1]}={ranked[1][0]:.2f}"
+                    nxt = next((r for r in ranked[1:] if r[1] != ranked[0][1]), None)
+                    if nxt:
+                        rec["runner_up"] = f"{nxt[1]}/{nxt[2]}={nxt[0]:.2f}"
             rows.append(rec)
 
     by_label = defaultdict(set)
@@ -181,8 +234,8 @@ def main() -> int:
             print(f"      {c[:42]:44} <- {'; '.join(sorted(items))[:90]}")
 
     if args.write:
-        cols = ["layer_b_label", "item", "unit", "n_values", "n_distinct", "raw_label", "share",
-                "status", "runner_up", "label_is_mixed"]
+        cols = ["layer_b_label", "item", "unit", "n_values", "n_distinct", "raw_label",
+                "raw_product", "product_agrees", "share", "status", "runner_up", "label_is_mixed"]
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -277,10 +277,26 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        asks this per label; a label can be right for one commodity and wrong for
                        another, and the alias key has no item dimension, so no label-level reroute
                        can fix it. 11 labels mix: australia's `p` is CHRISTMAS ISLAND phosphate,
-                       french polynesia's is MAKATEA, syrian arab republic carries Lebanon in COTTON
-                       only, usa's `n` is `usa and canada`. Needs the raw extract AND the panel.
+                       french polynesia's is MAKATEA, usa's `n` is `usa and canada`. Needs the raw
+                       extract AND the panel.
                        THE DISTINCTNESS FILTER IS NOT OPTIONAL: >=6 distinct values, or a few round
                        numbers match anything (unfiltered 43 labels, incl. cameroon <- new zealand).
+                       INDEXED PER RAW (LABEL, PRODUCT) SINCE 2026-08-19, not per raw label. A label
+                       is a union of its products -- `french syria and lebanon` carries 18 -- so a
+                       layer-B `grapes` series could score against values belonging to `wine`, the
+                       same class of error as matching a trade tonnage to a production one. The
+                       stricter index is uniformly more conservative: attributable 804->779,
+                       ambiguous 31->6, unattributable 92->142, and the 11 mixtures survive
+                       unchanged. It also corrected this entry: syrian arab republic carries Lebanon
+                       in GRAPES, ORANGES and TOBACCO as well as cotton, not "cotton only".
+                       It buys a second, independent signal. `raw_product` and `product_agrees`
+                       record whether the winning raw product names the SAME COMMODITY as the
+                       layer-B item -- a match on numbers can be chance, a match that also respects
+                       commodity identity is much harder to fake. 670 of 779 agree, 55 unknown, 54
+                       disagree, and check D of the gate pins that 54 bidirectionally. The
+                       disagreements are informative rather than wrong: `silk worm cocoons reelable`
+                       <- `sericulture` is a vocabulary gap, `flax fibre and tow` <- `linseed`
+                       independently reproduces issue 360's finding from another source.
                        --write refreshes state/item_provenance.csv
 21_item_product_switches.py
                        does one item series draw on several raw PRODUCTS, switching year to year?

--- a/pipelines/polity-autoimprove/state/item_provenance.csv
+++ b/pipelines/polity-autoimprove/state/item_provenance.csv
@@ -1,1919 +1,1919 @@
-layer_b_label,item,unit,n_values,n_distinct,raw_label,share,status,runner_up,label_is_mixed
-australia,butter cow milk,tonnes,7,7,,,too_few_values,,yes
-australia,cheese processed,tonnes,6,6,,,too_few_values,,yes
-australia,coffee green,ha,21,14,australia,1.0000,attributable,portugal=0.24,yes
-australia,coffee green,tonnes,21,17,australia,1.0000,attributable,uruguay=0.19,yes
-australia,cotton lint,ha,33,28,australia,0.8182,attributable,total=0.30,yes
-australia,cotton lint,tonnes,31,29,australia,0.8065,attributable,australia: queensland=0.23,yes
-australia,cotton seed,ha,20,16,australia,0.7000,attributable,total=0.50,yes
-australia,cotton seed,tonnes,20,19,,,unattributable,australia: queensland=0.55,yes
-australia,eggs hen in shell,tonnes,3,2,,,too_few_values,,yes
-australia,flax fibre and tow,ha,24,17,australia,1.0000,attributable,italy=0.33,yes
-australia,flax fibre and tow,tonnes,20,18,australia,1.0000,attributable,new zealand=0.25,yes
-australia,grapes,ha,27,21,australia,1.0000,attributable,total=0.33,yes
-australia,grapes,tonnes,27,27,australia,1.0000,attributable,czechoslovakia=0.07,yes
-australia,groundnuts with shell,ha,16,11,australia,1.0000,attributable,hungary=0.44,yes
-australia,groundnuts with shell,tonnes,15,15,australia,1.0000,attributable,hungary=0.33,yes
-australia,hops,ha,28,18,australia,1.0000,attributable,bulgaria=0.29,yes
-australia,hops,tonnes,28,28,australia,1.0000,attributable,ussr=0.04,yes
-australia,lemons and limes,ha,14,4,,,too_few_distinct,,yes
-australia,lemons and limes,tonnes,15,14,australia,1.0000,attributable,switzerland=0.13,yes
-australia,linseed,ha,6,6,,,too_few_values,,yes
-australia,linseed,tonnes,13,13,australia,1.0000,attributable,yugoslavia=0.00,yes
-australia,milk whole fresh cow,tonnes,7,7,,,too_few_values,,yes
-australia,n,tonnes,15,15,australia,1.0000,attributable,mexico=0.07,yes
-australia,olives,ha,8,4,,,too_few_distinct,,yes
-australia,olives,tonnes,14,9,australia,1.0000,attributable,french algeria=0.43,yes
-australia,oranges,ha,14,7,australia,1.0000,attributable,hungary=0.43,yes
-australia,oranges,tonnes,15,14,australia,1.0000,attributable,total=0.07,yes
-australia,other sugar crops n e c,ha,10,5,,,too_few_distinct,,yes
-australia,other sugar crops n e c,tonnes,14,13,australia,1.0000,attributable,italy=0.29,yes
-australia,p,tonnes,16,16,australian christmas island,1.0000,attributable,yugoslavia=0.00,yes
-australia,raisins,ha,3,3,,,too_few_values,,yes
-australia,raisins,tonnes,15,15,australia,1.0000,attributable,usa: california=0.07,yes
-australia,rye,ha,27,23,australia,1.0000,attributable,egypt=0.26,yes
-australia,rye,tonnes,27,26,australia,1.0000,attributable,british jamaica=0.11,yes
-australia,sugar raw centrifugal,tonnes,33,32,australia,0.9697,attributable,total=0.06,yes
-australia,tobacco unmanufactured,ha,28,21,australia,1.0000,attributable,total=0.29,yes
-australia,tobacco unmanufactured,tonnes,23,23,australia,1.0000,attributable,yugoslavia=0.00,yes
-australia,wine,ha,16,7,australia,1.0000,attributable,total south hemisphere aggregated=0.38,yes
-austria,butter cow milk,tonnes,7,7,,,too_few_values,,yes
-austria,cheese processed,tonnes,7,6,,,too_few_values,,yes
-austria,eggs hen in shell,tonnes,11,11,austria,1.0000,attributable,yugoslavia=0.00,yes
-austria,fertilizer mixed,tonnes,9,9,austria-hungary,0.6667,attributable,austria=0.33,yes
-austria,grapes,tonnes,5,5,,,too_few_values,,yes
-austria,hempseed,tonnes,2,1,,,too_few_values,,yes
-austria,hops,ha,3,3,,,too_few_values,,yes
-austria,milk whole fresh cow,tonnes,7,7,,,too_few_values,,yes
-austria,n,tonnes,14,9,austria-hungary,0.7143,attributable,austria=0.29,yes
-austria,p,tonnes,12,12,austria-hungary,0.6667,attributable,austria=0.33,yes
-austria,silk worm cocoons reelable,tonnes,8,8,austria,1.0000,attributable,yugoslavia=0.00,yes
-austria,soybeans,ha,5,2,,,too_few_values,,yes
-austria,sugar raw centrifugal,tonnes,32,32,austria,1.0000,attributable,total=0.06,yes
-austria,wine,ha,18,15,austria,1.0000,attributable,total=0.22,yes
-austria,wine,tonnes,31,31,,,unattributable,yugoslavia=0.00,yes
-austria,yarn of true hemp,ha,13,9,austria,1.0000,attributable,sweden=0.38,yes
-austria,yarn of true hemp,tonnes,24,21,austria,1.0000,attributable,yugoslavia=0.17,yes
-"china, mainland",beans dry,ha,1,1,,,too_few_values,,yes
-"china, mainland",beans dry,tonnes,2,2,,,too_few_values,,yes
-"china, mainland",castor beans seed,tonnes,4,4,,,too_few_values,,yes
-"china, mainland",cotton lint,ha,18,17,china,0.8889,attributable,usa=0.06,yes
-"china, mainland",cotton seed,ha,18,17,china,0.8889,attributable,usa=0.06,yes
-"china, mainland",cotton seed,tonnes,19,19,china,0.8947,attributable,total south hemisphere aggregated=0.11,yes
-"china, mainland",eggs hen in shell,tonnes,8,8,japan: kwantung leased territory,1.0000,attributable,yugoslavia=0.00,yes
-"china, mainland",flax fibre and tow,ha,1,1,,,too_few_values,,yes
-"china, mainland",flax fibre and tow,tonnes,1,1,,,too_few_values,,yes
-"china, mainland",groundnuts with shell,ha,13,13,,,unattributable,japan: kwantung leased territory=0.54,yes
-"china, mainland",groundnuts with shell,tonnes,3,3,,,too_few_values,,yes
-"china, mainland",hemp tow waste,tonnes,1,1,,,too_few_values,,yes
-"china, mainland",hempseed,ha,2,2,,,too_few_values,,yes
-"china, mainland",hempseed,tonnes,2,2,,,too_few_values,,yes
-"china, mainland",jute,tonnes,1,1,,,too_few_values,,yes
-"china, mainland",linseed,tonnes,1,1,,,too_few_values,,yes
-"china, mainland",n,tonnes,3,3,,,too_few_values,,yes
-"china, mainland",rapeseed,ha,5,5,,,too_few_values,,yes
-"china, mainland",rapeseed,tonnes,15,15,china,1.0000,attributable,yugoslavia=0.00,yes
-"china, mainland",sesame seed,ha,7,7,,,too_few_values,,yes
-"china, mainland",sesame seed,tonnes,15,15,,,unattributable,china=0.53,yes
-"china, mainland",silk worm cocoons reelable,tonnes,12,12,china,1.0000,attributable,yugoslavia=0.00,yes
-"china, mainland",soybeans,ha,12,12,,,unattributable,china=0.25,yes
-"china, mainland",soybeans,tonnes,13,13,,,unattributable,total=0.08,yes
-"china, mainland",tea,tonnes,15,15,china,1.0000,attributable,yugoslavia=0.00,yes
-"china, mainland",tobacco unmanufactured,ha,10,9,china,1.0000,attributable,italy=0.10,yes
-"china, mainland",tobacco unmanufactured,tonnes,1,1,,,too_few_values,,yes
-indonesia,cacao beans,ha,14,8,,,unattributable,total=0.57,yes
-indonesia,cacao beans,tonnes,28,27,,,unattributable,dutch java and madura=0.39,yes
-indonesia,castor beans seed,ha,3,2,,,too_few_values,,yes
-indonesia,castor beans seed,tonnes,2,2,,,too_few_values,,yes
-indonesia,coffee green,ha,16,16,,,unattributable,dutch east indies=0.19,yes
-indonesia,cotton lint,ha,21,20,dutch east indies,0.8571,attributable,hungary=0.29,yes
-indonesia,cotton lint,tonnes,29,27,dutch east indies,0.6552,attributable,dutch java and madura=0.21,yes
-indonesia,cotton seed,ha,11,10,dutch east indies,0.7273,attributable,hungary=0.55,yes
-indonesia,cotton seed,tonnes,18,17,,,unattributable,dutch east indies=0.56,yes
-indonesia,fertilizer mixed,tonnes,4,4,,,too_few_values,,yes
-indonesia,groundnuts with shell,ha,16,16,dutch java and madura,0.8750,attributable,total=0.12,yes
-indonesia,p,tonnes,12,12,dutch east indies,1.0000,attributable,peru=0.08,yes
-indonesia,rubber natural,ha,10,10,,,unattributable,dutch java and madura=0.20,yes
-indonesia,sesame seed,ha,12,10,dutch east indies,0.8333,attributable,yugoslavia=0.25,yes
-indonesia,sesame seed,tonnes,12,9,dutch east indies,1.0000,attributable,australia=0.25,yes
-indonesia,soybeans,ha,12,12,dutch java and madura,0.8333,attributable,total=0.17,yes
-indonesia,soybeans,tonnes,11,11,dutch java and madura,0.8182,attributable,total south hemisphere aggregated=0.09,yes
-indonesia,sugar raw centrifugal,tonnes,33,33,dutch java and madura,1.0000,attributable,switzerland=0.03,yes
-indonesia,tea,ha,17,13,,,unattributable,dutch east indies=0.53,yes
-indonesia,tobacco unmanufactured,ha,21,19,,,unattributable,dutch east indies=0.57,yes
-indonesia,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,yes
-malaysia,coffee green,ha,23,19,,,unattributable,british federated malay states=0.52,yes
-malaysia,coffee green,tonnes,14,14,british federated malay states,0.9286,attributable,hungary=0.07,yes
-malaysia,rubber natural,ha,8,5,,,too_few_distinct,,yes
-malaysia,tea,ha,10,8,,,ambiguous,british malaya=1.00;egypt=0.60,yes
-malaysia,tea,tonnes,6,6,,,too_few_values,,yes
-malaysia,tobacco unmanufactured,ha,19,15,british borneo,0.8947,attributable,french tonkin=0.37,yes
-malaysia,tobacco unmanufactured,tonnes,16,16,british borneo,1.0000,attributable,spanish fernando po=0.06,yes
-niger,cotton lint,ha,11,11,french west africa,0.6364,attributable,french niger=0.36,yes
-niger,cotton lint,tonnes,17,17,french west africa,0.7647,attributable,french niger=0.24,yes
-niger,cotton seed,ha,11,11,french west africa,0.6364,attributable,french niger=0.36,yes
-niger,cotton seed,tonnes,15,15,french west africa,0.7333,attributable,french niger=0.27,yes
-niger,eggs hen in shell,tonnes,9,6,french niger,1.0000,attributable,yugoslavia=0.00,yes
-niger,groundnuts with shell,ha,15,14,french niger,1.0000,attributable,total general excluding the ussr=0.13,yes
-niger,groundnuts with shell,tonnes,1,1,,,too_few_values,,yes
-niger,sesame seed,ha,7,4,,,too_few_values,,yes
-niger,sesame seed,tonnes,1,1,,,too_few_values,,yes
-niger,tobacco unmanufactured,ha,13,5,,,too_few_distinct,,yes
-niger,tobacco unmanufactured,tonnes,15,14,french niger,1.0000,attributable,total=0.13,yes
-papua new guinea,cacao beans,ha,15,11,dutch new guinea,1.0000,attributable,french algeria=0.40,yes
-papua new guinea,cacao beans,tonnes,9,8,dutch new guinea,1.0000,attributable,us puerto rico=0.44,yes
-papua new guinea,coffee green,ha,5,5,,,too_few_values,,yes
-papua new guinea,rubber natural,ha,4,2,,,too_few_values,,yes
-papua new guinea,tobacco unmanufactured,ha,8,7,australian papua and new guinea,1.0000,attributable,british mauritius=0.12,yes
-papua new guinea,tobacco unmanufactured,tonnes,5,5,,,too_few_values,,yes
-russian federation,beans dry,ha,1,1,,,too_few_values,,yes
-russian federation,castor beans seed,tonnes,1,1,,,too_few_values,,yes
-russian federation,cotton lint,ha,22,21,,,unattributable,ussr=0.50,yes
-russian federation,cotton lint,tonnes,22,22,,,unattributable,ussr=0.50,yes
-russian federation,cotton seed,ha,15,14,ussr,0.7333,attributable,ussr in asia=0.27,yes
-russian federation,cotton seed,tonnes,15,15,ussr,0.7333,attributable,ussr in asia=0.27,yes
-russian federation,eggs hen in shell,tonnes,7,7,,,too_few_values,,yes
-russian federation,fertilizer mixed,tonnes,1,1,,,too_few_values,,yes
-russian federation,flax fibre and tow,ha,26,26,,,unattributable,ussr=0.31,yes
-russian federation,flax fibre and tow,tonnes,20,20,,,unattributable,ussr=0.35,yes
-russian federation,grapes,ha,7,7,,,too_few_values,,yes
-russian federation,grapes,tonnes,3,3,,,too_few_values,,yes
-russian federation,groundnuts with shell,ha,6,6,,,too_few_values,,yes
-russian federation,groundnuts with shell,tonnes,1,1,,,too_few_values,,yes
-russian federation,hemp tow waste,ha,12,12,,,unattributable,ussr=0.08,yes
-russian federation,hemp tow waste,tonnes,2,2,,,too_few_values,,yes
-russian federation,hempseed,ha,14,14,ussr,0.7143,attributable,ussr in europe=0.29,yes
-russian federation,hempseed,tonnes,19,16,,,unattributable,ussr=0.42,yes
-russian federation,hops,tonnes,7,7,,,too_few_values,,yes
-russian federation,k,tonnes,2,2,,,too_few_values,,yes
-russian federation,linseed,ha,8,8,,,unattributable,ussr in europe=0.50,yes
-russian federation,linseed,tonnes,15,15,,,unattributable,ussr in europe=0.27,yes
-russian federation,n,tonnes,9,9,russia,0.6667,attributable,ussr=0.33,yes
-russian federation,oats,ha,1,1,,,too_few_values,,yes
-russian federation,oranges,ha,8,5,,,too_few_distinct,,yes
-russian federation,oranges,tonnes,7,7,,,too_few_values,,yes
-russian federation,p,tonnes,12,11,russia,0.6667,attributable,yugoslavia=0.00,yes
-russian federation,rapeseed,ha,12,12,,,unattributable,ussr=0.33,yes
-russian federation,rapeseed,tonnes,9,9,,,unattributable,japan: karafuto prefecture=0.44,yes
-russian federation,rye,ha,31,31,ussr,0.6452,attributable,total=0.19,yes
-russian federation,rye,tonnes,28,28,ussr,0.6429,attributable,total=0.11,yes
-russian federation,sesame seed,ha,9,9,ussr,1.0000,attributable,italy=0.33,yes
-russian federation,sesame seed,tonnes,5,5,,,too_few_values,,yes
-russian federation,silk worm cocoons reelable,tonnes,16,16,ussr,0.6250,attributable,russia in asia=0.19,yes
-russian federation,soybeans,ha,9,9,,,unattributable,ussr=0.56,yes
-russian federation,soybeans,tonnes,5,5,,,too_few_values,,yes
-russian federation,sugar raw centrifugal,tonnes,23,23,,,unattributable,ussr=0.48,yes
-russian federation,tea,ha,6,6,,,too_few_values,,yes
-russian federation,tea,tonnes,6,6,,,too_few_values,,yes
-russian federation,tobacco unmanufactured,ha,21,20,ussr,0.6190,attributable,usa: california=0.05,yes
-russian federation,tobacco unmanufactured,tonnes,17,17,,,unattributable,ussr=0.53,yes
-russian federation,wheat,ha,6,6,,,too_few_values,,yes
-russian federation,wheat,tonnes,2,2,,,too_few_values,,yes
-russian federation,wine,ha,6,5,,,too_few_values,,yes
-russian federation,wine,tonnes,3,2,,,too_few_values,,yes
-russian federation,yarn of true hemp,ha,13,13,ussr,0.6923,attributable,ussr in europe=0.31,yes
-russian federation,yarn of true hemp,tonnes,21,20,,,unattributable,ussr=0.33,yes
-syrian arab republic,beans dry,ha,8,3,,,too_few_distinct,,yes
-syrian arab republic,beans dry,tonnes,9,7,french syria,0.7778,attributable,british montserrat=0.56,yes
-syrian arab republic,butter cow milk,tonnes,7,3,,,too_few_values,,yes
-syrian arab republic,cheese processed,tonnes,7,4,,,too_few_values,,yes
-syrian arab republic,cotton lint,ha,19,19,french syria and lebanon,0.6316,attributable,french syria=0.47,yes
-syrian arab republic,cotton lint,tonnes,19,19,french syria and lebanon,0.6842,attributable,french syria=0.32,yes
-syrian arab republic,cotton seed,ha,19,19,french syria and lebanon,0.6316,attributable,french syria=0.47,yes
-syrian arab republic,cotton seed,tonnes,19,19,french syria and lebanon,0.6316,attributable,french syria=0.37,yes
-syrian arab republic,eggs hen in shell,tonnes,14,14,,,unattributable,french syria and lebanon=0.57,yes
-syrian arab republic,grapes,ha,16,16,,,unattributable,french syria and lebanon=0.56,yes
-syrian arab republic,grapes,tonnes,9,9,french syria and lebanon,1.0000,attributable,turkey=0.11,yes
-syrian arab republic,groundnuts with shell,tonnes,1,1,,,too_few_values,,yes
-syrian arab republic,hemp tow waste,ha,7,4,,,too_few_values,,yes
-syrian arab republic,hemp tow waste,tonnes,7,7,,,too_few_values,,yes
-syrian arab republic,hempseed,ha,16,13,french syria,0.9375,attributable,french syria and lebanon=0.44,yes
-syrian arab republic,hempseed,tonnes,18,16,french syria,0.7222,attributable,italy=0.39,yes
-syrian arab republic,milk whole fresh cow,tonnes,4,4,,,too_few_values,,yes
-syrian arab republic,oats,ha,7,3,,,too_few_values,,yes
-syrian arab republic,oats,tonnes,7,7,,,too_few_values,,yes
-syrian arab republic,oil olive virgin,tonnes,4,4,,,too_few_values,,yes
-syrian arab republic,olives,ha,17,13,,,unattributable,french syria and lebanon=0.59,yes
-syrian arab republic,olives,tonnes,18,18,,,unattributable,french syria=0.39,yes
-syrian arab republic,oranges,ha,9,6,french syria and lebanon,1.0000,attributable,italy=0.56,yes
-syrian arab republic,oranges,tonnes,13,13,french syria and lebanon,0.6923,attributable,french syria=0.31,yes
-syrian arab republic,other berries and fruits of the genus vaccinium n e c,ha,5,5,,,too_few_values,,yes
-syrian arab republic,other berries and fruits of the genus vaccinium n e c,tonnes,5,5,,,too_few_values,,yes
-syrian arab republic,raisins,tonnes,3,3,,,too_few_values,,yes
-syrian arab republic,sesame seed,ha,20,12,,,unattributable,french syria and lebanon=0.45,yes
-syrian arab republic,sesame seed,tonnes,20,17,,,unattributable,french syria and lebanon=0.45,yes
-syrian arab republic,silk worm cocoons reelable,tonnes,20,20,french syria and lebanon,0.6500,attributable,french syria=0.35,yes
-syrian arab republic,tobacco unmanufactured,ha,16,10,french syria and lebanon,0.6875,attributable,hungary=0.44,yes
-syrian arab republic,tobacco unmanufactured,tonnes,16,16,french syria and lebanon,0.6875,attributable,french syria=0.31,yes
-syrian arab republic,wine,ha,3,2,,,too_few_values,,yes
-syrian arab republic,wine,tonnes,13,12,,,unattributable,yugoslavia=0.00,yes
-syrian arab republic,yarn of true hemp,ha,11,10,french syria,1.0000,attributable,french syria and lebanon=0.55,yes
-syrian arab republic,yarn of true hemp,tonnes,10,10,french syria,0.9000,attributable,yugoslavia=0.20,yes
-timor-leste,cacao beans,tonnes,8,8,portuguese timor,1.0000,attributable,yugoslavia=0.00,yes
-timor-leste,coffee green,tonnes,9,8,portuguese timor and kambing,1.0000,attributable,siam=0.33,yes
-united states of america,cacao beans,tonnes,1,1,,,too_few_values,,yes
-united states of america,cheese processed,tonnes,7,7,,,too_few_values,,yes
-united states of america,coffee green,ha,28,25,,,unattributable,us puerto rico=0.36,yes
-united states of america,coffee green,tonnes,29,28,,,unattributable,us puerto rico=0.21,yes
-united states of america,cotton lint,ha,1,1,,,too_few_values,,yes
-united states of america,cotton seed,ha,20,20,,,unattributable,usa=0.55,yes
-united states of america,cotton seed,tonnes,1,1,,,too_few_values,,yes
-united states of america,eggs hen in shell,tonnes,17,17,usa,0.7059,attributable,yugoslavia=0.00,yes
-united states of america,fertilizer mixed,tonnes,17,17,usa,1.0000,attributable,yugoslavia=0.00,yes
-united states of america,flax fibre and tow,ha,1,1,,,too_few_values,,yes
-united states of america,flax fibre and tow,tonnes,6,6,,,too_few_values,,yes
-united states of america,hemp tow waste,ha,5,5,,,too_few_values,,yes
-united states of america,k,tonnes,4,4,,,too_few_values,,yes
-united states of america,milk whole fresh cow,tonnes,1,1,,,too_few_values,,yes
-united states of america,n,tonnes,17,12,usa and canada,0.7647,attributable,usa=0.35,yes
-united states of america,p,tonnes,17,17,usa,1.0000,attributable,yugoslavia=0.00,yes
-united states of america,raisins,ha,3,3,,,too_few_values,,yes
-united states of america,raisins,tonnes,16,15,usa,1.0000,attributable,total=0.06,yes
-united states of america,sugar raw centrifugal,tonnes,33,33,,,unattributable,usa=0.39,yes
-united states of america,wine,ha,7,6,,,too_few_values,,yes
-united states of america,wine,tonnes,13,13,,,unattributable,yugoslavia=0.00,yes
-united states of america,yarn of true hemp,ha,1,1,,,too_few_values,,yes
-united states of america,yarn of true hemp,tonnes,3,3,,,too_few_values,,yes
-albania,beans dry,tonnes,1,1,,,too_few_values,,no
-albania,eggs hen in shell,tonnes,6,3,,,too_few_values,,no
-albania,rye,ha,1,1,,,too_few_values,,no
-algeria,beans dry,ha,11,2,,,too_few_distinct,,no
-algeria,beans dry,tonnes,13,4,,,too_few_distinct,,no
-algeria,cotton lint,ha,24,20,french algeria,1.0000,attributable,british‑french cameroon=0.29,no
-algeria,cotton lint,tonnes,25,20,french algeria,1.0000,attributable,british cyprus=0.36,no
-algeria,cotton seed,ha,16,12,french algeria,1.0000,attributable,british‑french cameroon=0.44,no
-algeria,cotton seed,tonnes,17,12,french algeria,1.0000,attributable,british cyprus=0.47,no
-algeria,flax fibre and tow,ha,18,18,french algeria,1.0000,attributable,british jamaica=0.17,no
-algeria,flax fibre and tow,tonnes,5,5,,,too_few_values,,no
-algeria,grapes,ha,24,23,french algeria,1.0000,attributable,total=0.08,no
-algeria,grapes,tonnes,10,10,french algeria,1.0000,attributable,uk=0.10,no
-algeria,groundnuts with shell,ha,3,3,,,too_few_values,,no
-algeria,groundnuts with shell,tonnes,3,3,,,too_few_values,,no
-algeria,lemons and limes,ha,7,2,,,too_few_values,,no
-algeria,lemons and limes,tonnes,11,11,french algeria,1.0000,attributable,italy=0.27,no
-algeria,linseed,ha,5,5,,,too_few_values,,no
-algeria,linseed,tonnes,18,18,french algeria,1.0000,attributable,japanese taiwan=0.06,no
-algeria,n,tonnes,1,1,,,too_few_values,,no
-algeria,oats,tonnes,1,1,,,too_few_values,,no
-algeria,oil olive virgin,tonnes,2,2,,,too_few_values,,no
-algeria,olives,ha,15,13,french algeria,1.0000,attributable,total=0.27,no
-algeria,olives,tonnes,28,28,french algeria,1.0000,attributable,greece=0.04,no
-algeria,oranges,ha,14,9,french algeria,1.0000,attributable,french annam=0.50,no
-algeria,oranges,tonnes,14,14,french algeria,1.0000,attributable,yugoslavia=0.07,no
-algeria,other berries and fruits of the genus vaccinium n e c,ha,2,1,,,too_few_values,,no
-algeria,other sugar crops n e c,ha,3,3,,,too_few_values,,no
-algeria,other sugar crops n e c,tonnes,3,3,,,too_few_values,,no
-algeria,p,tonnes,17,17,french algeria,1.0000,attributable,total=0.06,no
-algeria,rye,ha,33,20,french algeria,1.0000,attributable,british cyprus=0.36,no
-algeria,rye,tonnes,33,28,french algeria,1.0000,attributable,austria=0.21,no
-algeria,silk worm cocoons reelable,tonnes,14,12,french algeria,1.0000,attributable,british cyprus=0.21,no
-algeria,tangerines mandarins clementines satsumas,ha,14,5,,,too_few_distinct,,no
-algeria,tangerines mandarins clementines satsumas,tonnes,14,13,french algeria,1.0000,attributable,total=0.36,no
-algeria,tobacco unmanufactured,ha,33,31,french algeria,1.0000,attributable,italy=0.21,no
-algeria,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-algeria,wine,ha,20,19,french algeria,1.0000,attributable,total=0.15,no
-algeria,wine,tonnes,1,1,,,too_few_values,,no
-american samoa,tobacco unmanufactured,ha,5,4,,,too_few_values,,no
-american samoa,tobacco unmanufactured,tonnes,5,4,,,too_few_values,,no
-angola,beans dry,ha,9,9,portuguese angola,1.0000,attributable,total=0.33,no
-angola,beans dry,tonnes,12,12,portuguese angola,1.0000,attributable,uruguay=0.08,no
-angola,castor beans seed,tonnes,7,6,,,too_few_values,,no
-angola,coffee green,ha,11,8,portuguese angola,1.0000,attributable,french morocco=0.27,no
-angola,cotton lint,ha,11,10,portuguese angola,1.0000,attributable,dutch east indies=0.27,no
-angola,cotton lint,tonnes,14,11,portuguese angola,1.0000,attributable,total=0.29,no
-angola,cotton seed,ha,11,10,portuguese angola,1.0000,attributable,dutch east indies=0.27,no
-angola,cotton seed,tonnes,14,13,portuguese angola,1.0000,attributable,italian dodecanese islands=0.14,no
-angola,groundnuts with shell,ha,11,8,portuguese angola,1.0000,attributable,spain=0.45,no
-angola,groundnuts with shell,tonnes,14,13,portuguese angola,1.0000,attributable,union of south africa=0.21,no
-angola,sesame seed,ha,10,6,,,ambiguous,portuguese angola=1.00;french tonkin=0.70;british cyprus=0.70,no
-angola,sesame seed,tonnes,14,12,portuguese angola,1.0000,attributable,british cyprus=0.43,no
-angola,sugar raw centrifugal,tonnes,15,15,portuguese angola,1.0000,attributable,us philippines=0.07,no
-angola,tobacco unmanufactured,ha,11,6,,,ambiguous,portuguese angola=1.00;spain=0.64;hungary=0.64,no
-angola,tobacco unmanufactured,tonnes,14,14,portuguese angola,1.0000,attributable,yugoslavia=0.00,no
-antigua and barbuda,cotton lint,ha,25,20,british antigua,1.0000,attributable,netherlands=0.32,no
-antigua and barbuda,cotton lint,tonnes,23,18,british antigua,1.0000,attributable,french guadeloupe and dependencies: marie‑galante=0.26,no
-antigua and barbuda,cotton seed,ha,14,10,british antigua,1.0000,attributable,french morocco=0.50,no
-antigua and barbuda,cotton seed,tonnes,13,12,british antigua,1.0000,attributable,british dominica=0.31,no
-antigua and barbuda,sugar raw centrifugal,tonnes,30,30,british antigua,1.0000,attributable,total=0.03,no
-argentina,beans dry,ha,1,1,,,too_few_values,,no
-argentina,castor beans seed,ha,6,5,,,too_few_values,,no
-argentina,castor beans seed,tonnes,6,6,,,too_few_values,,no
-argentina,cheese processed,tonnes,6,6,,,too_few_values,,no
-argentina,coffee green,ha,1,1,,,too_few_values,,no
-argentina,cotton lint,ha,1,1,,,too_few_values,,no
-argentina,cotton seed,ha,20,20,argentina,1.0000,attributable,total south hemisphere aggregated=0.05,no
-argentina,cotton seed,tonnes,2,2,,,too_few_values,,no
-argentina,flax fibre and tow,ha,1,1,,,too_few_values,,no
-argentina,flax fibre and tow,tonnes,13,13,argentina,1.0000,attributable,yugoslavia=0.00,no
-argentina,grapes,tonnes,6,6,,,too_few_values,,no
-argentina,oil olive virgin,tonnes,7,3,,,too_few_values,,no
-argentina,olives,tonnes,1,1,,,too_few_values,,no
-argentina,raisins,tonnes,8,8,argentina,1.0000,attributable,total=0.25,no
-argentina,rapeseed,ha,1,1,,,too_few_values,,no
-argentina,rapeseed,tonnes,1,1,,,too_few_values,,no
-argentina,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-argentina,wine,ha,1,1,,,too_few_values,,no
-argentina,wine,tonnes,1,1,,,too_few_values,,no
-azerbaijan,tea,ha,11,11,ussr: transcaucasian sfsr,1.0000,attributable,italy=0.18,no
-azerbaijan,tea,tonnes,10,10,ussr: transcaucasian sfsr,1.0000,attributable,british trinidad and tobago=0.10,no
-barbados,cotton lint,ha,24,20,british barbados,1.0000,attributable,british malta=0.25,no
-barbados,cotton lint,tonnes,23,19,british barbados,1.0000,attributable,sweden=0.22,no
-barbados,cotton seed,ha,12,8,british barbados,1.0000,attributable,british malta=0.50,no
-barbados,cotton seed,tonnes,16,9,british barbados,1.0000,attributable,british cyprus=0.56,no
-barbados,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-belgium,butter cow milk,tonnes,5,5,,,too_few_values,,no
-belgium,eggs hen in shell,tonnes,16,14,belgium,1.0000,attributable,yugoslavia=0.00,no
-belgium,fertilizer mixed,tonnes,4,4,,,too_few_values,,no
-belgium,flax fibre and tow,tonnes,1,1,,,too_few_values,,no
-belgium,grapes,ha,4,1,,,too_few_values,,no
-belgium,hempseed,ha,10,6,,,ambiguous,belgium=1.00;british malta=0.60,no
-belgium,hempseed,tonnes,5,1,,,too_few_values,,no
-belgium,milk whole fresh cow,tonnes,6,6,,,too_few_values,,no
-belgium,n,tonnes,16,16,belgium,1.0000,attributable,usa and canada=0.06,no
-belgium,p,tonnes,17,16,belgium,1.0000,attributable,yugoslavia=0.00,no
-belgium,rapeseed,ha,8,4,,,too_few_distinct,,no
-belgium,rapeseed,tonnes,1,1,,,too_few_values,,no
-belgium,sugar raw centrifugal,tonnes,33,33,belgium,1.0000,attributable,total=0.03,no
-belgium,yarn of true hemp,ha,13,9,belgium,1.0000,attributable,british malta=0.46,no
-belgium,yarn of true hemp,tonnes,13,9,belgium,1.0000,attributable,british saint vincent=0.38,no
-belize,cacao beans,tonnes,8,8,british honduras,1.0000,attributable,yugoslavia=0.00,no
-belize,grapefruit inc pomelos,ha,3,2,,,too_few_values,,no
-belize,grapefruit inc pomelos,tonnes,11,7,,,ambiguous,british honduras=1.00;france=0.64;british saint lucia=0.64,no
-benin,cacao beans,ha,7,5,,,too_few_values,,no
-benin,cacao beans,tonnes,7,3,,,too_few_values,,no
-benin,coffee green,ha,7,2,,,too_few_values,,no
-benin,coffee green,tonnes,5,4,,,too_few_values,,no
-benin,cotton lint,ha,4,4,,,too_few_values,,no
-benin,cotton lint,tonnes,4,3,,,too_few_values,,no
-benin,cotton seed,ha,4,4,,,too_few_values,,no
-benin,cotton seed,tonnes,4,3,,,too_few_values,,no
-benin,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-benin,groundnuts with shell,ha,15,14,french dahomey,1.0000,attributable,total=0.47,no
-benin,groundnuts with shell,tonnes,15,14,french dahomey,1.0000,attributable,total=0.27,no
-benin,tobacco unmanufactured,ha,12,6,,,ambiguous,french dahomey=1.00;french morocco=0.75;french mauritania=0.75,no
-benin,tobacco unmanufactured,tonnes,15,12,french dahomey,1.0000,attributable,australia=0.40,no
-bermuda,eggs hen in shell,tonnes,16,6,british bermuda,1.0000,attributable,french oceania=0.19,no
-bolivia,cacao beans,ha,1,1,,,too_few_values,,no
-bolivia,cacao beans,tonnes,1,1,,,too_few_values,,no
-bolivia,cotton lint,tonnes,2,2,,,too_few_values,,no
-bolivia,flax fibre and tow,tonnes,1,1,,,too_few_values,,no
-botswana,eggs hen in shell,tonnes,5,5,,,too_few_values,,no
-brazil,cacao beans,ha,9,7,brazil,1.0000,attributable,portugal=0.22,no
-brazil,cacao beans,tonnes,12,11,brazil,1.0000,attributable,total=0.17,no
-brazil,castor beans seed,tonnes,7,7,,,too_few_values,,no
-brazil,coffee green,ha,2,2,,,too_few_values,,no
-brazil,cotton lint,ha,2,2,,,too_few_values,,no
-brazil,cotton seed,ha,20,19,brazil,1.0000,attributable,ussr=0.05,no
-brazil,cotton seed,tonnes,1,1,,,too_few_values,,no
-brazil,grapes,tonnes,1,1,,,too_few_values,,no
-brazil,rye,ha,1,1,,,too_few_values,,no
-brazil,silk worm cocoons reelable,tonnes,2,2,,,too_few_values,,no
-brazil,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-brazil,sunflower seed,ha,2,2,,,too_few_values,,no
-brazil,sunflower seed,tonnes,2,2,,,too_few_values,,no
-brazil,tea,tonnes,1,1,,,too_few_values,,no
-brazil,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-brazil,wine,ha,2,2,,,too_few_values,,no
-british virgin islands,cotton lint,ha,4,2,,,too_few_values,,no
-british virgin islands,cotton lint,tonnes,15,15,british virgin islands,1.0000,attributable,switzerland=0.07,no
-british virgin islands,cotton seed,ha,4,2,,,too_few_values,,no
-british virgin islands,cotton seed,tonnes,4,3,,,too_few_values,,no
-brunei darussalam,eggs hen in shell,tonnes,6,3,,,too_few_values,,no
-brunei darussalam,rubber natural,ha,9,8,,,unattributable,british brunei=0.33,no
-brunei darussalam,rubber natural,tonnes,3,3,,,too_few_values,,no
-bulgaria,butter cow milk,tonnes,7,3,,,too_few_values,,no
-bulgaria,cheese processed,tonnes,7,7,,,too_few_values,,no
-bulgaria,cotton lint,ha,33,32,bulgaria,1.0000,attributable,australia=0.15,no
-bulgaria,cotton seed,ha,20,19,bulgaria,1.0000,attributable,australia=0.25,no
-bulgaria,cotton seed,tonnes,20,20,bulgaria,1.0000,attributable,france=0.15,no
-bulgaria,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-bulgaria,groundnuts with shell,ha,3,3,,,too_few_values,,no
-bulgaria,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-bulgaria,hops,ha,7,3,,,too_few_values,,no
-bulgaria,hops,tonnes,9,7,bulgaria,1.0000,attributable,british mauritius=0.11,no
-bulgaria,other berries and fruits of the genus vaccinium n e c,ha,19,10,bulgaria,1.0000,attributable,italy=0.53,no
-bulgaria,other berries and fruits of the genus vaccinium n e c,tonnes,18,18,bulgaria,1.0000,attributable,france=0.06,no
-bulgaria,rapeseed,ha,1,1,,,too_few_values,,no
-bulgaria,rye,tonnes,4,4,,,too_few_values,,no
-bulgaria,silk worm cocoons reelable,tonnes,33,32,bulgaria,1.0000,attributable,french lebanon=0.03,no
-bulgaria,soybeans,ha,4,3,,,too_few_values,,no
-bulgaria,sugar raw centrifugal,tonnes,33,33,bulgaria,1.0000,attributable,netherlands=0.09,no
-bulgaria,wine,ha,20,16,bulgaria,1.0000,attributable,total=0.20,no
-bulgaria,wine,tonnes,33,33,,,unattributable,yugoslavia=0.00,no
-bulgaria,yarn of true hemp,ha,13,12,bulgaria,1.0000,attributable,uk: northern ireland=0.23,no
-bulgaria,yarn of true hemp,tonnes,26,26,bulgaria,1.0000,attributable,uk: northern ireland=0.04,no
-burkina faso,cotton lint,ha,5,5,,,too_few_values,,no
-burkina faso,cotton lint,tonnes,5,5,,,too_few_values,,no
-burkina faso,cotton seed,ha,5,5,,,too_few_values,,no
-burkina faso,cotton seed,tonnes,5,5,,,too_few_values,,no
-burkina faso,eggs hen in shell,tonnes,4,4,,,too_few_values,,no
-burkina faso,groundnuts with shell,ha,6,6,,,too_few_values,,no
-burkina faso,groundnuts with shell,tonnes,7,7,,,too_few_values,,no
-burkina faso,sesame seed,ha,3,2,,,too_few_values,,no
-burkina faso,sesame seed,tonnes,5,3,,,too_few_values,,no
-burkina faso,tobacco unmanufactured,ha,3,3,,,too_few_values,,no
-burkina faso,tobacco unmanufactured,tonnes,3,3,,,too_few_values,,no
-burundi,cotton lint,ha,8,6,belgian ruanda-urundi,1.0000,attributable,hungary=0.50,no
-burundi,cotton lint,tonnes,8,7,belgian ruanda-urundi,1.0000,attributable,british cyprus=0.38,no
-burundi,cotton seed,ha,8,6,belgian ruanda-urundi,1.0000,attributable,hungary=0.50,no
-burundi,cotton seed,tonnes,7,7,,,too_few_values,,no
-burundi,groundnuts with shell,ha,7,6,,,too_few_values,,no
-burundi,groundnuts with shell,tonnes,7,7,,,too_few_values,,no
-burundi,tobacco unmanufactured,ha,7,5,,,too_few_values,,no
-burundi,tobacco unmanufactured,tonnes,7,6,,,too_few_values,,no
-cabo verde,beans dry,ha,4,2,,,too_few_values,,no
-cabo verde,beans dry,tonnes,6,5,,,too_few_values,,no
-cabo verde,coffee green,ha,3,3,,,too_few_values,,no
-cabo verde,coffee green,tonnes,5,2,,,too_few_values,,no
-cabo verde,oranges,tonnes,5,5,,,too_few_values,,no
-cabo verde,sugar raw centrifugal,tonnes,8,4,,,too_few_distinct,,no
-cabo verde,tobacco unmanufactured,tonnes,5,5,,,too_few_values,,no
-cambodia,beans dry,tonnes,3,2,,,too_few_values,,no
-cambodia,silk worm cocoons reelable,tonnes,1,1,,,too_few_values,,no
-cameroon,cacao beans,ha,15,7,british‑french cameroon,1.0000,attributable,total=0.53,no
-cameroon,coffee green,ha,7,1,,,too_few_values,,no
-cameroon,cotton lint,ha,5,1,,,too_few_values,,no
-cameroon,cotton lint,tonnes,4,1,,,too_few_values,,no
-cameroon,cotton seed,ha,12,1,,,too_few_distinct,,no
-cameroon,cotton seed,tonnes,11,2,,,too_few_distinct,,no
-cameroon,groundnuts with shell,ha,10,10,british‑french cameroon,1.0000,attributable,total=0.40,no
-cameroon,groundnuts with shell,tonnes,2,2,,,too_few_values,,no
-cameroon,rubber natural,ha,13,12,,,unattributable,french cameroon=0.54,no
-cameroon,sesame seed,ha,17,12,british‑french cameroon,1.0000,attributable,total=0.47,no
-cameroon,sesame seed,tonnes,17,14,british‑french cameroon,1.0000,attributable,austria=0.24,no
-cameroon,tobacco unmanufactured,ha,4,1,,,too_few_values,,no
-cameroon,tobacco unmanufactured,tonnes,3,3,,,too_few_values,,no
-canada,cheese processed,tonnes,7,7,,,too_few_values,,no
-canada,eggs hen in shell,tonnes,17,17,canada,0.6471,attributable,yugoslavia=0.00,no
-canada,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-canada,n,tonnes,12,12,canada,1.0000,attributable,yugoslavia=0.00,no
-canada,p,tonnes,17,16,canada,1.0000,attributable,portugal=0.06,no
-canada,sugar raw centrifugal,tonnes,32,32,canada,1.0000,attributable,portuguese mozambique=0.03,no
-canada,wine,tonnes,14,14,,,unattributable,yugoslavia=0.00,no
-central african republic,cacao beans,ha,2,2,,,too_few_values,,no
-central african republic,cacao beans,tonnes,2,2,,,too_few_values,,no
-central african republic,groundnuts with shell,ha,3,3,,,too_few_values,,no
-central african republic,groundnuts with shell,tonnes,3,3,,,too_few_values,,no
-chad,groundnuts with shell,ha,3,3,,,too_few_values,,no
-chad,groundnuts with shell,tonnes,3,3,,,too_few_values,,no
-chile,beans dry,ha,2,2,,,too_few_values,,no
-chile,eggs hen in shell,tonnes,9,8,chile,1.0000,attributable,yugoslavia=0.00,no
-chile,fertilizer mixed,tonnes,14,14,chile,1.0000,attributable,yugoslavia=0.00,no
-chile,flax fibre and tow,ha,4,4,,,too_few_values,,no
-chile,flax fibre and tow,tonnes,5,5,,,too_few_values,,no
-chile,grapes,tonnes,6,6,,,too_few_values,,no
-chile,hemp tow waste,ha,3,3,,,too_few_values,,no
-chile,hemp tow waste,tonnes,1,1,,,too_few_values,,no
-chile,hempseed,ha,1,1,,,too_few_values,,no
-chile,hempseed,tonnes,2,2,,,too_few_values,,no
-chile,n,tonnes,4,4,,,too_few_values,,no
-chile,no3,tonnes,13,13,chile,1.0000,attributable,yugoslavia=0.00,no
-chile,oil olive virgin,tonnes,1,1,,,too_few_values,,no
-chile,olives,ha,1,1,,,too_few_values,,no
-chile,olives,tonnes,1,1,,,too_few_values,,no
-chile,raisins,tonnes,8,3,,,too_few_distinct,,no
-chile,rapeseed,tonnes,1,1,,,too_few_values,,no
-chile,rye,ha,1,1,,,too_few_values,,no
-chile,rye,tonnes,2,2,,,too_few_values,,no
-chile,sugar raw centrifugal,tonnes,2,2,,,too_few_values,,no
-chile,tobacco unmanufactured,ha,6,6,,,too_few_values,,no
-chile,tobacco unmanufactured,tonnes,3,3,,,too_few_values,,no
-chile,yarn of true hemp,ha,2,2,,,too_few_values,,no
-chile,yarn of true hemp,tonnes,13,13,chile,1.0000,attributable,yugoslavia=0.00,no
-"china, hong kong sar",groundnuts with shell,ha,1,1,,,too_few_values,,no
-"china, hong kong sar",groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-"china, taiwan province of",fertilizer mixed,tonnes,12,12,japanese taiwan,1.0000,attributable,yugoslavia=0.00,no
-"china, taiwan province of",groundnuts with shell,ha,11,8,japanese taiwan,1.0000,attributable,austria=0.18,no
-"china, taiwan province of",jute,ha,21,20,japanese taiwan,1.0000,attributable,french cambodia=0.14,no
-"china, taiwan province of",jute,tonnes,21,21,japanese taiwan,1.0000,attributable,total=0.05,no
-"china, taiwan province of",oranges,tonnes,5,5,,,too_few_values,,no
-"china, taiwan province of",other berries and fruits of the genus vaccinium n e c,ha,8,6,japanese taiwan,1.0000,attributable,uruguay=0.50,no
-"china, taiwan province of",other citrus fruit n e c,tonnes,3,3,,,too_few_values,,no
-"china, taiwan province of",p,tonnes,4,4,,,too_few_values,,no
-"china, taiwan province of",rapeseed,ha,17,13,japanese taiwan,1.0000,attributable,french algeria=0.35,no
-"china, taiwan province of",rapeseed,tonnes,16,15,japanese taiwan,1.0000,attributable,romania=0.19,no
-"china, taiwan province of",sesame seed,ha,10,8,japanese taiwan,1.0000,attributable,us puerto rico=0.40,no
-"china, taiwan province of",sesame seed,tonnes,11,10,japanese taiwan,1.0000,attributable,hungary=0.27,no
-"china, taiwan province of",silk worm cocoons reelable,tonnes,16,16,japanese taiwan,1.0000,attributable,yugoslavia=0.00,no
-"china, taiwan province of",soybeans,ha,8,6,japanese taiwan,1.0000,attributable,french annam=0.50,no
-"china, taiwan province of",soybeans,tonnes,8,8,japanese taiwan,1.0000,attributable,albania=0.25,no
-"china, taiwan province of",sugar raw centrifugal,tonnes,33,33,japanese taiwan,1.0000,attributable,poland=0.03,no
-"china, taiwan province of",tea,ha,24,22,japanese taiwan,1.0000,attributable,portuguese angola=0.08,no
-"china, taiwan province of",tea,tonnes,1,1,,,too_few_values,,no
-"china, taiwan province of",tobacco unmanufactured,ha,21,19,japanese taiwan,1.0000,attributable,ireland=0.19,no
-"china, taiwan province of",tobacco unmanufactured,tonnes,23,23,japanese taiwan,1.0000,attributable,belgium=0.04,no
-colombia,cacao beans,ha,6,6,,,too_few_values,,no
-colombia,castor beans seed,tonnes,5,3,,,too_few_values,,no
-colombia,coffee green,ha,2,2,,,too_few_values,,no
-colombia,coffee green,tonnes,3,3,,,too_few_values,,no
-colombia,cotton lint,ha,14,12,colombia,1.0000,attributable,total=0.29,no
-colombia,cotton seed,ha,13,11,colombia,1.0000,attributable,total=0.31,no
-colombia,cotton seed,tonnes,3,3,,,too_few_values,,no
-colombia,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-congo,cacao beans,ha,9,7,french equatorial africa,0.7778,attributable,french morocco=0.44,no
-congo,cacao beans,tonnes,17,11,french equatorial africa,0.8235,attributable,british cyprus=0.29,no
-congo,coffee green,ha,12,11,french equatorial africa,1.0000,attributable,total=0.25,no
-congo,coffee green,tonnes,19,18,french equatorial africa,1.0000,attributable,bulgaria=0.21,no
-congo,cotton lint,ha,19,17,french equatorial africa,1.0000,attributable,total=0.11,no
-congo,cotton lint,tonnes,18,17,french equatorial africa,1.0000,attributable,total=0.11,no
-congo,cotton seed,ha,11,11,french equatorial africa,1.0000,attributable,total=0.18,no
-congo,cotton seed,tonnes,18,17,french equatorial africa,1.0000,attributable,turkey=0.11,no
-congo,groundnuts with shell,ha,12,12,french equatorial africa,0.7500,attributable,greece=0.25,no
-congo,groundnuts with shell,tonnes,10,10,french equatorial africa,0.7000,attributable,british southern rhodesia=0.20,no
-congo,sesame seed,ha,10,9,french equatorial africa,0.7000,attributable,total=0.30,no
-congo,sesame seed,tonnes,11,10,french equatorial africa,0.7273,attributable,italy=0.27,no
-congo,tobacco unmanufactured,ha,14,13,french equatorial africa,1.0000,attributable,switzerland=0.21,no
-congo,tobacco unmanufactured,tonnes,12,11,french equatorial africa,1.0000,attributable,brazil=0.17,no
-costa rica,cacao beans,ha,11,7,costa rica,1.0000,attributable,french syria=0.36,no
-costa rica,cacao beans,tonnes,28,28,costa rica,1.0000,attributable,czechoslovakia=0.14,no
-costa rica,coffee green,ha,4,4,,,too_few_values,,no
-costa rica,lemons and limes,tonnes,7,2,,,too_few_values,,no
-costa rica,oranges,tonnes,1,1,,,too_few_values,,no
-costa rica,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-cuba,cacao beans,ha,2,1,,,too_few_values,,no
-cuba,cacao beans,tonnes,13,12,cuba,1.0000,attributable,yugoslavia=0.08,no
-cuba,coffee green,ha,1,1,,,too_few_values,,no
-cuba,other citrus fruit n e c,tonnes,2,2,,,too_few_values,,no
-cuba,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-curaã§ao,p,tonnes,4,4,,,too_few_values,,no
-cyprus,beans dry,ha,9,3,,,too_few_distinct,,no
-cyprus,beans dry,tonnes,13,7,,,ambiguous,british cyprus=1.00;bulgaria=0.69,no
-cyprus,cotton lint,ha,24,17,british cyprus,1.0000,attributable,australia=0.38,no
-cyprus,cotton lint,tonnes,33,28,british cyprus,1.0000,attributable,france=0.21,no
-cyprus,cotton seed,ha,20,13,british cyprus,1.0000,attributable,australia=0.45,no
-cyprus,cotton seed,tonnes,20,16,british cyprus,1.0000,attributable,bulgaria=0.35,no
-cyprus,flax fibre and tow,ha,13,6,,,ambiguous,british cyprus=1.00;new zealand=0.69;french algeria=0.69,no
-cyprus,flax fibre and tow,tonnes,15,13,british cyprus,1.0000,attributable,france=0.33,no
-cyprus,grapefruit inc pomelos,ha,5,1,,,too_few_values,,no
-cyprus,grapefruit inc pomelos,tonnes,10,8,british cyprus,1.0000,attributable,new zealand=0.50,no
-cyprus,grapes,ha,30,25,british cyprus,1.0000,attributable,total=0.17,no
-cyprus,grapes,tonnes,28,28,british cyprus,1.0000,attributable,australia=0.11,no
-cyprus,groundnuts with shell,ha,7,6,,,too_few_values,,no
-cyprus,groundnuts with shell,tonnes,7,7,,,too_few_values,,no
-cyprus,hemp tow waste,tonnes,6,1,,,too_few_values,,no
-cyprus,hempseed,ha,9,5,,,too_few_distinct,,no
-cyprus,hempseed,tonnes,9,5,,,too_few_distinct,,no
-cyprus,lemons and limes,ha,5,2,,,too_few_values,,no
-cyprus,lemons and limes,tonnes,15,13,,,unattributable,italy=0.40,no
-cyprus,linseed,ha,4,4,,,too_few_values,,no
-cyprus,linseed,tonnes,4,4,,,too_few_values,,no
-cyprus,oats,ha,7,4,,,too_few_values,,no
-cyprus,oats,tonnes,7,7,,,too_few_values,,no
-cyprus,oil olive virgin,tonnes,24,22,british cyprus,1.0000,attributable,italy=0.25,no
-cyprus,olives,tonnes,20,19,british cyprus,1.0000,attributable,romania=0.10,no
-cyprus,oranges,ha,7,1,,,too_few_values,,no
-cyprus,oranges,tonnes,15,15,british cyprus,1.0000,attributable,union of south africa=0.13,no
-cyprus,raisins,ha,4,4,,,too_few_values,,no
-cyprus,raisins,tonnes,20,19,british cyprus,1.0000,attributable,spain=0.15,no
-cyprus,sesame seed,ha,20,10,british cyprus,1.0000,attributable,french algeria=0.55,no
-cyprus,sesame seed,tonnes,20,13,british cyprus,1.0000,attributable,british dominica=0.40,no
-cyprus,silk worm cocoons reelable,tonnes,24,24,british cyprus,1.0000,attributable,yugoslavia=0.00,no
-cyprus,tangerines mandarins clementines satsumas,tonnes,11,5,,,too_few_distinct,,no
-cyprus,tobacco unmanufactured,ha,19,15,british cyprus,1.0000,attributable,italy=0.32,no
-cyprus,tobacco unmanufactured,tonnes,29,29,british cyprus,1.0000,attributable,romania=0.07,no
-cyprus,wine,ha,8,8,british cyprus,1.0000,attributable,yugoslavia=0.00,no
-cyprus,yarn of true hemp,ha,9,5,,,too_few_distinct,,no
-cyprus,yarn of true hemp,tonnes,9,6,british cyprus,1.0000,attributable,french guadeloupe and dependencies: marie‑galante=0.56,no
-czech republic,beans dry,ha,13,4,,,too_few_distinct,,no
-czech republic,beans dry,tonnes,13,13,czechoslovakia,1.0000,attributable,total=0.23,no
-czech republic,butter cow milk,tonnes,7,6,,,too_few_values,,no
-czech republic,cheese processed,tonnes,7,6,,,too_few_values,,no
-czech republic,eggs hen in shell,tonnes,5,5,,,too_few_values,,no
-czech republic,flax fibre and tow,ha,23,21,czechoslovakia,1.0000,attributable,total=0.17,no
-czech republic,flax fibre and tow,tonnes,22,22,czechoslovakia,1.0000,attributable,egypt=0.14,no
-czech republic,grapes,ha,17,13,czechoslovakia,1.0000,attributable,total=0.29,no
-czech republic,grapes,tonnes,15,14,czechoslovakia,1.0000,attributable,bulgaria=0.27,no
-czech republic,hemp tow waste,ha,10,5,,,too_few_distinct,,no
-czech republic,hemp tow waste,tonnes,7,6,,,too_few_values,,no
-czech republic,hempseed,ha,17,11,czechoslovakia,1.0000,attributable,total=0.47,no
-czech republic,hempseed,tonnes,22,21,czechoslovakia,1.0000,attributable,japan=0.09,no
-czech republic,hops,ha,23,23,czechoslovakia,1.0000,attributable,hungary=0.09,no
-czech republic,hops,tonnes,21,21,czechoslovakia,1.0000,attributable,belgium=0.05,no
-czech republic,linseed,ha,8,8,czechoslovakia,1.0000,attributable,yugoslavia=0.00,no
-czech republic,linseed,tonnes,11,11,czechoslovakia,1.0000,attributable,yugoslavia=0.00,no
-czech republic,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-czech republic,n,tonnes,4,4,,,too_few_values,,no
-czech republic,oats,ha,7,7,,,too_few_values,,no
-czech republic,oats,tonnes,7,7,,,too_few_values,,no
-czech republic,other forage products n e c,ha,4,4,,,too_few_values,,no
-czech republic,other forage products n e c,tonnes,4,4,,,too_few_values,,no
-czech republic,p,tonnes,4,4,,,too_few_values,,no
-czech republic,rapeseed,ha,23,22,czechoslovakia,1.0000,attributable,french algeria=0.26,no
-czech republic,rapeseed,tonnes,22,22,czechoslovakia,1.0000,attributable,us philippines=0.05,no
-czech republic,rye,ha,24,22,czechoslovakia,1.0000,attributable,yugoslavia=0.17,no
-czech republic,rye,tonnes,23,23,czechoslovakia,1.0000,attributable,greece=0.09,no
-czech republic,silk worm cocoons reelable,tonnes,14,10,czechoslovakia,1.0000,attributable,romania=0.14,no
-czech republic,soybeans,ha,9,1,,,too_few_distinct,,no
-czech republic,soybeans,tonnes,11,5,,,too_few_distinct,,no
-czech republic,sugar raw centrifugal,tonnes,23,23,czechoslovakia,1.0000,attributable,yugoslavia=0.00,no
-czech republic,tobacco unmanufactured,ha,21,16,czechoslovakia,1.0000,attributable,total=0.29,no
-czech republic,tobacco unmanufactured,tonnes,21,21,czechoslovakia,1.0000,attributable,total=0.05,no
-czech republic,wheat,ha,20,18,czechoslovakia,1.0000,attributable,total=0.25,no
-czech republic,wheat,tonnes,20,19,czechoslovakia,1.0000,attributable,romania=0.05,no
-czech republic,wine,ha,20,15,czechoslovakia,1.0000,attributable,total=0.20,no
-czech republic,wine,tonnes,20,20,,,unattributable,yugoslavia=0.00,no
-czech republic,yarn of true hemp,ha,13,9,czechoslovakia,1.0000,attributable,switzerland=0.38,no
-czech republic,yarn of true hemp,tonnes,15,14,czechoslovakia,1.0000,attributable,netherlands=0.13,no
-denmark,butter cow milk,tonnes,7,7,,,too_few_values,,no
-denmark,cheese processed,tonnes,7,7,,,too_few_values,,no
-denmark,eggs hen in shell,tonnes,15,15,denmark,1.0000,attributable,yugoslavia=0.00,no
-denmark,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-denmark,n,tonnes,12,8,denmark,1.0000,attributable,british saint lucia=0.17,no
-denmark,p,tonnes,15,15,denmark,1.0000,attributable,italy=0.07,no
-denmark,sugar raw centrifugal,tonnes,33,33,denmark,1.0000,attributable,french sudan=0.03,no
-denmark,tobacco unmanufactured,ha,3,1,,,too_few_values,,no
-djibouti,coffee green,tonnes,4,4,,,too_few_values,,no
-djibouti,eggs hen in shell,tonnes,1,1,,,too_few_values,,no
-dominica,cacao beans,ha,8,4,,,too_few_distinct,,no
-dominica,cacao beans,tonnes,29,20,british dominica,1.0000,attributable,british cyprus=0.31,no
-dominica,grapefruit inc pomelos,ha,4,1,,,too_few_values,,no
-dominica,grapefruit inc pomelos,tonnes,11,3,,,too_few_distinct,,no
-dominica,lemons and limes,ha,14,6,,,ambiguous,british dominica=1.00;french algeria=0.79;british cyprus=0.79,no
-dominica,lemons and limes,tonnes,14,13,british dominica,1.0000,attributable,italian eritrea=0.21,no
-dominica,oranges,ha,4,1,,,too_few_values,,no
-dominica,oranges,tonnes,11,3,,,too_few_distinct,,no
-dominican republic,cacao beans,ha,4,2,,,too_few_values,,no
-dominican republic,cacao beans,tonnes,1,1,,,too_few_values,,no
-dominican republic,coffee green,ha,3,3,,,too_few_values,,no
-dominican republic,coffee green,tonnes,1,1,,,too_few_values,,no
-dominican republic,cotton lint,tonnes,4,1,,,too_few_values,,no
-dominican republic,cotton seed,tonnes,5,2,,,too_few_values,,no
-dominican republic,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-dominican republic,tobacco unmanufactured,ha,1,1,,,too_few_values,,no
-dr congo,cacao beans,ha,17,10,belgian congo,1.0000,attributable,total=0.41,no
-dr congo,cacao beans,tonnes,17,13,belgian congo,1.0000,attributable,french annam=0.35,no
-dr congo,coffee green,ha,14,14,belgian congo,1.0000,attributable,greece=0.14,no
-dr congo,cotton lint,ha,23,23,belgian congo,1.0000,attributable,usa=0.04,no
-dr congo,cotton lint,tonnes,5,5,,,too_few_values,,no
-dr congo,cotton seed,ha,19,19,belgian congo,1.0000,attributable,usa=0.05,no
-dr congo,cotton seed,tonnes,19,19,belgian congo,1.0000,attributable,greece=0.05,no
-dr congo,groundnuts with shell,ha,7,5,,,too_few_values,,no
-dr congo,groundnuts with shell,tonnes,4,2,,,too_few_values,,no
-dr congo,rubber natural,ha,6,6,,,too_few_values,,no
-dr congo,sesame seed,ha,4,4,,,too_few_values,,no
-dr congo,sesame seed,tonnes,7,7,,,too_few_values,,no
-dr congo,sugar raw centrifugal,tonnes,11,9,belgian congo,1.0000,attributable,total=0.36,no
-dr congo,tobacco unmanufactured,ha,7,6,,,too_few_values,,no
-dr congo,tobacco unmanufactured,tonnes,7,6,,,too_few_values,,no
-ecuador,cacao beans,ha,1,1,,,too_few_values,,no
-ecuador,cacao beans,tonnes,1,1,,,too_few_values,,no
-ecuador,castor beans seed,tonnes,6,6,,,too_few_values,,no
-ecuador,cotton lint,tonnes,1,1,,,too_few_values,,no
-ecuador,cotton seed,tonnes,7,6,,,too_few_values,,no
-ecuador,lemons and limes,tonnes,4,2,,,too_few_values,,no
-ecuador,oranges,tonnes,2,2,,,too_few_values,,no
-egypt,beans dry,tonnes,3,3,,,too_few_values,,no
-egypt,cotton lint,ha,33,33,,,unattributable,egypt=0.12,no
-egypt,cotton lint,tonnes,1,1,,,too_few_values,,no
-egypt,cotton seed,ha,20,20,,,unattributable,sweden=0.05,no
-egypt,cotton seed,tonnes,20,20,,,unattributable,dutch java and madura=0.05,no
-egypt,eggs hen in shell,tonnes,12,12,egypt,1.0000,attributable,yugoslavia=0.00,no
-egypt,flax fibre and tow,ha,29,23,egypt,1.0000,attributable,bulgaria=0.31,no
-egypt,flax fibre and tow,tonnes,22,21,egypt,1.0000,attributable,romania=0.23,no
-egypt,grapes,ha,25,18,egypt,1.0000,attributable,italy=0.32,no
-egypt,grapes,tonnes,10,10,egypt,1.0000,attributable,portuguese mozambique: company concession=0.10,no
-egypt,groundnuts with shell,ha,20,17,,,unattributable,czechoslovakia=0.20,no
-egypt,groundnuts with shell,tonnes,20,19,,,unattributable,total=0.10,no
-egypt,lemons and limes,tonnes,11,11,egypt,1.0000,attributable,argentina=0.09,no
-egypt,linseed,ha,8,8,egypt,1.0000,attributable,french cambodia=0.12,no
-egypt,linseed,tonnes,11,11,egypt,1.0000,attributable,yugoslavia=0.00,no
-egypt,milk whole fresh cow,tonnes,4,4,,,too_few_values,,no
-egypt,n,tonnes,3,3,,,too_few_values,,no
-egypt,oil olive virgin,tonnes,4,1,,,too_few_values,,no
-egypt,olives,ha,5,1,,,too_few_values,,no
-egypt,olives,tonnes,7,6,,,too_few_values,,no
-egypt,oranges,ha,13,7,egypt,1.0000,attributable,hungary=0.38,no
-egypt,oranges,tonnes,11,11,egypt,1.0000,attributable,uruguay=0.09,no
-egypt,p,tonnes,17,17,egypt,1.0000,attributable,yugoslavia=0.00,no
-egypt,sesame seed,ha,20,19,,,unattributable,egypt=0.35,no
-egypt,sesame seed,tonnes,20,20,,,unattributable,egypt=0.10,no
-egypt,silk worm cocoons reelable,tonnes,7,6,,,too_few_values,,no
-egypt,sugar raw centrifugal,tonnes,33,33,egypt,1.0000,attributable,total=0.03,no
-egypt,tangerines mandarins clementines satsumas,tonnes,11,11,egypt,1.0000,attributable,uruguay=0.18,no
-egypt,wine,ha,4,4,,,too_few_values,,no
-el salvador,coffee green,ha,1,1,,,too_few_values,,no
-el salvador,coffee green,tonnes,2,2,,,too_few_values,,no
-el salvador,cotton lint,ha,6,4,,,too_few_values,,no
-el salvador,cotton lint,tonnes,1,1,,,too_few_values,,no
-el salvador,cotton seed,ha,11,6,,,ambiguous,czechoslovakia=0.82;total=0.73;spain=0.64,no
-el salvador,cotton seed,tonnes,12,12,el salvador,0.6667,attributable,el salvador: san salvador department=0.33,no
-el salvador,sugar raw centrifugal,tonnes,2,2,,,too_few_values,,no
-equatorial guinea,cacao beans,ha,10,7,,,unattributable,hungary=0.20,no
-equatorial guinea,coffee green,ha,6,3,,,too_few_values,,no
-equatorial guinea,coffee green,tonnes,7,5,,,too_few_values,,no
-eritrea,coffee green,ha,3,3,,,too_few_values,,no
-eritrea,coffee green,tonnes,8,6,italian eritrea,1.0000,attributable,french tonkin=0.25,no
-eritrea,cotton lint,ha,11,9,italian eritrea,1.0000,attributable,french cambodia=0.45,no
-eritrea,cotton lint,tonnes,11,9,italian eritrea,1.0000,attributable,romania=0.27,no
-eritrea,cotton seed,ha,11,9,italian eritrea,1.0000,attributable,french cambodia=0.45,no
-eritrea,cotton seed,tonnes,11,10,italian eritrea,1.0000,attributable,yugoslavia=0.36,no
-eritrea,eggs hen in shell,tonnes,3,2,,,too_few_values,,no
-eritrea,flax fibre and tow,ha,5,2,,,too_few_values,,no
-eritrea,flax fibre and tow,tonnes,5,5,,,too_few_values,,no
-eritrea,groundnuts with shell,ha,5,2,,,too_few_values,,no
-eritrea,groundnuts with shell,tonnes,5,2,,,too_few_values,,no
-eritrea,linseed,ha,4,4,,,too_few_values,,no
-eritrea,linseed,tonnes,4,3,,,too_few_values,,no
-eritrea,sesame seed,ha,6,4,,,too_few_values,,no
-eritrea,sesame seed,tonnes,7,6,,,too_few_values,,no
-eritrea,tobacco unmanufactured,ha,8,4,,,too_few_distinct,,no
-eritrea,tobacco unmanufactured,tonnes,8,8,italian eritrea,1.0000,attributable,british cyprus=0.25,no
-estonia,butter cow milk,tonnes,1,1,,,too_few_values,,no
-estonia,cheese processed,tonnes,2,2,,,too_few_values,,no
-estonia,eggs hen in shell,tonnes,10,10,estonia,1.0000,attributable,yugoslavia=0.00,no
-estonia,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-estonia,p,tonnes,4,4,,,too_few_values,,no
-eswatini,cotton seed,ha,2,2,,,too_few_values,,no
-eswatini,cotton seed,tonnes,2,2,,,too_few_values,,no
-eswatini,tobacco unmanufactured,ha,8,4,,,too_few_distinct,,no
-eswatini,tobacco unmanufactured,tonnes,14,13,british swaziland,1.0000,attributable,czechoslovakia=0.21,no
-ethiopia,coffee green,tonnes,1,1,,,too_few_values,,no
-ethiopia pdr,coffee green,tonnes,11,11,,,unattributable,total=0.36,no
-falkland islands (malvinas),fertilizer mixed,tonnes,6,6,,,too_few_values,,no
-faroe islands,eggs hen in shell,tonnes,5,4,,,too_few_values,,no
-fiji,cacao beans,ha,10,7,british fiji islands,1.0000,attributable,us philippines=0.10,no
-fiji,cacao beans,tonnes,10,9,british fiji islands,1.0000,attributable,bulgaria=0.10,no
-fiji,cotton lint,ha,17,12,british fiji islands,1.0000,attributable,french india=0.41,no
-fiji,cotton lint,tonnes,8,4,,,too_few_distinct,,no
-fiji,cotton seed,ha,8,4,,,too_few_distinct,,no
-fiji,cotton seed,tonnes,8,4,,,too_few_distinct,,no
-fiji,groundnuts with shell,ha,2,2,,,too_few_values,,no
-fiji,groundnuts with shell,tonnes,2,2,,,too_few_values,,no
-fiji,sugar raw centrifugal,tonnes,32,32,british fiji islands,1.0000,attributable,total=0.03,no
-fiji,tea,ha,15,5,,,too_few_distinct,,no
-fiji,tea,tonnes,14,10,british fiji islands,1.0000,attributable,japan: karafuto prefecture=0.07,no
-fiji,tobacco unmanufactured,ha,15,13,british fiji islands,1.0000,attributable,french algeria=0.13,no
-fiji,tobacco unmanufactured,tonnes,15,14,british fiji islands,1.0000,attributable,bulgaria=0.07,no
-finland,butter cow milk,tonnes,7,7,,,too_few_values,,no
-finland,cheese processed,tonnes,6,6,,,too_few_values,,no
-finland,eggs hen in shell,tonnes,4,4,,,too_few_values,,no
-finland,p,tonnes,4,4,,,too_few_values,,no
-finland,sugar raw centrifugal,tonnes,23,21,finland,1.0000,attributable,french syria=0.17,no
-france,butter cow milk,tonnes,7,7,,,too_few_values,,no
-france,cheese processed,tonnes,7,7,,,too_few_values,,no
-france,eggs hen in shell,tonnes,10,5,,,too_few_distinct,,no
-france,fertilizer mixed,tonnes,12,8,france,1.0000,attributable,switzerland=0.08,no
-france,grapes,tonnes,28,28,france,1.0000,attributable,total=0.04,no
-france,k,tonnes,4,4,,,too_few_values,,no
-france,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-france,n,tonnes,17,17,france,1.0000,attributable,usa and canada=0.06,no
-france,other berries and fruits of the genus vaccinium n e c,tonnes,16,15,france,1.0000,attributable,total south hemisphere aggregated=0.06,no
-france,other citrus fruit n e c,tonnes,11,8,france,1.0000,attributable,french annam=0.36,no
-france,p,tonnes,16,16,france,1.0000,attributable,yugoslavia=0.00,no
-france,silk worm cocoons reelable,tonnes,33,33,france,1.0000,attributable,italy=0.03,no
-france,sugar raw centrifugal,tonnes,33,33,france,1.0000,attributable,netherlands=0.03,no
-france,wine,ha,20,19,france,1.0000,attributable,yugoslavia=0.00,no
-france,wine,tonnes,33,33,,,unattributable,yugoslavia=0.00,no
-france,yarn of true hemp,ha,13,10,france,1.0000,attributable,hungary=0.38,no
-france,yarn of true hemp,tonnes,26,26,france,1.0000,attributable,ussr=0.04,no
-french guiana,cacao beans,ha,5,2,,,too_few_values,,no
-french guiana,cacao beans,tonnes,11,7,french guiana,1.0000,attributable,uruguay=0.45,no
-french guiana,eggs hen in shell,tonnes,7,2,,,too_few_values,,no
-french guiana,p,tonnes,5,5,,,too_few_values,,no
-french guiana,sugar raw centrifugal,tonnes,5,2,,,too_few_values,,no
-french polynesia,cacao beans,ha,1,1,,,too_few_values,,no
-french polynesia,eggs hen in shell,tonnes,5,1,,,too_few_values,,no
-french polynesia,p,tonnes,16,15,french oceania: makatea island,1.0000,attributable,total general excluding the ussr=0.06,no
-french polynesia,sugar raw centrifugal,tonnes,3,2,,,too_few_values,,no
-french polynesia,tobacco unmanufactured,ha,8,3,,,too_few_distinct,,no
-french polynesia,tobacco unmanufactured,tonnes,8,3,,,too_few_distinct,,no
-gabon,cacao beans,ha,6,5,,,too_few_values,,no
-gabon,cacao beans,tonnes,16,16,french equatorial africa: gabon,1.0000,attributable,yugoslavia=0.00,no
-gabon,coffee green,ha,4,3,,,too_few_values,,no
-gabon,coffee green,tonnes,12,11,french equatorial africa: gabon,1.0000,attributable,british fiji islands=0.08,no
-gabon,groundnuts with shell,ha,3,2,,,too_few_values,,no
-gabon,groundnuts with shell,tonnes,3,3,,,too_few_values,,no
-gabon,sesame seed,ha,3,1,,,too_few_values,,no
-gabon,sesame seed,tonnes,3,1,,,too_few_values,,no
-gambia,groundnuts with shell,ha,7,7,,,too_few_values,,no
-gambia,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-germany,butter cow milk,tonnes,3,3,,,too_few_values,,no
-germany,cheese processed,tonnes,3,3,,,too_few_values,,no
-germany,eggs hen in shell,tonnes,4,2,,,too_few_values,,no
-germany,fertilizer mixed,tonnes,12,12,germany,1.0000,attributable,yugoslavia=0.00,no
-germany,grapes,tonnes,4,4,,,too_few_values,,no
-germany,k,tonnes,4,4,,,too_few_values,,no
-germany,milk whole fresh cow,tonnes,4,4,,,too_few_values,,no
-germany,n,tonnes,17,17,germany,1.0000,attributable,usa and canada=0.06,no
-germany,p,tonnes,17,11,germany,0.7647,attributable,french morocco=0.41,no
-germany,sugar raw centrifugal,tonnes,32,32,germany,1.0000,attributable,usa=0.03,no
-germany,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-germany,wine,ha,15,12,germany,1.0000,attributable,usa=0.13,no
-germany,wine,tonnes,28,28,,,unattributable,yugoslavia=0.00,no
-germany,yarn of true hemp,ha,9,9,germany,1.0000,attributable,italy=0.33,no
-germany,yarn of true hemp,tonnes,4,4,,,too_few_values,,no
-ghana,cacao beans,ha,16,9,,,unattributable,british gold coast=0.50,no
-ghana,cotton lint,ha,13,8,german togoland,1.0000,attributable,italy=0.15,no
-ghana,cotton lint,tonnes,19,12,,,unattributable,british gold coast=0.53,no
-ghana,cotton seed,ha,3,3,,,too_few_values,,no
-ghana,cotton seed,tonnes,9,9,german togoland,1.0000,attributable,hungary=0.22,no
-ghana,groundnuts with shell,ha,9,7,german togoland,1.0000,attributable,hungary=0.44,no
-ghana,groundnuts with shell,tonnes,12,11,german togoland,1.0000,attributable,italy=0.25,no
-ghana,rubber natural,ha,4,1,,,too_few_values,,no
-greece,cotton lint,ha,26,26,greece,1.0000,attributable,yugoslavia=0.12,no
-greece,cotton seed,ha,18,18,greece,1.0000,attributable,yugoslavia=0.17,no
-greece,cotton seed,tonnes,20,20,greece,1.0000,attributable,venezuela=0.10,no
-greece,eggs hen in shell,tonnes,7,7,,,too_few_values,,no
-greece,fertilizer mixed,tonnes,2,2,,,too_few_values,,no
-greece,grapes,tonnes,10,7,,,unattributable,italian dodecanese islands=0.40,no
-greece,lemons and limes,tonnes,1,1,,,too_few_values,,no
-greece,other berries and fruits of the genus vaccinium n e c,tonnes,7,7,,,too_few_values,,no
-greece,other citrus fruit n e c,tonnes,10,7,greece,1.0000,attributable,british cyprus=0.50,no
-greece,p,tonnes,4,4,,,too_few_values,,no
-greece,raisins,ha,6,6,,,too_few_values,,no
-greece,raisins,tonnes,16,15,greece,1.0000,attributable,yugoslavia=0.06,no
-greece,rye,ha,1,1,,,too_few_values,,no
-greece,silk worm cocoons reelable,tonnes,11,10,,,unattributable,greece=0.27,no
-greece,wine,ha,14,13,greece,0.9286,attributable,total general excluding the ussr=0.14,no
-greece,wine,tonnes,23,23,,,unattributable,lithuania=0.04,no
-grenada,cacao beans,ha,7,2,,,too_few_values,,no
-grenada,cacao beans,tonnes,31,30,british grenada,1.0000,attributable,czechoslovakia=0.13,no
-grenada,cotton lint,ha,18,9,british grenada,1.0000,attributable,austria=0.33,no
-grenada,cotton lint,tonnes,31,20,british grenada,1.0000,attributable,british cyprus=0.39,no
-grenada,cotton seed,ha,12,4,,,too_few_distinct,,no
-grenada,cotton seed,tonnes,18,10,british grenada,1.0000,attributable,french algeria=0.44,no
-grenada,lemons and limes,ha,4,2,,,too_few_values,,no
-guadeloupe,cacao beans,ha,22,6,french guadeloupe,1.0000,attributable,austria=0.50,no
-guadeloupe,cacao beans,tonnes,30,21,french guadeloupe,1.0000,attributable,british southern rhodesia=0.30,no
-guadeloupe,coffee green,ha,23,8,french guadeloupe,0.8261,attributable,total=0.43,no
-guadeloupe,coffee green,tonnes,30,25,french guadeloupe,0.6000,attributable,french guadeloupe and dependencies=0.40,no
-guadeloupe,cotton lint,ha,14,8,,,unattributable,french guadeloupe=0.50,no
-guadeloupe,cotton lint,tonnes,12,8,french guadeloupe,0.7500,attributable,french algeria=0.50,no
-guadeloupe,cotton seed,ha,10,4,,,too_few_distinct,,no
-guadeloupe,cotton seed,tonnes,15,9,french guadeloupe,0.6000,attributable,french guadeloupe and dependencies: marie‑galante=0.47,no
-guadeloupe,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-guatemala,butter cow milk,tonnes,6,3,,,too_few_values,,no
-guatemala,cacao beans,ha,15,9,guatemala,1.0000,attributable,french tonkin=0.53,no
-guatemala,cacao beans,tonnes,17,15,guatemala,1.0000,attributable,british cyprus=0.29,no
-guatemala,cheese processed,tonnes,6,4,,,too_few_values,,no
-guatemala,coffee green,ha,3,3,,,too_few_values,,no
-guatemala,cotton lint,ha,15,10,guatemala,1.0000,attributable,french cochinchina=0.47,no
-guatemala,cotton lint,tonnes,4,2,,,too_few_values,,no
-guatemala,cotton seed,ha,15,11,guatemala,1.0000,attributable,french cochinchina=0.47,no
-guatemala,cotton seed,tonnes,13,12,guatemala,1.0000,attributable,austria=0.46,no
-guatemala,eggs hen in shell,tonnes,5,5,,,too_few_values,,no
-guatemala,groundnuts with shell,ha,6,5,,,too_few_values,,no
-guatemala,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-guatemala,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-guatemala,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-guatemala,tobacco unmanufactured,ha,1,1,,,too_few_values,,no
-guatemala,tobacco unmanufactured,tonnes,7,7,,,too_few_values,,no
-guinea,coffee green,ha,6,3,,,too_few_values,,no
-guinea,coffee green,tonnes,7,5,,,too_few_values,,no
-guinea,cotton lint,ha,7,7,,,too_few_values,,no
-guinea,cotton lint,tonnes,7,7,,,too_few_values,,no
-guinea,cotton seed,ha,7,7,,,too_few_values,,no
-guinea,cotton seed,tonnes,7,7,,,too_few_values,,no
-guinea,groundnuts with shell,ha,10,9,french guinea,1.0000,attributable,poland=0.20,no
-guinea,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-guinea,sesame seed,ha,6,2,,,too_few_values,,no
-guinea,sesame seed,tonnes,16,13,french guinea,1.0000,attributable,british southern rhodesia=0.44,no
-guinea,tobacco unmanufactured,ha,4,1,,,too_few_values,,no
-guinea,tobacco unmanufactured,tonnes,12,12,french guinea,1.0000,attributable,uruguay=0.25,no
-guinea-bissau,groundnuts with shell,ha,3,2,,,too_few_values,,no
-guinea-bissau,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-guyana,cacao beans,ha,24,20,british guiana,1.0000,attributable,iran=0.21,no
-guyana,cacao beans,tonnes,3,1,,,too_few_values,,no
-guyana,coffee green,ha,31,22,british guiana,1.0000,attributable,british cyprus=0.35,no
-guyana,coffee green,tonnes,11,8,british guiana,1.0000,attributable,french annam=0.36,no
-guyana,lemons and limes,ha,6,5,,,too_few_values,,no
-haiti,cacao beans,ha,6,1,,,too_few_values,,no
-haiti,cacao beans,tonnes,24,19,haiti,1.0000,attributable,hungary=0.17,no
-haiti,castor beans seed,tonnes,4,4,,,too_few_values,,no
-haiti,coffee green,ha,1,1,,,too_few_values,,no
-haiti,coffee green,tonnes,2,2,,,too_few_values,,no
-haiti,cotton lint,ha,6,6,,,too_few_values,,no
-haiti,cotton seed,ha,6,6,,,too_few_values,,no
-haiti,cotton seed,tonnes,16,14,haiti,1.0000,attributable,czechoslovakia=0.31,no
-haiti,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-honduras,coffee green,tonnes,2,2,,,too_few_values,,no
-honduras,tobacco unmanufactured,ha,1,1,,,too_few_values,,no
-hungary,butter cow milk,tonnes,4,4,,,too_few_values,,no
-hungary,cheese processed,tonnes,4,3,,,too_few_values,,no
-hungary,fertilizer mixed,tonnes,3,3,,,too_few_values,,no
-hungary,grapes,tonnes,6,6,,,too_few_values,,no
-hungary,hops,ha,4,4,,,too_few_values,,no
-hungary,hops,tonnes,1,1,,,too_few_values,,no
-hungary,milk whole fresh cow,tonnes,4,4,,,too_few_values,,no
-hungary,n,tonnes,4,4,,,too_few_values,,no
-hungary,p,tonnes,4,4,,,too_few_values,,no
-hungary,silk worm cocoons reelable,tonnes,21,20,hungary,1.0000,attributable,french tunisia=0.05,no
-hungary,sugar raw centrifugal,tonnes,29,29,hungary,1.0000,attributable,japan=0.03,no
-hungary,sunflower seed,tonnes,1,1,,,too_few_values,,no
-hungary,wine,ha,17,16,hungary,1.0000,attributable,usa: california=0.06,no
-hungary,wine,tonnes,26,26,,,unattributable,yugoslavia=0.00,no
-hungary,yarn of true hemp,ha,13,13,hungary,1.0000,attributable,total=0.31,no
-hungary,yarn of true hemp,tonnes,19,19,hungary,1.0000,attributable,egypt=0.11,no
-india,coffee green,ha,17,17,,,unattributable,british india=0.18,no
-india,cotton lint,ha,25,22,,,unattributable,uruguay=0.16,no
-india,cotton seed,ha,12,10,,,unattributable,norway=0.33,no
-india,cotton seed,tonnes,13,13,,,unattributable,british southern rhodesia=0.31,no
-india,eggs hen in shell,tonnes,7,5,,,too_few_values,,no
-india,fertilizer mixed,tonnes,4,4,,,too_few_values,,no
-india,flax fibre and tow,ha,13,13,british india,1.0000,attributable,yugoslavia=0.00,no
-india,groundnuts with shell,ha,18,10,,,unattributable,french india=0.56,no
-india,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-india,jute,ha,21,21,british india,1.0000,attributable,yugoslavia=0.00,no
-india,jute,tonnes,21,21,british india,1.0000,attributable,yugoslavia=0.00,no
-india,k,tonnes,4,4,,,too_few_values,,no
-india,linseed,ha,8,8,british india,1.0000,attributable,[error] inde=0.12,no
-india,linseed,tonnes,1,1,,,too_few_values,,no
-india,n,tonnes,4,4,,,too_few_values,,no
-india,p,tonnes,4,4,,,too_few_values,,no
-india,rapeseed,ha,21,21,british india,1.0000,attributable,[error] inde=0.05,no
-india,rapeseed,tonnes,20,20,british india,1.0000,attributable,yugoslavia=0.00,no
-india,rubber natural,ha,4,4,,,too_few_values,,no
-india,sesame seed,ha,18,9,,,unattributable,new zealand=0.56,no
-india,sesame seed,tonnes,18,10,,,unattributable,french india=0.56,no
-india,sugar raw centrifugal,tonnes,21,21,british india,0.8571,attributable,yugoslavia=0.00,no
-india,tea,ha,19,19,,,unattributable,british india=0.42,no
-india,tea,tonnes,20,20,british india,0.8500,attributable,yugoslavia=0.00,no
-india,tobacco unmanufactured,ha,19,19,,,unattributable,british india=0.21,no
-iran,castor beans seed,tonnes,4,4,,,too_few_values,,no
-iran,cotton lint,ha,13,10,iran,1.0000,attributable,total=0.54,no
-iran,cotton seed,ha,13,10,iran,1.0000,attributable,total=0.54,no
-iran,cotton seed,tonnes,17,17,iran,1.0000,attributable,total=0.24,no
-iran,grapes,tonnes,4,3,,,too_few_values,,no
-iran,jute,ha,4,2,,,too_few_values,,no
-iran,jute,tonnes,6,6,,,too_few_values,,no
-iran,oranges,tonnes,4,4,,,too_few_values,,no
-iran,raisins,tonnes,12,10,iran,1.0000,attributable,yugoslavia=0.17,no
-iran,sesame seed,ha,4,3,,,too_few_values,,no
-iran,sesame seed,tonnes,6,6,,,too_few_values,,no
-iran,silk worm cocoons reelable,tonnes,8,8,iran,1.0000,attributable,venezuela=0.12,no
-iran,sugar raw centrifugal,tonnes,12,12,iran,1.0000,attributable,italy=0.25,no
-iran,tea,ha,6,5,,,too_few_values,,no
-iran,tea,tonnes,6,6,,,too_few_values,,no
-iran,tobacco unmanufactured,ha,14,8,iran,1.0000,attributable,total=0.43,no
-iran,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-iran,wine,tonnes,1,1,,,too_few_values,,no
-iraq,beans dry,ha,1,1,,,too_few_values,,no
-iraq,beans dry,tonnes,5,4,,,too_few_values,,no
-iraq,cotton lint,ha,11,8,british iraq,1.0000,attributable,total=0.27,no
-iraq,cotton lint,tonnes,20,16,british iraq,1.0000,attributable,total=0.20,no
-iraq,cotton seed,ha,11,8,british iraq,1.0000,attributable,total=0.27,no
-iraq,cotton seed,tonnes,19,18,british iraq,1.0000,attributable,bulgaria=0.37,no
-iraq,sesame seed,ha,9,7,british iraq,1.0000,attributable,romania=0.56,no
-iraq,sesame seed,tonnes,9,9,british iraq,1.0000,attributable,hungary=0.33,no
-iraq,silk worm cocoons reelable,tonnes,3,3,,,too_few_values,,no
-iraq,tobacco unmanufactured,ha,8,7,,,ambiguous,british iraq=1.00;total=0.62,no
-iraq,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-ireland,butter cow milk,tonnes,7,6,,,too_few_values,,no
-ireland,eggs hen in shell,tonnes,15,14,ireland,1.0000,attributable,yugoslavia=0.00,no
-ireland,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-ireland,n,tonnes,4,1,,,too_few_values,,no
-ireland,p,tonnes,4,4,,,too_few_values,,no
-ireland,rye,ha,3,2,,,too_few_values,,no
-ireland,rye,tonnes,2,2,,,too_few_values,,no
-ireland,sugar raw centrifugal,tonnes,16,16,ireland,1.0000,attributable,total=0.06,no
-ireland,tobacco unmanufactured,ha,6,1,,,too_few_values,,no
-israel,eggs hen in shell,tonnes,7,7,,,too_few_values,,no
-israel,grapefruit inc pomelos,tonnes,7,7,,,too_few_values,,no
-israel,grapes,ha,7,3,,,too_few_values,,no
-israel,grapes,tonnes,20,20,british palestine,1.0000,attributable,total=0.10,no
-israel,lemons and limes,tonnes,9,9,british palestine,1.0000,attributable,yugoslavia=0.22,no
-israel,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-israel,oats,ha,6,1,,,too_few_values,,no
-israel,oats,tonnes,7,5,,,too_few_values,,no
-israel,oil olive virgin,tonnes,17,16,british palestine,1.0000,attributable,total=0.18,no
-israel,olives,ha,11,9,british palestine,1.0000,attributable,uruguay=0.27,no
-israel,olives,tonnes,20,20,british palestine,1.0000,attributable,usa=0.05,no
-israel,oranges,ha,5,4,,,too_few_values,,no
-israel,oranges,tonnes,9,9,british palestine,1.0000,attributable,romania=0.11,no
-israel,raisins,tonnes,1,1,,,too_few_values,,no
-israel,sesame seed,ha,11,9,british palestine,1.0000,attributable,total=0.36,no
-israel,sesame seed,tonnes,20,20,british palestine,1.0000,attributable,hungary=0.10,no
-israel,tobacco unmanufactured,ha,19,12,british palestine,1.0000,attributable,italy=0.53,no
-israel,tobacco unmanufactured,tonnes,19,19,british palestine,1.0000,attributable,turkey=0.05,no
-israel,wine,ha,4,2,,,too_few_values,,no
-israel,wine,tonnes,18,16,,,unattributable,yugoslavia=0.00,no
-italy,butter cow milk,tonnes,7,7,,,too_few_values,,no
-italy,cheese processed,tonnes,7,7,,,too_few_values,,no
-italy,cotton lint,ha,20,16,italy,1.0000,attributable,mexico=0.30,no
-italy,cotton seed,ha,20,16,italy,1.0000,attributable,mexico=0.30,no
-italy,cotton seed,tonnes,19,17,italy,1.0000,attributable,egypt=0.16,no
-italy,eggs hen in shell,tonnes,7,7,,,too_few_values,,no
-italy,fertilizer mixed,tonnes,17,17,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,lemons and limes,ha,2,2,,,too_few_values,,no
-italy,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-italy,n,tonnes,16,16,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,olives,ha,1,1,,,too_few_values,,no
-italy,oranges,ha,2,2,,,too_few_values,,no
-italy,other berries and fruits of the genus vaccinium n e c,tonnes,20,20,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,other citrus fruit n e c,ha,4,1,,,too_few_values,,no
-italy,other citrus fruit n e c,tonnes,8,8,italy,0.6250,attributable,union of south africa=0.12,no
-italy,other sugar crops n e c,ha,7,1,,,too_few_values,,no
-italy,other sugar crops n e c,tonnes,7,7,,,too_few_values,,no
-italy,p,tonnes,16,16,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,sesame seed,tonnes,1,1,,,too_few_values,,no
-italy,silk worm cocoons reelable,tonnes,33,33,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,sugar raw centrifugal,tonnes,33,33,italy,1.0000,attributable,bulgaria=0.06,no
-italy,wine,ha,11,11,italy,1.0000,attributable,yugoslavia=0.00,no
-italy,wine,tonnes,33,33,,,unattributable,yugoslavia=0.00,no
-italy,yarn of true hemp,ha,13,13,italy,1.0000,attributable,turkey=0.08,no
-italy,yarn of true hemp,tonnes,26,26,italy,1.0000,attributable,denmark=0.04,no
-ivory coast,beans dry,ha,2,1,,,too_few_values,,no
-ivory coast,cacao beans,ha,14,12,french ivory coast,1.0000,attributable,total=0.21,no
-ivory coast,coffee green,ha,14,13,french ivory coast,1.0000,attributable,total=0.29,no
-ivory coast,cotton lint,ha,3,3,,,too_few_values,,no
-ivory coast,cotton lint,tonnes,3,3,,,too_few_values,,no
-ivory coast,cotton seed,ha,3,3,,,too_few_values,,no
-ivory coast,cotton seed,tonnes,3,3,,,too_few_values,,no
-ivory coast,eggs hen in shell,tonnes,4,4,,,too_few_values,,no
-ivory coast,groundnuts with shell,ha,14,11,french ivory coast,1.0000,attributable,usa=0.21,no
-ivory coast,groundnuts with shell,tonnes,12,9,french ivory coast,1.0000,attributable,italy=0.33,no
-ivory coast,sesame seed,ha,6,6,,,too_few_values,,no
-ivory coast,sesame seed,tonnes,4,4,,,too_few_values,,no
-ivory coast,tobacco unmanufactured,ha,11,5,,,too_few_distinct,,no
-ivory coast,tobacco unmanufactured,tonnes,11,7,french ivory coast,1.0000,attributable,total=0.45,no
-jamaica,cacao beans,ha,20,20,british jamaica,1.0000,attributable,total=0.05,no
-jamaica,cacao beans,tonnes,29,25,british jamaica,1.0000,attributable,australia=0.14,no
-jamaica,coffee green,ha,20,20,british jamaica,1.0000,attributable,usa=0.05,no
-jamaica,coffee green,tonnes,28,27,british jamaica,1.0000,attributable,uruguay=0.11,no
-jamaica,cotton lint,ha,20,17,british jamaica,0.6500,attributable,total=0.15,no
-jamaica,cotton lint,tonnes,14,13,,,unattributable,british jamaica=0.50,no
-jamaica,cotton seed,ha,7,5,,,too_few_values,,no
-jamaica,cotton seed,tonnes,7,6,,,too_few_values,,no
-jamaica,grapefruit inc pomelos,ha,2,2,,,too_few_values,,no
-jamaica,grapefruit inc pomelos,tonnes,14,13,british jamaica,1.0000,attributable,british cyprus=0.36,no
-jamaica,lemons and limes,tonnes,4,2,,,too_few_values,,no
-jamaica,oranges,ha,2,2,,,too_few_values,,no
-jamaica,oranges,tonnes,14,14,british jamaica,1.0000,attributable,british cyprus=0.29,no
-jamaica,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-jamaica,tobacco unmanufactured,ha,13,13,british jamaica,1.0000,attributable,french algeria=0.15,no
-jamaica,tobacco unmanufactured,tonnes,3,3,,,too_few_values,,no
-japan,beans dry,ha,5,5,,,too_few_values,,no
-japan,beans dry,tonnes,5,5,,,too_few_values,,no
-japan,cotton lint,ha,22,20,japan,1.0000,attributable,french algeria=0.18,no
-japan,cotton lint,tonnes,23,21,japan,1.0000,attributable,british ceylon=0.17,no
-japan,cotton seed,ha,11,8,japan,1.0000,attributable,french algeria=0.45,no
-japan,cotton seed,tonnes,10,9,japan,1.0000,attributable,french cambodia=0.30,no
-japan,eggs hen in shell,tonnes,11,11,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,fertilizer mixed,tonnes,16,16,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,flax fibre and tow,ha,23,21,japan,1.0000,attributable,yugoslavia=0.09,no
-japan,flax fibre and tow,tonnes,24,24,japan,1.0000,attributable,czechoslovakia=0.08,no
-japan,grapes,ha,6,3,,,too_few_values,,no
-japan,grapes,tonnes,22,22,japan,1.0000,attributable,total=0.05,no
-japan,groundnuts with shell,ha,11,8,japan,1.0000,attributable,total=0.36,no
-japan,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-japan,hemp tow waste,ha,12,12,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,jute,ha,16,13,japan,1.0000,attributable,yugoslavia=0.25,no
-japan,jute,tonnes,16,14,japan,1.0000,attributable,japanese taiwan=0.19,no
-japan,k,tonnes,3,3,,,too_few_values,,no
-japan,lemons and limes,ha,3,1,,,too_few_values,,no
-japan,lemons and limes,tonnes,4,3,,,too_few_values,,no
-japan,linseed,ha,8,8,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,linseed,tonnes,18,18,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,n,tonnes,16,15,japan,1.0000,attributable,switzerland=0.19,no
-japan,oranges,ha,7,5,,,too_few_values,,no
-japan,oranges,tonnes,7,7,,,too_few_values,,no
-japan,other berries and fruits of the genus vaccinium n e c,ha,11,11,japan,1.0000,attributable,total=0.09,no
-japan,other sugar crops n e c,ha,3,2,,,too_few_values,,no
-japan,other sugar crops n e c,tonnes,3,3,,,too_few_values,,no
-japan,p,tonnes,16,16,japan,1.0000,attributable,british saint vincent=0.06,no
-japan,rapeseed,ha,25,24,japan,1.0000,attributable,total=0.04,no
-japan,rapeseed,tonnes,30,30,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,sesame seed,ha,11,8,japan,1.0000,attributable,french cambodia=0.36,no
-japan,sesame seed,tonnes,14,13,japan,1.0000,attributable,italy=0.21,no
-japan,silk worm cocoons reelable,tonnes,32,32,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,soybeans,ha,9,9,japan,1.0000,attributable,total south hemisphere aggregated=0.11,no
-japan,soybeans,tonnes,13,13,japan,1.0000,attributable,yugoslavia=0.00,no
-japan,sugar raw centrifugal,tonnes,26,26,japan,1.0000,attributable,total south hemisphere aggregated=0.04,no
-japan,tangerines mandarins clementines satsumas,ha,7,7,,,too_few_values,,no
-japan,tangerines mandarins clementines satsumas,tonnes,7,7,,,too_few_values,,no
-japan,tea,ha,26,22,japan,1.0000,attributable,uk: england and wales=0.08,no
-japan,tobacco unmanufactured,ha,27,24,japan,1.0000,attributable,greece=0.11,no
-japan,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-japan,wine,tonnes,5,5,,,too_few_values,,no
-japan,yarn of true hemp,ha,12,9,japan,1.0000,attributable,us philippines=0.33,no
-japan,yarn of true hemp,tonnes,22,21,japan,1.0000,attributable,us virgin islands=0.05,no
-jordan,eggs hen in shell,tonnes,8,7,british transjordan,1.0000,attributable,yugoslavia=0.00,no
-jordan,grapes,ha,1,1,,,too_few_values,,no
-jordan,grapes,tonnes,4,4,,,too_few_values,,no
-jordan,oil olive virgin,tonnes,1,1,,,too_few_values,,no
-jordan,olives,tonnes,1,1,,,too_few_values,,no
-jordan,raisins,tonnes,3,2,,,too_few_values,,no
-jordan,sesame seed,tonnes,8,6,,,ambiguous,british transjordan=1.00;french morocco=0.75;new zealand=0.62,no
-jordan,tobacco unmanufactured,ha,1,1,,,too_few_values,,no
-jordan,tobacco unmanufactured,tonnes,10,10,british transjordan,1.0000,attributable,usa: hawaii=0.10,no
-kenya,beans dry,ha,9,3,,,too_few_distinct,,no
-kenya,beans dry,tonnes,2,1,,,too_few_values,,no
-kenya,coffee green,ha,15,14,british kenya,1.0000,attributable,total=0.20,no
-kenya,cotton lint,tonnes,16,15,british kenya,1.0000,attributable,italy=0.25,no
-kenya,cotton seed,tonnes,17,17,british kenya,1.0000,attributable,spain=0.12,no
-kenya,eggs hen in shell,tonnes,5,3,,,too_few_values,,no
-kenya,flax fibre and tow,ha,7,6,,,too_few_values,,no
-kenya,flax fibre and tow,tonnes,7,7,,,too_few_values,,no
-kenya,groundnuts with shell,tonnes,17,17,british kenya,1.0000,attributable,french india=0.18,no
-kenya,linseed,ha,3,3,,,too_few_values,,no
-kenya,linseed,tonnes,4,4,,,too_few_values,,no
-kenya,oats,ha,4,2,,,too_few_values,,no
-kenya,oats,tonnes,3,3,,,too_few_values,,no
-kenya,sesame seed,tonnes,16,16,british kenya,1.0000,attributable,british cyprus=0.25,no
-kenya,sugar raw centrifugal,tonnes,8,8,british kenya,1.0000,attributable,switzerland=0.25,no
-kenya,tea,ha,15,8,british kenya,1.0000,attributable,french annam=0.40,no
-kenya,tea,tonnes,5,5,,,too_few_values,,no
-kiribati,p,tonnes,4,4,,,too_few_values,,no
-latvia,butter cow milk,tonnes,1,1,,,too_few_values,,no
-latvia,cheese processed,tonnes,1,1,,,too_few_values,,no
-latvia,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-latvia,p,tonnes,4,4,,,too_few_values,,no
-latvia,sugar raw centrifugal,tonnes,16,11,latvia,1.0000,attributable,lithuania=0.38,no
-latvia,yarn of true hemp,ha,1,1,,,too_few_values,,no
-latvia,yarn of true hemp,tonnes,1,1,,,too_few_values,,no
-lebanon,beans dry,ha,4,3,,,too_few_values,,no
-lebanon,beans dry,tonnes,4,4,,,too_few_values,,no
-lebanon,butter cow milk,tonnes,5,1,,,too_few_values,,no
-lebanon,cheese processed,tonnes,5,2,,,too_few_values,,no
-lebanon,eggs hen in shell,tonnes,3,3,,,too_few_values,,no
-lebanon,grapes,ha,6,3,,,too_few_values,,no
-lebanon,grapes,tonnes,6,5,,,too_few_values,,no
-lebanon,groundnuts with shell,ha,1,1,,,too_few_values,,no
-lebanon,groundnuts with shell,tonnes,3,3,,,too_few_values,,no
-lebanon,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-lebanon,oats,ha,4,1,,,too_few_values,,no
-lebanon,oats,tonnes,6,5,,,too_few_values,,no
-lebanon,oil olive virgin,tonnes,4,4,,,too_few_values,,no
-lebanon,olives,ha,4,2,,,too_few_values,,no
-lebanon,olives,tonnes,6,6,,,too_few_values,,no
-lebanon,oranges,ha,5,2,,,too_few_values,,no
-lebanon,oranges,tonnes,5,5,,,too_few_values,,no
-lebanon,other berries and fruits of the genus vaccinium n e c,ha,3,2,,,too_few_values,,no
-lebanon,other berries and fruits of the genus vaccinium n e c,tonnes,3,3,,,too_few_values,,no
-lebanon,sesame seed,ha,2,2,,,too_few_values,,no
-lebanon,sesame seed,tonnes,4,4,,,too_few_values,,no
-lebanon,silk worm cocoons reelable,tonnes,6,5,,,too_few_values,,no
-lebanon,tobacco unmanufactured,ha,6,1,,,too_few_values,,no
-lebanon,tobacco unmanufactured,tonnes,7,7,,,too_few_values,,no
-lebanon,wine,ha,4,2,,,too_few_values,,no
-lebanon,wine,tonnes,8,8,,,unattributable,yugoslavia=0.00,no
-liberia,coffee green,tonnes,2,2,,,too_few_values,,no
-liberia,rubber natural,ha,7,6,,,too_few_values,,no
-libya,grapes,ha,8,7,,,unattributable,total=0.50,no
-libya,grapes,tonnes,6,6,,,too_few_values,,no
-libya,oil olive virgin,tonnes,18,16,italian libya,0.6111,attributable,italy=0.28,no
-libya,olives,ha,8,8,,,unattributable,italian libya=0.50,no
-libya,olives,tonnes,10,10,,,unattributable,italian libya=0.40,no
-libya,other berries and fruits of the genus vaccinium n e c,ha,6,5,,,too_few_values,,no
-libya,other berries and fruits of the genus vaccinium n e c,tonnes,4,2,,,too_few_values,,no
-libya,silk worm cocoons reelable,tonnes,5,5,,,too_few_values,,no
-libya,tobacco unmanufactured,ha,7,4,,,too_few_values,,no
-libya,tobacco unmanufactured,tonnes,6,6,,,too_few_values,,no
-libya,wine,ha,6,6,,,too_few_values,,no
-libya,wine,tonnes,7,7,,,too_few_values,,no
-lithuania,butter cow milk,tonnes,1,1,,,too_few_values,,no
-lithuania,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-lithuania,p,tonnes,4,4,,,too_few_values,,no
-lithuania,sugar raw centrifugal,tonnes,15,10,lithuania,1.0000,attributable,latvia=0.40,no
-luxembourg,eggs hen in shell,tonnes,4,4,,,too_few_values,,no
-luxembourg,flax fibre and tow,ha,7,6,,,too_few_values,,no
-luxembourg,flax fibre and tow,tonnes,2,2,,,too_few_values,,no
-luxembourg,hemp tow waste,ha,5,4,,,too_few_values,,no
-luxembourg,p,tonnes,12,12,luxembourg,1.0000,attributable,british nauru=0.08,no
-luxembourg,rye,ha,6,4,,,too_few_values,,no
-luxembourg,rye,tonnes,5,4,,,too_few_values,,no
-luxembourg,wine,ha,9,9,luxembourg,1.0000,attributable,french cochinchina=0.22,no
-luxembourg,wine,tonnes,32,32,,,unattributable,yugoslavia=0.00,no
-madagascar,beans dry,ha,12,10,french madagascar,1.0000,attributable,usa: california=0.25,no
-madagascar,beans dry,tonnes,12,11,french madagascar,1.0000,attributable,yugoslavia=0.17,no
-madagascar,cacao beans,ha,9,4,,,too_few_distinct,,no
-madagascar,cacao beans,tonnes,15,5,,,too_few_distinct,,no
-madagascar,castor beans seed,ha,7,4,,,too_few_values,,no
-madagascar,castor beans seed,tonnes,7,7,,,too_few_values,,no
-madagascar,coffee green,ha,25,20,french madagascar,1.0000,attributable,total=0.12,no
-madagascar,cotton lint,ha,6,5,,,too_few_values,,no
-madagascar,cotton lint,tonnes,4,3,,,too_few_values,,no
-madagascar,cotton seed,ha,6,5,,,too_few_values,,no
-madagascar,cotton seed,tonnes,4,4,,,too_few_values,,no
-madagascar,eggs hen in shell,tonnes,9,6,french madagascar,0.6667,attributable,yugoslavia=0.00,no
-madagascar,grapes,ha,6,4,,,too_few_values,,no
-madagascar,grapes,tonnes,2,2,,,too_few_values,,no
-madagascar,groundnuts with shell,ha,16,12,french madagascar,1.0000,attributable,hungary=0.44,no
-madagascar,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-madagascar,p,tonnes,4,4,,,too_few_values,,no
-madagascar,silk worm cocoons reelable,tonnes,4,4,,,too_few_values,,no
-madagascar,sugar raw centrifugal,tonnes,18,15,french madagascar,1.0000,attributable,czechoslovakia=0.22,no
-madagascar,tobacco unmanufactured,ha,23,16,french madagascar,1.0000,attributable,total=0.39,no
-madagascar,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-madagascar,wine,ha,6,2,,,too_few_values,,no
-madagascar,wine,tonnes,12,4,,,too_few_distinct,,no
-malawi,coffee green,ha,25,21,british nyasaland,1.0000,attributable,british cyprus=0.24,no
-malawi,coffee green,tonnes,22,20,british nyasaland,1.0000,attributable,sweden=0.18,no
-malawi,cotton lint,ha,30,27,british nyasaland,1.0000,attributable,hungary=0.23,no
-malawi,cotton lint,tonnes,30,26,british nyasaland,1.0000,attributable,austria=0.23,no
-malawi,cotton seed,ha,19,16,british nyasaland,1.0000,attributable,hungary=0.37,no
-malawi,cotton seed,tonnes,19,17,british nyasaland,1.0000,attributable,british cyprus=0.32,no
-malawi,groundnuts with shell,ha,13,8,british nyasaland,1.0000,attributable,french cochinchina=0.46,no
-malawi,groundnuts with shell,tonnes,13,10,british nyasaland,1.0000,attributable,netherlands=0.38,no
-malawi,rubber natural,ha,13,2,,,too_few_distinct,,no
-malawi,tea,ha,32,24,british nyasaland,1.0000,attributable,total=0.25,no
-malawi,tea,tonnes,3,3,,,too_few_values,,no
-malawi,tobacco unmanufactured,ha,30,22,british nyasaland,1.0000,attributable,italy=0.27,no
-malawi,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-mali,cotton lint,ha,5,5,,,too_few_values,,no
-mali,cotton lint,tonnes,6,6,,,too_few_values,,no
-mali,cotton seed,ha,5,5,,,too_few_values,,no
-mali,cotton seed,tonnes,5,5,,,too_few_values,,no
-mali,groundnuts with shell,ha,8,8,french sudan,1.0000,attributable,total=0.38,no
-mali,tobacco unmanufactured,ha,9,7,french sudan,0.8889,attributable,japan=0.44,no
-mali,tobacco unmanufactured,tonnes,9,8,french sudan,0.8889,attributable,turkey=0.11,no
-malta,cotton lint,ha,26,22,british malta,1.0000,attributable,british ceylon=0.23,no
-malta,cotton lint,tonnes,8,4,,,too_few_distinct,,no
-malta,cotton seed,ha,13,9,british malta,1.0000,attributable,british barbados=0.46,no
-malta,cotton seed,tonnes,13,9,british malta,1.0000,attributable,sweden=0.46,no
-malta,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-malta,oranges,ha,4,2,,,too_few_values,,no
-malta,oranges,tonnes,10,6,british malta,1.0000,attributable,france=0.50,no
-malta,wine,ha,15,8,british malta,1.0000,attributable,switzerland=0.47,no
-malta,wine,tonnes,19,18,,,unattributable,yugoslavia=0.00,no
-martinique,cacao beans,ha,7,3,,,too_few_values,,no
-martinique,cacao beans,tonnes,29,21,french martinique,1.0000,attributable,british cyprus=0.34,no
-martinique,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-mauritania,beans dry,ha,11,7,,,ambiguous,french mauritania=1.00;total=0.73;mexico=0.64,no
-mauritania,beans dry,tonnes,11,9,french mauritania,1.0000,attributable,italy=0.55,no
-mauritania,cotton lint,ha,3,3,,,too_few_values,,no
-mauritania,cotton lint,tonnes,3,3,,,too_few_values,,no
-mauritania,cotton seed,ha,3,3,,,too_few_values,,no
-mauritania,cotton seed,tonnes,3,3,,,too_few_values,,no
-mauritania,groundnuts with shell,ha,18,8,french mauritania,1.0000,attributable,italy=0.56,no
-mauritania,groundnuts with shell,tonnes,19,16,french mauritania,1.0000,attributable,french annam=0.37,no
-mauritania,tobacco unmanufactured,ha,9,6,,,ambiguous,french mauritania=1.00;french madagascar=0.67;french algeria=0.67,no
-mauritania,tobacco unmanufactured,tonnes,14,12,french mauritania,1.0000,attributable,british southern rhodesia=0.50,no
-mauritius,coffee green,ha,10,7,british mauritius,1.0000,attributable,french tunisia=0.20,no
-mauritius,coffee green,tonnes,6,6,,,too_few_values,,no
-mauritius,groundnuts with shell,ha,11,4,,,too_few_distinct,,no
-mauritius,groundnuts with shell,tonnes,18,5,,,too_few_distinct,,no
-mauritius,sugar raw centrifugal,tonnes,33,33,british mauritius,1.0000,attributable,bulgaria=0.03,no
-mauritius,tea,ha,28,11,british mauritius,1.0000,attributable,french algeria=0.39,no
-mauritius,tea,tonnes,27,19,british mauritius,1.0000,attributable,french mauritania=0.04,no
-mauritius,tobacco unmanufactured,ha,16,11,british mauritius,1.0000,attributable,french india=0.31,no
-mauritius,tobacco unmanufactured,tonnes,20,18,british mauritius,1.0000,attributable,french tunisia=0.15,no
-mexico,cacao beans,ha,14,10,mexico,1.0000,attributable,total=0.43,no
-mexico,castor beans seed,tonnes,6,6,,,too_few_values,,no
-mexico,coffee green,ha,3,2,,,too_few_values,,no
-mexico,cotton lint,ha,12,12,mexico,1.0000,attributable,netherlands=0.08,no
-mexico,cotton seed,ha,19,18,mexico,1.0000,attributable,finland=0.05,no
-mexico,cotton seed,tonnes,4,4,,,too_few_values,,no
-mexico,flax fibre and tow,ha,9,7,mexico,1.0000,attributable,total=0.44,no
-mexico,flax fibre and tow,tonnes,11,10,mexico,1.0000,attributable,italy=0.36,no
-mexico,lemons and limes,tonnes,1,1,,,too_few_values,,no
-mexico,oranges,tonnes,1,1,,,too_few_values,,no
-mexico,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-mexico,wine,tonnes,6,5,,,too_few_values,,no
-micronesia (federated states of),eggs hen in shell,tonnes,6,2,,,too_few_values,,no
-micronesia (federated states of),sugar raw centrifugal,tonnes,6,6,,,too_few_values,,no
-micronesia (federated states of),tobacco unmanufactured,ha,5,1,,,too_few_values,,no
-micronesia (federated states of),tobacco unmanufactured,tonnes,5,5,,,too_few_values,,no
-montserrat,cotton lint,ha,33,22,british montserrat,1.0000,attributable,british cyprus=0.33,no
-montserrat,cotton lint,tonnes,33,25,british montserrat,1.0000,attributable,british cyprus=0.27,no
-montserrat,cotton seed,ha,20,10,british montserrat,1.0000,attributable,british cyprus=0.55,no
-montserrat,cotton seed,tonnes,20,12,british montserrat,1.0000,attributable,us philippines=0.25,no
-montserrat,lemons and limes,ha,6,5,,,too_few_values,,no
-montserrat,lemons and limes,tonnes,15,8,british montserrat,1.0000,attributable,british cyprus=0.40,no
-montserrat,sugar raw centrifugal,tonnes,14,5,,,too_few_distinct,,no
-morocco,beans dry,ha,6,1,,,too_few_values,,no
-morocco,beans dry,tonnes,12,8,french morocco,1.0000,attributable,france=0.58,no
-morocco,cotton lint,ha,10,6,,,ambiguous,french morocco=1.00;british cyprus=0.70;french dahomey=0.60,no
-morocco,cotton lint,tonnes,9,7,,,ambiguous,french morocco=1.00;british southern rhodesia=0.67,no
-morocco,cotton seed,ha,12,7,,,ambiguous,french morocco=1.00;british cyprus=0.75,no
-morocco,cotton seed,tonnes,10,7,french morocco,1.0000,attributable,french annam=0.50,no
-morocco,eggs hen in shell,tonnes,7,4,,,too_few_values,,no
-morocco,flax fibre and tow,ha,19,17,french morocco,1.0000,attributable,total=0.21,no
-morocco,flax fibre and tow,tonnes,12,12,french morocco,1.0000,attributable,hungary=0.25,no
-morocco,grapes,ha,13,12,french morocco,1.0000,attributable,french algeria=0.23,no
-morocco,grapes,tonnes,8,8,french morocco,1.0000,attributable,italy=0.25,no
-morocco,hempseed,ha,3,3,,,too_few_values,,no
-morocco,lemons and limes,tonnes,1,1,,,too_few_values,,no
-morocco,linseed,ha,7,7,,,too_few_values,,no
-morocco,linseed,tonnes,14,14,french morocco,1.0000,attributable,paraguay=0.07,no
-morocco,oats,ha,7,6,,,too_few_values,,no
-morocco,oats,tonnes,7,7,,,too_few_values,,no
-morocco,oil olive virgin,tonnes,1,1,,,too_few_values,,no
-morocco,olives,tonnes,12,12,french morocco,1.0000,attributable,usa=0.08,no
-morocco,p,tonnes,17,6,french morocco,1.0000,attributable,france=0.59,no
-morocco,raisins,ha,1,1,,,too_few_values,,no
-morocco,raisins,tonnes,5,5,,,too_few_values,,no
-morocco,rye,ha,9,8,french morocco,1.0000,attributable,bulgaria=0.56,no
-morocco,rye,tonnes,9,8,french morocco,1.0000,attributable,austria=0.44,no
-morocco,sesame seed,ha,1,1,,,too_few_values,,no
-morocco,sesame seed,tonnes,1,1,,,too_few_values,,no
-morocco,silk worm cocoons reelable,tonnes,4,4,,,too_few_values,,no
-morocco,sunflower seed,ha,2,2,,,too_few_values,,no
-morocco,sunflower seed,tonnes,2,2,,,too_few_values,,no
-morocco,tobacco unmanufactured,ha,14,6,,,ambiguous,french morocco=1.00;new zealand=0.71;french india=0.71,no
-morocco,tobacco unmanufactured,tonnes,14,14,french morocco,1.0000,attributable,yugoslavia=0.00,no
-morocco,wine,ha,12,12,french morocco,1.0000,attributable,french equatorial africa=0.25,no
-morocco,yarn of true hemp,ha,6,6,,,too_few_values,,no
-morocco,yarn of true hemp,tonnes,3,3,,,too_few_values,,no
-mozambique,beans dry,ha,1,1,,,too_few_values,,no
-mozambique,beans dry,tonnes,1,1,,,too_few_values,,no
-mozambique,cotton lint,ha,11,9,portuguese mozambique: company concession,0.6364,attributable,portuguese mozambique: province=0.36,no
-mozambique,cotton lint,tonnes,10,8,portuguese mozambique: company concession,0.8000,attributable,yugoslavia=0.40,no
-mozambique,cotton seed,ha,6,6,,,too_few_values,,no
-mozambique,cotton seed,tonnes,6,6,,,too_few_values,,no
-mozambique,eggs hen in shell,tonnes,7,4,,,too_few_values,,no
-mozambique,groundnuts with shell,ha,3,3,,,too_few_values,,no
-mozambique,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-mozambique,sugar raw centrifugal,tonnes,7,7,,,too_few_values,,no
-mozambique,tea,ha,5,2,,,too_few_values,,no
-mozambique,tea,tonnes,5,3,,,too_few_values,,no
-mozambique,tobacco unmanufactured,ha,4,3,,,too_few_values,,no
-mozambique,tobacco unmanufactured,tonnes,5,4,,,too_few_values,,no
-myanmar,beans dry,ha,6,6,,,too_few_values,,no
-myanmar,cotton lint,ha,11,11,british burma,1.0000,attributable,total=0.18,no
-myanmar,cotton lint,tonnes,11,11,british burma,1.0000,attributable,hungary=0.18,no
-myanmar,cotton seed,ha,11,11,british burma,1.0000,attributable,total=0.18,no
-myanmar,cotton seed,tonnes,11,11,british burma,1.0000,attributable,uk: england and wales=0.09,no
-myanmar,groundnuts with shell,ha,11,11,british burma,1.0000,attributable,total=0.18,no
-myanmar,groundnuts with shell,tonnes,11,8,british burma,1.0000,attributable,brazil=0.09,no
-myanmar,rapeseed,ha,3,2,,,too_few_values,,no
-myanmar,rubber natural,ha,6,5,,,too_few_values,,no
-myanmar,sesame seed,ha,12,12,british burma,1.0000,attributable,british uganda=0.17,no
-myanmar,sesame seed,tonnes,10,10,british burma,1.0000,attributable,greece=0.10,no
-myanmar,tea,ha,5,1,,,too_few_values,,no
-myanmar,tobacco unmanufactured,ha,12,11,british burma,1.0000,attributable,total=0.25,no
-myanmar,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-namibia,tobacco unmanufactured,tonnes,8,8,german south west africa,1.0000,attributable,yugoslavia=0.12,no
-nauru,p,tonnes,15,11,british nauru,1.0000,attributable,uruguay=0.07,no
-nepal,jute,tonnes,18,16,nepal,1.0000,attributable,spain=0.17,no
-netherlands,butter cow milk,tonnes,7,7,,,too_few_values,,no
-netherlands,cheese processed,tonnes,7,7,,,too_few_values,,no
-netherlands,eggs hen in shell,tonnes,17,15,netherlands,1.0000,attributable,switzerland=0.06,no
-netherlands,grapes,ha,10,1,,,too_few_distinct,,no
-netherlands,hemp tow waste,ha,11,8,netherlands,1.0000,attributable,japan: karafuto prefecture=0.09,no
-netherlands,hops,ha,10,7,netherlands,1.0000,attributable,dutch new guinea=0.10,no
-netherlands,milk whole fresh cow,tonnes,4,4,,,too_few_values,,no
-netherlands,n,tonnes,13,10,netherlands,1.0000,attributable,paraguay=0.08,no
-netherlands,p,tonnes,16,16,netherlands,1.0000,attributable,mexico=0.06,no
-netherlands,sugar raw centrifugal,tonnes,33,33,netherlands,1.0000,attributable,yugoslavia=0.00,no
-netherlands,tobacco unmanufactured,ha,8,5,,,too_few_distinct,,no
-netherlands,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-netherlands,yarn of true hemp,tonnes,12,12,netherlands,1.0000,attributable,yugoslavia=0.00,no
-new caledonia,coffee green,ha,16,5,,,too_few_distinct,,no
-new caledonia,coffee green,tonnes,18,14,french new caledonia,1.0000,attributable,bulgaria=0.39,no
-new caledonia,cotton lint,ha,4,2,,,too_few_values,,no
-new caledonia,cotton lint,tonnes,6,4,,,too_few_values,,no
-new caledonia,cotton seed,ha,4,2,,,too_few_values,,no
-new caledonia,cotton seed,tonnes,7,4,,,too_few_values,,no
-new caledonia,p,tonnes,4,3,,,too_few_values,,no
-new zealand,butter cow milk,tonnes,7,7,,,too_few_values,,no
-new zealand,cheese processed,tonnes,7,7,,,too_few_values,,no
-new zealand,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-new zealand,flax fibre and tow,ha,17,11,new zealand,1.0000,attributable,austria=0.59,no
-new zealand,flax fibre and tow,tonnes,6,5,,,too_few_values,,no
-new zealand,grapes,ha,16,8,new zealand,1.0000,attributable,french algeria=0.38,no
-new zealand,hops,ha,27,17,new zealand,1.0000,attributable,french guadeloupe=0.30,no
-new zealand,hops,tonnes,8,8,new zealand,1.0000,attributable,yugoslavia=0.00,no
-new zealand,lemons and limes,tonnes,3,3,,,too_few_values,,no
-new zealand,linseed,ha,7,7,,,too_few_values,,no
-new zealand,linseed,tonnes,9,9,new zealand,1.0000,attributable,yugoslavia=0.00,no
-new zealand,milk whole fresh cow,tonnes,5,5,,,too_few_values,,no
-new zealand,oranges,tonnes,2,2,,,too_few_values,,no
-new zealand,p,tonnes,4,4,,,too_few_values,,no
-new zealand,rye,ha,14,11,new zealand,1.0000,attributable,uruguay=0.29,no
-new zealand,rye,tonnes,21,15,new zealand,1.0000,attributable,british cyprus=0.43,no
-new zealand,tobacco unmanufactured,ha,20,9,new zealand,1.0000,attributable,french morocco=0.55,no
-new zealand,tobacco unmanufactured,tonnes,15,15,new zealand,1.0000,attributable,germany=0.07,no
-new zealand,wine,ha,10,7,new zealand,1.0000,attributable,sweden=0.50,no
-new zealand,wine,tonnes,3,3,,,too_few_values,,no
-nicaragua,cacao beans,ha,4,3,,,too_few_values,,no
-nicaragua,cacao beans,tonnes,18,12,nicaragua,1.0000,attributable,british cyprus=0.44,no
-nicaragua,coffee green,ha,1,1,,,too_few_values,,no
-nicaragua,coffee green,tonnes,1,1,,,too_few_values,,no
-nicaragua,cotton lint,ha,7,4,,,too_few_values,,no
-nicaragua,cotton seed,ha,7,4,,,too_few_values,,no
-nicaragua,cotton seed,tonnes,7,7,,,too_few_values,,no
-nicaragua,eggs hen in shell,tonnes,2,1,,,too_few_values,,no
-nicaragua,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-nigeria,cotton lint,ha,9,3,,,too_few_distinct,,no
-nigeria,cotton lint,tonnes,1,1,,,too_few_values,,no
-nigeria,cotton seed,tonnes,17,16,british nigeria,1.0000,attributable,spain=0.06,no
-nigeria,groundnuts with shell,ha,2,2,,,too_few_values,,no
-nigeria,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-nigeria,rubber natural,ha,5,4,,,too_few_values,,no
-nigeria,sesame seed,ha,4,4,,,too_few_values,,no
-nigeria,sesame seed,tonnes,19,19,british nigeria,1.0000,attributable,norway=0.11,no
-norway,butter cow milk,tonnes,7,7,,,too_few_values,,no
-norway,cheese processed,tonnes,7,7,,,too_few_values,,no
-norway,eggs hen in shell,tonnes,10,10,norway,1.0000,attributable,yugoslavia=0.00,no
-norway,milk whole fresh cow,tonnes,2,2,,,too_few_values,,no
-norway,n,tonnes,15,14,norway,1.0000,attributable,sweden=0.07,no
-norway,no3,tonnes,13,13,norway,1.0000,attributable,yugoslavia=0.00,no
-norway,p,tonnes,14,14,norway,1.0000,attributable,yugoslavia=0.00,no
-palau,p,tonnes,13,9,japanese south pacific: palau-angaur,1.0000,attributable,france=0.15,no
-panama,cacao beans,tonnes,23,22,panama,1.0000,attributable,spain=0.13,no
-panama,coffee green,ha,1,1,,,too_few_values,,no
-panama,eggs hen in shell,tonnes,6,6,,,too_few_values,,no
-paraguay,beans dry,ha,1,1,,,too_few_values,,no
-paraguay,beans dry,tonnes,1,1,,,too_few_values,,no
-paraguay,coffee green,ha,2,2,,,too_few_values,,no
-paraguay,coffee green,tonnes,3,3,,,too_few_values,,no
-paraguay,cotton lint,ha,12,11,paraguay,1.0000,attributable,total=0.25,no
-paraguay,cotton lint,tonnes,4,4,,,too_few_values,,no
-paraguay,cotton seed,ha,12,11,paraguay,1.0000,attributable,total=0.25,no
-paraguay,cotton seed,tonnes,13,13,paraguay,1.0000,attributable,us puerto rico=0.08,no
-paraguay,groundnuts with shell,ha,2,2,,,too_few_values,,no
-paraguay,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-paraguay,lemons and limes,tonnes,6,3,,,too_few_values,,no
-paraguay,oranges,ha,1,1,,,too_few_values,,no
-paraguay,oranges,tonnes,2,2,,,too_few_values,,no
-paraguay,sugar raw centrifugal,tonnes,27,25,paraguay,1.0000,attributable,hungary=0.11,no
-paraguay,tangerines mandarins clementines satsumas,tonnes,2,2,,,too_few_values,,no
-peru,coffee green,tonnes,1,1,,,too_few_values,,no
-peru,cotton lint,ha,1,1,,,too_few_values,,no
-peru,cotton seed,ha,18,18,peru,1.0000,attributable,total=0.28,no
-peru,cotton seed,tonnes,1,1,,,too_few_values,,no
-peru,fertilizer mixed,tonnes,17,17,peru,1.0000,attributable,yugoslavia=0.00,no
-peru,grapes,ha,1,1,,,too_few_values,,no
-peru,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-peru,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-peru,wine,ha,3,2,,,too_few_values,,no
-peru,wine,tonnes,9,9,,,unattributable,yugoslavia=0.00,no
-philippines,cacao beans,ha,16,14,us philippines,1.0000,attributable,italy=0.25,no
-philippines,cacao beans,tonnes,16,14,us philippines,1.0000,attributable,spain=0.19,no
-philippines,coffee green,ha,16,13,us philippines,1.0000,attributable,italian eritrea=0.31,no
-philippines,coffee green,tonnes,20,17,us philippines,1.0000,attributable,new zealand=0.25,no
-philippines,cotton lint,ha,9,6,us philippines,1.0000,attributable,ireland=0.56,no
-philippines,cotton lint,tonnes,9,7,us philippines,1.0000,attributable,nicaragua=0.44,no
-philippines,cotton seed,ha,8,6,,,ambiguous,us philippines=1.00;ireland=0.62,no
-philippines,cotton seed,tonnes,8,8,us philippines,1.0000,attributable,japan=0.38,no
-philippines,eggs hen in shell,tonnes,9,9,us philippines,1.0000,attributable,yugoslavia=0.00,no
-philippines,grapefruit inc pomelos,ha,7,4,,,too_few_values,,no
-philippines,grapefruit inc pomelos,tonnes,7,7,,,too_few_values,,no
-philippines,groundnuts with shell,ha,11,8,us philippines,1.0000,attributable,total=0.36,no
-philippines,groundnuts with shell,tonnes,11,10,us philippines,1.0000,attributable,british southern rhodesia=0.18,no
-philippines,hemp tow waste,ha,7,7,,,too_few_values,,no
-philippines,manila fibre abaca,ha,13,13,us philippines,1.0000,attributable,france=0.08,no
-philippines,manila fibre abaca,tonnes,13,12,us philippines,1.0000,attributable,total general excluding the ussr=0.08,no
-philippines,oranges,ha,7,4,,,too_few_values,,no
-philippines,oranges,tonnes,7,7,,,too_few_values,,no
-philippines,rubber natural,ha,6,3,,,too_few_values,,no
-philippines,sugar raw centrifugal,tonnes,30,30,us philippines,0.9333,attributable,spanish spanish guinea=0.03,no
-philippines,tangerines mandarins clementines satsumas,ha,7,4,,,too_few_values,,no
-philippines,tangerines mandarins clementines satsumas,tonnes,7,6,,,too_few_values,,no
-philippines,tobacco unmanufactured,ha,26,25,us philippines,1.0000,attributable,total=0.08,no
-philippines,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-philippines,yarn of true hemp,tonnes,8,8,us philippines,1.0000,attributable,yugoslavia=0.00,no
-poland,hops,ha,1,1,,,too_few_values,,no
-poland,hops,tonnes,1,1,,,too_few_values,,no
-poland,k,tonnes,4,4,,,too_few_values,,no
-poland,n,tonnes,4,4,,,too_few_values,,no
-poland,p,tonnes,4,4,,,too_few_values,,no
-poland,soybeans,ha,3,2,,,too_few_values,,no
-poland,sugar raw centrifugal,tonnes,23,23,poland,1.0000,attributable,total general excluding the ussr=0.04,no
-poland,tobacco unmanufactured,ha,1,1,,,too_few_values,,no
-poland,yarn of true hemp,ha,13,11,poland,1.0000,attributable,italy=0.23,no
-poland,yarn of true hemp,tonnes,15,15,poland,1.0000,attributable,yugoslavia=0.07,no
-portugal,eggs hen in shell,tonnes,1,1,,,too_few_values,,no
-portugal,fertilizer mixed,tonnes,5,4,,,too_few_values,,no
-portugal,lemons and limes,tonnes,8,4,,,too_few_distinct,,no
-portugal,n,tonnes,8,7,portugal,1.0000,attributable,ireland=0.12,no
-portugal,olives,ha,1,1,,,too_few_values,,no
-portugal,oranges,tonnes,14,5,,,too_few_distinct,,no
-portugal,p,tonnes,15,13,portugal,1.0000,attributable,portuguese mozambique=0.07,no
-portugal,silk worm cocoons reelable,tonnes,1,1,,,too_few_values,,no
-portugal,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-portugal,wine,ha,4,1,,,too_few_values,,no
-portugal,wine,tonnes,29,29,,,unattributable,yugoslavia=0.00,no
-reunion,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-reunion,sugar raw centrifugal,tonnes,33,32,french reunion,1.0000,attributable,total=0.06,no
-reunion,tobacco unmanufactured,tonnes,11,8,french reunion,1.0000,attributable,total=0.27,no
-romania,cotton lint,ha,16,13,romania,1.0000,attributable,hungary=0.44,no
-romania,cotton lint,tonnes,1,1,,,too_few_values,,no
-romania,cotton seed,ha,16,13,romania,1.0000,attributable,hungary=0.44,no
-romania,cotton seed,tonnes,15,15,romania,1.0000,attributable,italian eritrea=0.33,no
-romania,fertilizer mixed,tonnes,4,4,,,too_few_values,,no
-romania,hops,ha,4,4,,,too_few_values,,no
-romania,n,tonnes,3,3,,,too_few_values,,no
-romania,p,tonnes,2,2,,,too_few_values,,no
-romania,silk worm cocoons reelable,tonnes,20,20,romania,1.0000,attributable,sweden=0.10,no
-romania,soybeans,ha,4,4,,,too_few_values,,no
-romania,sugar raw centrifugal,tonnes,29,29,romania,1.0000,attributable,switzerland=0.03,no
-romania,wine,ha,8,6,romania,1.0000,attributable,yugoslavia=0.00,no
-romania,wine,tonnes,28,28,,,unattributable,yugoslavia=0.00,no
-romania,yarn of true hemp,ha,13,11,romania,1.0000,attributable,poland=0.23,no
-romania,yarn of true hemp,tonnes,21,21,romania,1.0000,attributable,total south hemisphere aggregated=0.05,no
-saint kitts and nevis,cotton lint,ha,33,20,british saint christopher and nevis,1.0000,attributable,french algeria=0.30,no
-saint kitts and nevis,cotton lint,tonnes,33,26,british saint christopher and nevis,1.0000,attributable,british montserrat=0.24,no
-saint kitts and nevis,cotton seed,ha,20,9,british saint christopher and nevis,1.0000,attributable,french algeria=0.50,no
-saint kitts and nevis,cotton seed,tonnes,18,15,british saint christopher and nevis,1.0000,attributable,british cyprus=0.28,no
-saint kitts and nevis,sugar raw centrifugal,tonnes,32,32,british saint christopher and nevis,1.0000,attributable,total=0.03,no
-saint lucia,cacao beans,ha,28,6,british saint lucia,1.0000,attributable,italy=0.39,no
-saint lucia,cacao beans,tonnes,31,22,british saint lucia,1.0000,attributable,france=0.26,no
-saint lucia,lemons and limes,ha,13,3,,,too_few_distinct,,no
-saint lucia,lemons and limes,tonnes,14,9,british saint lucia,1.0000,attributable,portugal=0.43,no
-saint lucia,sugar raw centrifugal,tonnes,27,25,british saint lucia,1.0000,attributable,british nigeria=0.07,no
-saint vincent and the grenadines,cacao beans,ha,19,6,british saint vincent,1.0000,attributable,british sierra leone=0.26,no
-saint vincent and the grenadines,cacao beans,tonnes,20,20,british saint vincent,1.0000,attributable,usa: hawaii=0.10,no
-saint vincent and the grenadines,cotton lint,ha,33,23,british saint vincent,1.0000,attributable,british cyprus=0.33,no
-saint vincent and the grenadines,cotton lint,tonnes,32,24,british saint vincent,1.0000,attributable,british cyprus=0.28,no
-saint vincent and the grenadines,cotton seed,ha,20,10,british saint vincent,1.0000,attributable,british cyprus=0.55,no
-saint vincent and the grenadines,cotton seed,tonnes,18,15,british saint vincent,1.0000,attributable,guatemala=0.28,no
-saint vincent and the grenadines,grapefruit inc pomelos,tonnes,5,1,,,too_few_values,,no
-saint vincent and the grenadines,groundnuts with shell,ha,7,5,,,too_few_values,,no
-saint vincent and the grenadines,groundnuts with shell,tonnes,13,8,,,ambiguous,british saint vincent=1.00;british cyprus=0.77,no
-saint vincent and the grenadines,lemons and limes,tonnes,13,3,,,too_few_distinct,,no
-saint vincent and the grenadines,oranges,tonnes,5,1,,,too_few_values,,no
-saint vincent and the grenadines,sugar raw centrifugal,tonnes,14,12,british saint vincent,1.0000,attributable,yugoslavia=0.29,no
-samoa,cacao beans,ha,13,7,new zealand western samoa,0.6923,attributable,us philippines=0.31,no
-samoa,cacao beans,tonnes,26,25,new zealand western samoa,0.7308,attributable,british samoa=0.27,no
-sao tome and principe,coffee green,tonnes,10,9,,,ambiguous,portuguese sao tome and principe=1.00;british southern rhodesia=0.60;british montserrat=0.60,no
-senegal,beans dry,ha,12,11,french senegal,1.0000,attributable,total=0.33,no
-senegal,beans dry,tonnes,12,11,french senegal,1.0000,attributable,total=0.58,no
-senegal,cotton lint,ha,8,6,french senegal,1.0000,attributable,french annam=0.38,no
-senegal,cotton lint,tonnes,7,5,,,too_few_values,,no
-senegal,cotton seed,ha,8,6,french senegal,1.0000,attributable,french annam=0.38,no
-senegal,cotton seed,tonnes,7,5,,,too_few_values,,no
-senegal,eggs hen in shell,tonnes,4,3,,,too_few_values,,no
-senegal,groundnuts with shell,ha,19,18,french senegal,0.7895,attributable,total=0.26,no
-senegal,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-senegal,other citrus fruit n e c,ha,2,1,,,too_few_values,,no
-senegal,other citrus fruit n e c,tonnes,4,1,,,too_few_values,,no
-senegal,tobacco unmanufactured,ha,4,4,,,too_few_values,,no
-senegal,tobacco unmanufactured,tonnes,4,4,,,too_few_values,,no
-serbia,beans dry,ha,7,4,,,too_few_values,,no
-serbia,beans dry,tonnes,7,6,,,too_few_values,,no
-serbia,castor beans seed,tonnes,1,1,,,too_few_values,,no
-serbia,cotton lint,ha,14,12,yugoslavia,0.7143,attributable,french tonkin=0.36,no
-serbia,cotton lint,tonnes,14,13,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,cotton seed,ha,15,13,yugoslavia,0.7333,attributable,total=0.33,no
-serbia,cotton seed,tonnes,14,13,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,flax fibre and tow,ha,17,15,,,unattributable,yugoslavia=0.59,no
-serbia,flax fibre and tow,tonnes,16,15,yugoslavia,0.6250,attributable,"kingdom of serbs, croats and slovenes=0.38",no
-serbia,grapes,ha,9,9,yugoslavia,0.7778,attributable,"kingdom of serbs, croats and slovenes=0.22",no
-serbia,grapes,tonnes,5,5,,,too_few_values,,no
-serbia,hemp tow waste,ha,7,7,,,too_few_values,,no
-serbia,hemp tow waste,tonnes,2,2,,,too_few_values,,no
-serbia,hempseed,tonnes,10,10,yugoslavia,1.0000,attributable,bulgaria=0.30,no
-serbia,hops,ha,14,14,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,hops,tonnes,14,14,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,lemons and limes,tonnes,6,2,,,too_few_values,,no
-serbia,linseed,tonnes,4,4,,,too_few_values,,no
-serbia,n,tonnes,4,4,,,too_few_values,,no
-serbia,oats,ha,2,2,,,too_few_values,,no
-serbia,oats,tonnes,6,6,,,too_few_values,,no
-serbia,oil olive virgin,tonnes,20,18,yugoslavia,0.8000,attributable,total=0.20,no
-serbia,olives,tonnes,7,7,,,too_few_values,,no
-serbia,oranges,tonnes,6,5,,,too_few_values,,no
-serbia,p,tonnes,3,3,,,too_few_values,,no
-serbia,rapeseed,ha,14,13,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,rapeseed,tonnes,16,16,yugoslavia,0.7500,attributable,"kingdom of serbs, croats and slovenes=0.25",no
-serbia,rye,ha,22,20,yugoslavia,0.7273,attributable,"kingdom of serbs, croats and slovenes=0.27",no
-serbia,rye,tonnes,22,22,yugoslavia,0.7273,attributable,"kingdom of serbs, croats and slovenes=0.27",no
-serbia,sesame seed,ha,10,6,,,ambiguous,yugoslavia=1.00;ireland=0.60;british cyprus=0.60,no
-serbia,sesame seed,tonnes,10,8,yugoslavia,1.0000,attributable,france=0.40,no
-serbia,silk worm cocoons reelable,tonnes,16,15,yugoslavia,0.6875,attributable,"kingdom of serbs, croats and slovenes=0.31",no
-serbia,soybeans,ha,7,5,,,too_few_values,,no
-serbia,soybeans,tonnes,7,7,,,too_few_values,,no
-serbia,sugar raw centrifugal,tonnes,25,25,yugoslavia,0.6000,attributable,"kingdom of serbs, croats and slovenes=0.40",no
-serbia,sunflower seed,ha,1,1,,,too_few_values,,no
-serbia,sunflower seed,tonnes,1,1,,,too_few_values,,no
-serbia,tobacco unmanufactured,ha,17,16,yugoslavia,0.6471,attributable,"kingdom of serbs, croats and slovenes=0.35",no
-serbia,tobacco unmanufactured,tonnes,17,17,yugoslavia,0.6471,attributable,"kingdom of serbs, croats and slovenes=0.35",no
-serbia,wheat,ha,14,13,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,wheat,tonnes,14,14,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,wine,ha,14,14,yugoslavia,0.7143,attributable,"kingdom of serbs, croats and slovenes=0.29",no
-serbia,wine,tonnes,18,18,,,unattributable,yugoslavia=0.00,no
-serbia,yarn of true hemp,ha,13,13,yugoslavia,0.6923,attributable,"kingdom of serbs, croats and slovenes=0.31",no
-serbia,yarn of true hemp,tonnes,18,18,,,unattributable,yugoslavia=0.50,no
-seychelles,cacao beans,tonnes,7,6,,,too_few_values,,no
-seychelles,fertilizer mixed,tonnes,11,11,british seychelles,1.0000,attributable,yugoslavia=0.00,no
-sierra leone,cacao beans,ha,9,8,british sierra leone,1.0000,attributable,total=0.11,no
-sierra leone,cacao beans,tonnes,17,14,british sierra leone,1.0000,attributable,british cyprus=0.35,no
-sierra leone,coffee green,ha,10,2,,,too_few_distinct,,no
-sierra leone,coffee green,tonnes,13,5,,,too_few_distinct,,no
-sierra leone,groundnuts with shell,ha,7,1,,,too_few_values,,no
-sierra leone,groundnuts with shell,tonnes,3,1,,,too_few_values,,no
-sierra leone,rubber natural,ha,6,1,,,too_few_values,,no
-sierra leone,sesame seed,tonnes,15,11,british sierra leone,1.0000,attributable,france=0.33,no
-singapore,coffee green,ha,11,10,british straits settlements,1.0000,attributable,luxembourg=0.09,no
-somalia,cotton lint,ha,9,8,italian somaliland,1.0000,attributable,japan=0.33,no
-somalia,cotton lint,tonnes,9,8,italian somaliland,1.0000,attributable,yugoslavia=0.33,no
-somalia,cotton seed,ha,6,6,,,too_few_values,,no
-somalia,cotton seed,tonnes,5,5,,,too_few_values,,no
-somalia,eggs hen in shell,tonnes,3,2,,,too_few_values,,no
-somalia,groundnuts with shell,ha,4,2,,,too_few_values,,no
-somalia,groundnuts with shell,tonnes,4,4,,,too_few_values,,no
-somalia,sesame seed,ha,5,4,,,too_few_values,,no
-somalia,sesame seed,tonnes,4,4,,,too_few_values,,no
-somalia,sugar raw centrifugal,tonnes,2,2,,,too_few_values,,no
-south africa,beans dry,tonnes,2,2,,,too_few_values,,no
-south africa,butter cow milk,tonnes,7,6,,,too_few_values,,no
-south africa,cheese processed,tonnes,7,6,,,too_few_values,,no
-south africa,cotton lint,ha,16,16,union of south africa,1.0000,attributable,paraguay=0.06,no
-south africa,cotton lint,tonnes,18,14,union of south africa,1.0000,attributable,british cyprus=0.44,no
-south africa,cotton seed,ha,6,6,,,too_few_values,,no
-south africa,cotton seed,tonnes,19,16,union of south africa,1.0000,attributable,british cyprus=0.42,no
-south africa,fertilizer mixed,tonnes,4,4,,,too_few_values,,no
-south africa,grapefruit inc pomelos,tonnes,6,6,,,too_few_values,,no
-south africa,grapes,ha,7,7,,,too_few_values,,no
-south africa,grapes,tonnes,5,5,,,too_few_values,,no
-south africa,groundnuts with shell,ha,6,6,,,too_few_values,,no
-south africa,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-south africa,lemons and limes,tonnes,9,8,union of south africa,1.0000,attributable,hungary=0.44,no
-south africa,n,tonnes,4,4,,,too_few_values,,no
-south africa,oats,tonnes,7,7,,,too_few_values,,no
-south africa,oranges,tonnes,6,6,,,too_few_values,,no
-south africa,raisins,tonnes,11,8,union of south africa,1.0000,attributable,total=0.27,no
-south africa,rye,ha,8,8,union of south africa,1.0000,attributable,total=0.12,no
-south africa,rye,tonnes,17,16,union of south africa,1.0000,attributable,yugoslavia=0.12,no
-south africa,sugar raw centrifugal,tonnes,32,32,union of south africa,1.0000,attributable,yugoslavia=0.00,no
-south africa,tangerines mandarins clementines satsumas,tonnes,8,5,,,too_few_distinct,,no
-south africa,tea,ha,27,16,union of south africa,1.0000,attributable,new zealand=0.37,no
-south africa,tea,tonnes,27,27,union of south africa,1.0000,attributable,british uganda=0.04,no
-south africa,tobacco unmanufactured,ha,10,9,union of south africa,1.0000,attributable,switzerland=0.30,no
-south africa,tobacco unmanufactured,tonnes,2,2,,,too_few_values,,no
-south africa,wine,ha,3,3,,,too_few_values,,no
-south africa,wine,tonnes,1,1,,,too_few_values,,no
-south korea,beans dry,ha,3,3,,,too_few_values,,no
-south korea,beans dry,tonnes,3,3,,,too_few_values,,no
-south korea,cotton lint,ha,33,33,japanese korea,1.0000,attributable,usa=0.06,no
-south korea,cotton lint,tonnes,32,32,japanese korea,1.0000,attributable,austria=0.06,no
-south korea,cotton seed,ha,20,20,japanese korea,1.0000,attributable,usa=0.10,no
-south korea,cotton seed,tonnes,20,20,japanese korea,1.0000,attributable,us puerto rico=0.05,no
-south korea,eggs hen in shell,tonnes,7,6,,,too_few_values,,no
-south korea,grapes,ha,6,6,,,too_few_values,,no
-south korea,grapes,tonnes,17,17,japanese korea,1.0000,attributable,italy=0.12,no
-south korea,groundnuts with shell,ha,11,9,japanese korea,1.0000,attributable,new zealand=0.36,no
-south korea,groundnuts with shell,tonnes,11,11,japanese korea,1.0000,attributable,turkey=0.09,no
-south korea,hemp tow waste,ha,12,12,japanese korea,1.0000,attributable,yugoslavia=0.00,no
-south korea,n,tonnes,4,4,,,too_few_values,,no
-south korea,other berries and fruits of the genus vaccinium n e c,ha,12,11,japanese korea,1.0000,attributable,total=0.17,no
-south korea,sesame seed,ha,12,9,japanese korea,1.0000,attributable,czechoslovakia=0.42,no
-south korea,sesame seed,tonnes,12,12,japanese korea,1.0000,attributable,france=0.17,no
-south korea,silk worm cocoons reelable,tonnes,28,28,japanese korea,1.0000,attributable,yugoslavia=0.00,no
-south korea,soybeans,ha,9,9,japanese korea,1.0000,attributable,usa=0.11,no
-south korea,soybeans,tonnes,10,10,japanese korea,1.0000,attributable,yugoslavia=0.00,no
-south korea,sugar raw centrifugal,tonnes,8,7,japanese korea,1.0000,attributable,costa rica=0.25,no
-south korea,tobacco unmanufactured,ha,28,26,japanese korea,1.0000,attributable,french morocco=0.14,no
-south korea,tobacco unmanufactured,tonnes,28,28,japanese korea,1.0000,attributable,yugoslavia=0.00,no
-south korea,yarn of true hemp,ha,11,10,japanese korea,1.0000,attributable,total=0.27,no
-south korea,yarn of true hemp,tonnes,24,23,japanese korea,1.0000,attributable,yugoslavia=0.04,no
-spain,cotton lint,ha,17,17,spain,1.0000,attributable,total=0.18,no
-spain,cotton seed,ha,17,17,spain,1.0000,attributable,total=0.18,no
-spain,cotton seed,tonnes,16,16,spain,1.0000,attributable,portuguese mozambique=0.12,no
-spain,eggs hen in shell,tonnes,1,1,,,too_few_values,,no
-spain,fertilizer mixed,tonnes,14,14,spain,1.0000,attributable,yugoslavia=0.00,no
-spain,grapes,ha,1,1,,,too_few_values,,no
-spain,k,tonnes,4,4,,,too_few_values,,no
-spain,milk whole fresh cow,tonnes,1,1,,,too_few_values,,no
-spain,n,tonnes,15,14,spain,1.0000,attributable,yugoslavia=0.00,no
-spain,other berries and fruits of the genus vaccinium n e c,ha,1,1,,,too_few_values,,no
-spain,other berries and fruits of the genus vaccinium n e c,tonnes,13,12,spain,1.0000,attributable,switzerland=0.15,no
-spain,p,tonnes,15,15,spain,1.0000,attributable,yugoslavia=0.00,no
-spain,raisins,ha,2,2,,,too_few_values,,no
-spain,raisins,tonnes,13,13,spain,1.0000,attributable,total north hemisphere aggregated=0.08,no
-spain,silk worm cocoons reelable,tonnes,29,28,spain,1.0000,attributable,french upper volta=0.03,no
-spain,sugar raw centrifugal,tonnes,31,31,spain,1.0000,attributable,finland=0.06,no
-spain,wine,ha,17,16,spain,1.0000,attributable,yugoslavia=0.00,no
-spain,wine,tonnes,32,32,,,unattributable,yugoslavia=0.00,no
-spain,yarn of true hemp,ha,10,9,spain,1.0000,attributable,mexico=0.30,no
-spain,yarn of true hemp,tonnes,17,17,spain,1.0000,attributable,czechoslovakia=0.12,no
-sri lanka,cacao beans,ha,20,12,british ceylon,1.0000,attributable,total=0.25,no
-sri lanka,cacao beans,tonnes,31,30,british ceylon,1.0000,attributable,total=0.10,no
-sri lanka,coffee green,ha,14,11,british ceylon,1.0000,attributable,sweden=0.07,no
-sri lanka,coffee green,tonnes,8,6,british ceylon,1.0000,attributable,british virgin islands=0.12,no
-sri lanka,cotton lint,ha,12,7,british ceylon,1.0000,attributable,union of south africa=0.42,no
-sri lanka,cotton lint,tonnes,11,5,,,too_few_distinct,,no
-sri lanka,cotton seed,ha,12,7,british ceylon,1.0000,attributable,union of south africa=0.42,no
-sri lanka,cotton seed,tonnes,11,6,british ceylon,1.0000,attributable,new zealand=0.55,no
-sri lanka,rubber natural,ha,13,8,,,unattributable,british ceylon=0.54,no
-sri lanka,sugar raw centrifugal,tonnes,8,7,british ceylon,1.0000,attributable,french mauritania=0.12,no
-sri lanka,tea,ha,32,20,british ceylon,1.0000,attributable,total=0.06,no
-sri lanka,tea,tonnes,1,1,,,too_few_values,,no
-sri lanka,tobacco unmanufactured,ha,22,13,british ceylon,1.0000,attributable,total=0.23,no
-sri lanka,tobacco unmanufactured,tonnes,3,1,,,too_few_values,,no
-suriname,cacao beans,ha,20,17,dutch guiana,1.0000,attributable,new zealand=0.25,no
-suriname,cacao beans,tonnes,24,20,dutch guiana,1.0000,attributable,british grenada=0.25,no
-suriname,coffee green,ha,18,9,dutch guiana,1.0000,attributable,total=0.33,no
-suriname,coffee green,tonnes,32,31,dutch guiana,1.0000,attributable,canada=0.19,no
-suriname,groundnuts with shell,tonnes,4,2,,,too_few_values,,no
-suriname,oranges,ha,12,5,,,too_few_distinct,,no
-suriname,oranges,tonnes,14,11,dutch guiana,1.0000,attributable,uruguay=0.29,no
-suriname,sugar raw centrifugal,tonnes,31,31,dutch guiana,1.0000,attributable,total=0.06,no
-suriname,tobacco unmanufactured,tonnes,6,6,,,too_few_values,,no
-sweden,butter cow milk,tonnes,7,7,,,too_few_values,,no
-sweden,cheese processed,tonnes,7,7,,,too_few_values,,no
-sweden,eggs hen in shell,tonnes,2,2,,,too_few_values,,no
-sweden,fertilizer mixed,tonnes,9,9,sweden,1.0000,attributable,spain=0.11,no
-sweden,flax fibre and tow,ha,4,1,,,too_few_values,,no
-sweden,flax fibre and tow,tonnes,1,1,,,too_few_values,,no
-sweden,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-sweden,n,tonnes,12,11,sweden,1.0000,attributable,usa and canada=0.17,no
-sweden,p,tonnes,16,16,sweden,1.0000,attributable,yugoslavia=0.00,no
-sweden,rapeseed,tonnes,1,1,,,too_few_values,,no
-sweden,sugar raw centrifugal,tonnes,33,33,sweden,1.0000,attributable,yugoslavia=0.00,no
-sweden,tobacco unmanufactured,ha,2,1,,,too_few_values,,no
-switzerland,butter cow milk,tonnes,7,7,,,too_few_values,,no
-switzerland,cheese processed,tonnes,7,7,,,too_few_values,,no
-switzerland,eggs hen in shell,tonnes,15,12,switzerland,1.0000,attributable,netherlands=0.07,no
-switzerland,fertilizer mixed,tonnes,4,4,,,too_few_values,,no
-switzerland,grapes,tonnes,1,1,,,too_few_values,,no
-switzerland,hemp tow waste,ha,4,2,,,too_few_values,,no
-switzerland,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-switzerland,n,tonnes,16,10,switzerland,1.0000,attributable,usa=0.19,no
-switzerland,p,tonnes,4,4,,,too_few_values,,no
-switzerland,rapeseed,ha,3,2,,,too_few_values,,no
-switzerland,rapeseed,tonnes,2,2,,,too_few_values,,no
-switzerland,silk worm cocoons reelable,tonnes,16,15,switzerland,1.0000,attributable,british virgin islands=0.06,no
-switzerland,sugar raw centrifugal,tonnes,33,32,switzerland,1.0000,attributable,italy=0.06,no
-switzerland,wine,ha,13,9,switzerland,1.0000,attributable,total=0.31,no
-switzerland,wine,tonnes,33,33,,,unattributable,yugoslavia=0.00,no
-switzerland,yarn of true hemp,tonnes,3,3,,,too_few_values,,no
-tanzania,cacao beans,ha,4,4,,,too_few_values,,no
-tanzania,coffee green,ha,11,9,british tanganyika,1.0000,attributable,french niger=0.36,no
-tanzania,cotton lint,ha,17,15,british tanganyika,1.0000,attributable,union of south africa=0.12,no
-tanzania,cotton lint,tonnes,1,1,,,too_few_values,,no
-tanzania,cotton seed,ha,10,9,british tanganyika,1.0000,attributable,uk: northern ireland=0.10,no
-tanzania,cotton seed,tonnes,20,20,british tanganyika,1.0000,attributable,total=0.10,no
-tanzania,groundnuts with shell,ha,7,7,,,too_few_values,,no
-tanzania,rubber natural,ha,4,2,,,too_few_values,,no
-tanzania,sesame seed,ha,7,6,,,too_few_values,,no
-tanzania,sesame seed,tonnes,20,18,british tanganyika,1.0000,attributable,total=0.15,no
-tanzania,tea,ha,5,2,,,too_few_values,,no
-tanzania,tea,tonnes,7,7,,,too_few_values,,no
-tanzania,tobacco unmanufactured,ha,7,3,,,too_few_values,,no
-tanzania,tobacco unmanufactured,tonnes,7,7,,,too_few_values,,no
-thailand,cotton lint,ha,26,25,siam,1.0000,attributable,bulgaria=0.19,no
-thailand,cotton lint,tonnes,16,15,siam,1.0000,attributable,total=0.25,no
-thailand,cotton seed,ha,16,15,siam,1.0000,attributable,bulgaria=0.31,no
-thailand,cotton seed,tonnes,15,15,siam,1.0000,attributable,british cyprus=0.20,no
-thailand,rubber natural,ha,4,4,,,too_few_values,,no
-thailand,sesame seed,ha,16,9,,,ambiguous,siam=1.00;italy=0.62;french tonkin=0.62,no
-thailand,sesame seed,tonnes,16,13,siam,1.0000,attributable,hungary=0.25,no
-thailand,tobacco unmanufactured,ha,26,24,siam,1.0000,attributable,total=0.27,no
-thailand,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-togo,cacao beans,ha,3,3,,,too_few_values,,no
-togo,cacao beans,tonnes,5,5,,,too_few_values,,no
-togo,groundnuts with shell,ha,1,1,,,too_few_values,,no
-togo,groundnuts with shell,tonnes,1,1,,,too_few_values,,no
-trinidad and tobago,cacao beans,ha,23,18,british trinidad and tobago,1.0000,attributable,turkey=0.04,no
-trinidad and tobago,cacao beans,tonnes,1,1,,,too_few_values,,no
-trinidad and tobago,coffee green,ha,20,8,british trinidad and tobago,1.0000,attributable,switzerland=0.20,no
-trinidad and tobago,coffee green,tonnes,17,14,british trinidad and tobago,1.0000,attributable,british montserrat=0.29,no
-trinidad and tobago,grapefruit inc pomelos,ha,2,2,,,too_few_values,,no
-trinidad and tobago,grapefruit inc pomelos,tonnes,7,7,,,too_few_values,,no
-trinidad and tobago,rubber natural,ha,13,1,,,too_few_distinct,,no
-trinidad and tobago,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-tunisia,cotton lint,ha,6,3,,,too_few_values,,no
-tunisia,eggs hen in shell,tonnes,8,1,,,too_few_distinct,,no
-tunisia,flax fibre and tow,ha,15,9,french tunisia,1.0000,attributable,sweden=0.47,no
-tunisia,flax fibre and tow,tonnes,8,3,,,too_few_distinct,,no
-tunisia,grapes,ha,29,24,french tunisia,1.0000,attributable,total=0.21,no
-tunisia,grapes,tonnes,18,14,french tunisia,1.0000,attributable,total=0.17,no
-tunisia,lemons and limes,ha,3,1,,,too_few_values,,no
-tunisia,lemons and limes,tonnes,14,10,french tunisia,1.0000,attributable,french annam=0.43,no
-tunisia,linseed,ha,8,8,french tunisia,1.0000,attributable,us philippines=0.12,no
-tunisia,linseed,tonnes,21,18,french tunisia,1.0000,attributable,total=0.10,no
-tunisia,oats,tonnes,7,7,,,too_few_values,,no
-tunisia,oil olive virgin,tonnes,3,3,,,too_few_values,,no
-tunisia,olives,ha,5,4,,,too_few_values,,no
-tunisia,olives,tonnes,6,5,,,too_few_values,,no
-tunisia,oranges,ha,3,2,,,too_few_values,,no
-tunisia,oranges,tonnes,14,11,french tunisia,1.0000,attributable,total=0.21,no
-tunisia,p,tonnes,17,17,french tunisia,1.0000,attributable,yugoslavia=0.00,no
-tunisia,tobacco unmanufactured,ha,25,23,french tunisia,1.0000,attributable,new zealand=0.20,no
-tunisia,tobacco unmanufactured,tonnes,32,32,french tunisia,1.0000,attributable,turkey=0.03,no
-tunisia,wine,ha,20,15,french tunisia,1.0000,attributable,total=0.30,no
-tunisia,wine,tonnes,1,1,,,too_few_values,,no
-turkey,beans dry,ha,11,9,turkey,1.0000,attributable,mexico=0.18,no
-turkey,beans dry,tonnes,12,12,turkey,1.0000,attributable,spain=0.08,no
-turkey,cotton lint,ha,19,19,turkey,0.8421,attributable,turkey in asia=0.11,no
-turkey,cotton seed,ha,18,18,turkey,0.8889,attributable,turkey in asia=0.11,no
-turkey,cotton seed,tonnes,17,17,turkey,0.8824,attributable,turkey in asia=0.12,no
-turkey,eggs hen in shell,tonnes,12,11,turkey,1.0000,attributable,yugoslavia=0.00,no
-turkey,flax fibre and tow,ha,13,13,turkey,1.0000,attributable,total=0.38,no
-turkey,flax fibre and tow,tonnes,13,12,turkey,1.0000,attributable,italy=0.15,no
-turkey,grapes,ha,13,11,turkey,1.0000,attributable,total=0.08,no
-turkey,grapes,tonnes,13,13,turkey,1.0000,attributable,usa=0.08,no
-turkey,hemp tow waste,ha,7,4,,,too_few_values,,no
-turkey,hemp tow waste,tonnes,7,6,,,too_few_values,,no
-turkey,hempseed,ha,11,7,turkey,1.0000,attributable,total=0.55,no
-turkey,hempseed,tonnes,13,11,turkey,1.0000,attributable,egypt=0.31,no
-turkey,lemons and limes,tonnes,6,5,,,too_few_values,,no
-turkey,linseed,ha,4,4,,,too_few_values,,no
-turkey,linseed,tonnes,4,4,,,too_few_values,,no
-turkey,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-turkey,oats,ha,1,1,,,too_few_values,,no
-turkey,oil olive virgin,tonnes,1,1,,,too_few_values,,no
-turkey,olives,ha,7,4,,,too_few_values,,no
-turkey,olives,tonnes,15,15,turkey,1.0000,attributable,total=0.13,no
-turkey,oranges,tonnes,6,6,,,too_few_values,,no
-turkey,raisins,ha,2,2,,,too_few_values,,no
-turkey,raisins,tonnes,13,13,turkey,0.8462,attributable,total=0.08,no
-turkey,rye,ha,19,19,turkey,0.9474,attributable,total north hemisphere aggregated=0.05,no
-turkey,rye,tonnes,18,18,turkey,0.9444,attributable,dutch java and madura=0.06,no
-turkey,sesame seed,ha,17,14,turkey,1.0000,attributable,total=0.12,no
-turkey,sesame seed,tonnes,16,16,turkey,1.0000,attributable,uk: england and wales=0.06,no
-turkey,silk worm cocoons reelable,tonnes,19,19,turkey,1.0000,attributable,romania=0.05,no
-turkey,sugar raw centrifugal,tonnes,16,14,turkey,1.0000,attributable,netherlands=0.06,no
-turkey,sunflower seed,ha,1,1,,,too_few_values,,no
-turkey,sunflower seed,tonnes,1,1,,,too_few_values,,no
-turkey,tangerines mandarins clementines satsumas,tonnes,6,6,,,too_few_values,,no
-turkey,tobacco unmanufactured,ha,16,14,turkey,1.0000,attributable,total=0.19,no
-turkey,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-turkey,wheat,ha,1,1,,,too_few_values,,no
-turkey,wine,ha,2,2,,,too_few_values,,no
-turkey,yarn of true hemp,ha,6,5,,,too_few_values,,no
-turkey,yarn of true hemp,tonnes,6,5,,,too_few_values,,no
-united kingdom,butter cow milk,tonnes,7,4,,,too_few_values,,no
-united kingdom,cheese processed,tonnes,7,6,,,too_few_values,,no
-united kingdom,eggs hen in shell,tonnes,11,11,,,unattributable,uk: scotland=0.09,no
-united kingdom,fertilizer mixed,tonnes,17,17,uk,1.0000,attributable,yugoslavia=0.00,no
-united kingdom,milk whole fresh cow,tonnes,7,7,,,too_few_values,,no
-united kingdom,n,tonnes,17,17,uk,1.0000,attributable,yugoslavia=0.00,no
-united kingdom,p,tonnes,17,17,uk,1.0000,attributable,yugoslavia=0.00,no
-united kingdom,sugar raw centrifugal,tonnes,20,20,uk,0.8000,attributable,uk: england and wales=0.15,no
-united states virgin islands,sugar raw centrifugal,tonnes,32,31,us virgin islands,1.0000,attributable,bulgaria=0.09,no
-uruguay,beans dry,ha,3,2,,,too_few_values,,no
-uruguay,beans dry,tonnes,3,3,,,too_few_values,,no
-uruguay,eggs hen in shell,tonnes,3,3,,,too_few_values,,no
-uruguay,flax fibre and tow,ha,1,1,,,too_few_values,,no
-uruguay,flax fibre and tow,tonnes,13,13,uruguay,1.0000,attributable,egypt=0.15,no
-uruguay,grapes,tonnes,6,6,,,too_few_values,,no
-uruguay,groundnuts with shell,ha,1,1,,,too_few_values,,no
-uruguay,lemons and limes,tonnes,2,2,,,too_few_values,,no
-uruguay,olives,ha,1,1,,,too_few_values,,no
-uruguay,olives,tonnes,2,2,,,too_few_values,,no
-uruguay,oranges,tonnes,2,2,,,too_few_values,,no
-uruguay,rye,ha,4,2,,,too_few_values,,no
-uruguay,rye,tonnes,10,6,,,ambiguous,uruguay=1.00;portugal=0.60;french tonkin=0.60,no
-uruguay,sugar raw centrifugal,tonnes,4,4,,,too_few_values,,no
-uruguay,sunflower seed,ha,1,1,,,too_few_values,,no
-uruguay,sunflower seed,tonnes,1,1,,,too_few_values,,no
-uruguay,tobacco unmanufactured,ha,4,4,,,too_few_values,,no
-uruguay,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
-vanuatu,cacao beans,ha,6,4,,,too_few_values,,no
-vanuatu,cacao beans,tonnes,21,18,british‑french new hebrides,1.0000,attributable,bulgaria=0.19,no
-vanuatu,coffee green,ha,8,4,,,too_few_distinct,,no
-vanuatu,coffee green,tonnes,19,14,british‑french new hebrides,1.0000,attributable,british cyprus=0.58,no
-vanuatu,cotton lint,ha,5,3,,,too_few_values,,no
-vanuatu,cotton lint,tonnes,17,13,british‑french new hebrides,1.0000,attributable,british cyprus=0.41,no
-vanuatu,cotton seed,ha,5,3,,,too_few_values,,no
-vanuatu,cotton seed,tonnes,12,10,british‑french new hebrides,1.0000,attributable,british saint vincent=0.50,no
-venezuela,cacao beans,tonnes,1,1,,,too_few_values,,no
-venezuela,coffee green,ha,1,1,,,too_few_values,,no
-venezuela,cotton lint,ha,7,6,,,too_few_values,,no
-venezuela,cotton seed,ha,7,6,,,too_few_values,,no
-venezuela,cotton seed,tonnes,7,6,,,too_few_values,,no
-venezuela,sugar raw centrifugal,tonnes,1,1,,,too_few_values,,no
-viet nam,coffee green,ha,13,6,,,ambiguous,french tonkin=1.00;italy=0.69;australia=0.69,no
-viet nam,coffee green,tonnes,11,9,french tonkin,1.0000,attributable,british cyprus=0.55,no
-viet nam,cotton lint,ha,14,6,,,ambiguous,french tonkin=1.00;new zealand=0.64;french india=0.64,no
-viet nam,cotton lint,tonnes,14,5,,,too_few_distinct,,no
-viet nam,cotton seed,ha,14,6,,,ambiguous,french tonkin=1.00;new zealand=0.64;french india=0.64,no
-viet nam,cotton seed,tonnes,12,8,french tonkin,1.0000,attributable,british dominica=0.50,no
-viet nam,groundnuts with shell,ha,14,7,french tonkin,1.0000,attributable,british southern rhodesia=0.57,no
-viet nam,groundnuts with shell,tonnes,13,11,french tonkin,1.0000,attributable,french annam=0.31,no
-viet nam,jute,ha,11,7,french tonkin,1.0000,attributable,french cochinchina=0.55,no
-viet nam,jute,tonnes,7,6,,,too_few_values,,no
-viet nam,other berries and fruits of the genus vaccinium n e c,ha,14,6,,,ambiguous,french tonkin=1.00;british southern rhodesia=0.71;austria=0.64,no
-viet nam,other berries and fruits of the genus vaccinium n e c,tonnes,4,4,,,too_few_values,,no
-viet nam,sesame seed,ha,7,4,,,too_few_values,,no
-viet nam,sesame seed,tonnes,7,7,,,too_few_values,,no
-viet nam,silk worm cocoons reelable,tonnes,4,4,,,too_few_values,,no
-viet nam,sugar raw centrifugal,tonnes,6,6,,,too_few_values,,no
-viet nam,tea,ha,14,9,french tonkin,1.0000,attributable,italy=0.50,no
-viet nam,tea,tonnes,10,9,french tonkin,1.0000,attributable,romania=0.20,no
-viet nam,tobacco unmanufactured,ha,13,6,,,ambiguous,french tonkin=1.00;total=0.62;austria=0.62,no
-viet nam,tobacco unmanufactured,tonnes,13,13,french tonkin,1.0000,attributable,total=0.23,no
-yemen,coffee green,tonnes,17,17,british aden,1.0000,attributable,australia=0.18,no
-zambia,cotton lint,ha,7,7,,,too_few_values,,no
-zambia,cotton lint,tonnes,7,7,,,too_few_values,,no
-zambia,cotton seed,ha,7,7,,,too_few_values,,no
-zambia,cotton seed,tonnes,7,7,,,too_few_values,,no
-zambia,groundnuts with shell,ha,10,6,british northern rhodesia,1.0000,attributable,uruguay=0.50,no
-zambia,groundnuts with shell,tonnes,9,7,british northern rhodesia,1.0000,attributable,french tonkin=0.44,no
-zambia,lemons and limes,ha,5,1,,,too_few_values,,no
-zambia,lemons and limes,tonnes,5,2,,,too_few_values,,no
-zambia,oranges,ha,8,4,,,too_few_distinct,,no
-zambia,oranges,tonnes,8,5,,,too_few_distinct,,no
-zambia,other sugar crops n e c,ha,3,2,,,too_few_values,,no
-zambia,other sugar crops n e c,tonnes,3,3,,,too_few_values,,no
-zambia,tobacco unmanufactured,ha,11,7,british northern rhodesia,1.0000,attributable,total=0.45,no
-zambia,tobacco unmanufactured,tonnes,17,17,british northern rhodesia,1.0000,attributable,latvia=0.06,no
-zimbabwe,beans dry,ha,9,3,,,too_few_distinct,,no
-zimbabwe,beans dry,tonnes,12,6,british southern rhodesia,1.0000,attributable,british cyprus=0.50,no
-zimbabwe,butter cow milk,tonnes,7,3,,,too_few_values,,no
-zimbabwe,cheese processed,tonnes,7,2,,,too_few_values,,no
-zimbabwe,cotton lint,ha,16,8,,,ambiguous,british southern rhodesia=1.00;italy=0.62;french tonkin=0.62,no
-zimbabwe,cotton lint,tonnes,14,10,british southern rhodesia,1.0000,attributable,french india=0.50,no
-zimbabwe,cotton seed,ha,16,9,british southern rhodesia,1.0000,attributable,italy=0.56,no
-zimbabwe,cotton seed,tonnes,16,13,british southern rhodesia,1.0000,attributable,french tonkin=0.44,no
-zimbabwe,eggs hen in shell,tonnes,8,7,british southern rhodesia,1.0000,attributable,yugoslavia=0.00,no
-zimbabwe,flax fibre and tow,ha,6,5,,,too_few_values,,no
-zimbabwe,groundnuts with shell,ha,18,9,,,ambiguous,british southern rhodesia=1.00;french tonkin=0.61,no
-zimbabwe,groundnuts with shell,tonnes,2,2,,,too_few_values,,no
-zimbabwe,linseed,ha,3,3,,,too_few_values,,no
-zimbabwe,linseed,tonnes,5,5,,,too_few_values,,no
-zimbabwe,oats,tonnes,4,2,,,too_few_values,,no
-zimbabwe,oranges,tonnes,13,13,british southern rhodesia,1.0000,attributable,us philippines=0.15,no
-zimbabwe,other sugar crops n e c,tonnes,6,4,,,too_few_values,,no
-zimbabwe,rye,ha,6,6,,,too_few_values,,no
-zimbabwe,soybeans,tonnes,4,2,,,too_few_values,,no
-zimbabwe,sunflower seed,ha,7,2,,,too_few_values,,no
-zimbabwe,sunflower seed,tonnes,7,2,,,too_few_values,,no
-zimbabwe,tea,ha,7,3,,,too_few_values,,no
-zimbabwe,tea,tonnes,7,7,,,too_few_values,,no
-zimbabwe,tobacco unmanufactured,ha,28,24,british southern rhodesia,1.0000,attributable,yugoslavia=0.14,no
-zimbabwe,tobacco unmanufactured,tonnes,1,1,,,too_few_values,,no
+layer_b_label,item,unit,n_values,n_distinct,raw_label,raw_product,product_agrees,share,status,runner_up,label_is_mixed
+australia,butter cow milk,tonnes,7,7,,,,,too_few_values,,yes
+australia,cheese processed,tonnes,6,6,,,,,too_few_values,,yes
+australia,coffee green,ha,21,14,australia,coffee: raw,yes,1.0000,attributable,portugal/citrus fruits: lemons=0.24,yes
+australia,coffee green,tonnes,21,17,australia,coffee: raw,yes,1.0000,attributable,uruguay/rye=0.19,yes
+australia,cotton lint,ha,33,28,australia,cotton,yes,0.6061,attributable,australia: queensland/cottonseed=0.30,yes
+australia,cotton lint,tonnes,31,29,australia,cotton,yes,0.6129,attributable,australia: queensland/cotton: ginned=0.23,yes
+australia,cotton seed,ha,20,16,,,,,unattributable,australia: queensland/cottonseed=0.50,yes
+australia,cotton seed,tonnes,20,19,,,,,unattributable,australia: queensland/cottonseed=0.55,yes
+australia,eggs hen in shell,tonnes,3,2,,,,,too_few_values,,yes
+australia,flax fibre and tow,ha,24,17,australia,linseed,no,0.6667,attributable,sweden/tobacco=0.25,yes
+australia,flax fibre and tow,tonnes,20,18,australia,flax: fibre,yes,0.6000,attributable,portuguese mozambique: company concession/cotton: ginned=0.20,yes
+australia,grapes,ha,27,21,,,,,unattributable,australia/vineyards=0.41,yes
+australia,grapes,tonnes,27,27,,,,,unattributable,"australia/vineyards: grapes, raisins=0.41",yes
+australia,groundnuts with shell,ha,16,11,australia,groundnut,yes,1.0000,attributable,spain/tobacco=0.31,yes
+australia,groundnuts with shell,tonnes,15,15,australia,groundnut,yes,1.0000,attributable,hungary/soybean=0.13,yes
+australia,hops,ha,28,18,australia,hops,yes,1.0000,attributable,"french tunisia/vineyards: grapes, raisins=0.14",yes
+australia,hops,tonnes,28,28,australia,hops,yes,1.0000,attributable,ussr/soybean=0.04,yes
+australia,lemons and limes,ha,14,4,,,,,too_few_distinct,,yes
+australia,lemons and limes,tonnes,15,14,australia,citrus fruits: lemons,yes,1.0000,attributable,switzerland/meslin=0.13,yes
+australia,linseed,ha,6,6,,,,,too_few_values,,yes
+australia,linseed,tonnes,13,13,australia,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+australia,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,yes
+australia,n,tonnes,15,15,australia,fertilizers: ammonium sulfate,unknown,1.0000,attributable,mexico/vineyards: grapes=0.07,yes
+australia,olives,ha,8,4,,,,,too_few_distinct,,yes
+australia,olives,tonnes,14,9,australia,olive grove,yes,1.0000,attributable,french algeria/beans: dried=0.36,yes
+australia,oranges,ha,14,7,australia,"citrus fruits: mandarins, oranges",yes,0.7857,attributable,czechoslovakia/vineyards: all=0.29,yes
+australia,oranges,tonnes,15,14,australia,"citrus fruits: mandarins, oranges",yes,0.8000,attributable,"total/citrus fruits: grapefruits, lemons, mandarins, oranges, other=0.07",yes
+australia,other sugar crops n e c,ha,10,5,,,,,too_few_distinct,,yes
+australia,other sugar crops n e c,tonnes,14,13,australia,citrus fruits: other,no,1.0000,attributable,yugoslavia/hempseed=0.14,yes
+australia,p,tonnes,16,16,australian christmas island,"fertilizers: phosphate, natural",unknown,1.0000,attributable,yugoslavia/wine=0.00,yes
+australia,raisins,ha,3,3,,,,,too_few_values,,yes
+australia,raisins,tonnes,15,15,australia,raisins,yes,0.8000,attributable,"usa: california/vineyards: grapes, raisins=0.07",yes
+australia,rye,ha,27,23,australia,rye,yes,1.0000,attributable,"ussr/citrus fruits: lemons, mandarins, oranges=0.15",yes
+australia,rye,tonnes,27,26,australia,rye,yes,1.0000,attributable,british jamaica/cacao: raw=0.07,yes
+australia,sugar raw centrifugal,tonnes,33,32,,,,,unattributable,australia/sugar: cane=0.52,yes
+australia,tobacco unmanufactured,ha,28,21,australia,tobacco,yes,1.0000,attributable,hungary/flax: fibre=0.21,yes
+australia,tobacco unmanufactured,tonnes,23,23,australia,tobacco,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+australia,wine,ha,16,7,australia,wine,yes,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.38",yes
+austria,butter cow milk,tonnes,7,7,,,,,too_few_values,,yes
+austria,cheese processed,tonnes,7,6,,,,,too_few_values,,yes
+austria,eggs hen in shell,tonnes,11,11,austria,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+austria,fertilizer mixed,tonnes,9,9,,,,,unattributable,"kingdom of serbs, croats and slovenes/sugar: beet=0.11",yes
+austria,grapes,tonnes,5,5,,,,,too_few_values,,yes
+austria,hempseed,tonnes,2,1,,,,,too_few_values,,yes
+austria,hops,ha,3,3,,,,,too_few_values,,yes
+austria,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,yes
+austria,n,tonnes,14,9,austria-hungary,fertilizers: calcium cyanamide,unknown,0.7143,attributable,austria/fertilizers: ammonium sulfate=0.29,yes
+austria,p,tonnes,12,12,,,,,unattributable,austria/fertilizers: calcium superphosphate=0.33,yes
+austria,silk worm cocoons reelable,tonnes,8,8,austria,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,yes
+austria,soybeans,ha,5,2,,,,,too_few_values,,yes
+austria,sugar raw centrifugal,tonnes,32,32,austria,sugar: beet,yes,1.0000,attributable,us puerto rico/tobacco=0.03,yes
+austria,wine,ha,18,15,austria,wine,yes,1.0000,attributable,japanese taiwan/groundnut=0.11,yes
+austria,wine,tonnes,31,31,,,,,unattributable,yugoslavia/wine=0.00,yes
+austria,yarn of true hemp,ha,13,9,austria,hemp: fibre,yes,1.0000,attributable,sweden/tobacco=0.38,yes
+austria,yarn of true hemp,tonnes,24,21,austria,hemp: fibre,yes,1.0000,attributable,french tonkin/cotton: ginned=0.17,yes
+"china, mainland",beans dry,ha,1,1,,,,,too_few_values,,yes
+"china, mainland",beans dry,tonnes,2,2,,,,,too_few_values,,yes
+"china, mainland",castor beans seed,tonnes,4,4,,,,,too_few_values,,yes
+"china, mainland",cotton lint,ha,18,17,china,cottonseed,yes,0.8889,attributable,usa/citrus fruits: grapefruits=0.06,yes
+"china, mainland",cotton seed,ha,18,17,china,cottonseed,yes,0.8889,attributable,usa/citrus fruits: grapefruits=0.06,yes
+"china, mainland",cotton seed,tonnes,19,19,china,cottonseed,yes,0.8947,attributable,total south hemisphere aggregated/groundnut=0.05,yes
+"china, mainland",eggs hen in shell,tonnes,8,8,japan: kwantung leased territory,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+"china, mainland",flax fibre and tow,ha,1,1,,,,,too_few_values,,yes
+"china, mainland",flax fibre and tow,tonnes,1,1,,,,,too_few_values,,yes
+"china, mainland",groundnuts with shell,ha,13,13,,,,,unattributable,japan: kwantung leased territory/groundnut=0.54,yes
+"china, mainland",groundnuts with shell,tonnes,3,3,,,,,too_few_values,,yes
+"china, mainland",hemp tow waste,tonnes,1,1,,,,,too_few_values,,yes
+"china, mainland",hempseed,ha,2,2,,,,,too_few_values,,yes
+"china, mainland",hempseed,tonnes,2,2,,,,,too_few_values,,yes
+"china, mainland",jute,tonnes,1,1,,,,,too_few_values,,yes
+"china, mainland",linseed,tonnes,1,1,,,,,too_few_values,,yes
+"china, mainland",n,tonnes,3,3,,,,,too_few_values,,yes
+"china, mainland",rapeseed,ha,5,5,,,,,too_few_values,,yes
+"china, mainland",rapeseed,tonnes,15,15,china,rapeseed,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+"china, mainland",sesame seed,ha,7,7,,,,,too_few_values,,yes
+"china, mainland",sesame seed,tonnes,15,15,,,,,unattributable,china/sesame=0.53,yes
+"china, mainland",silk worm cocoons reelable,tonnes,12,12,china,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,yes
+"china, mainland",soybeans,ha,12,12,,,,,unattributable,china/soybean=0.25,yes
+"china, mainland",soybeans,tonnes,13,13,,,,,unattributable,total/cottonseed=0.08,yes
+"china, mainland",tea,tonnes,15,15,china,tea,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+"china, mainland",tobacco unmanufactured,ha,10,9,china,tobacco,yes,1.0000,attributable,italy/oats=0.10,yes
+"china, mainland",tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,yes
+indonesia,cacao beans,ha,14,8,,,,,unattributable,dutch east indies/cacao: raw=0.57,yes
+indonesia,cacao beans,tonnes,28,27,,,,,unattributable,dutch java and madura/cacao: raw=0.39,yes
+indonesia,castor beans seed,ha,3,2,,,,,too_few_values,,yes
+indonesia,castor beans seed,tonnes,2,2,,,,,too_few_values,,yes
+indonesia,coffee green,ha,16,16,,,,,unattributable,dutch east indies/coffee: raw=0.19,yes
+indonesia,cotton lint,ha,21,20,dutch east indies,cotton,yes,0.6667,attributable,dutch java and madura/cottonseed=0.14,yes
+indonesia,cotton lint,tonnes,29,27,,,,,unattributable,dutch east indies/cotton=0.52,yes
+indonesia,cotton seed,ha,11,10,dutch east indies,cottonseed,yes,0.7273,attributable,dutch java and madura/cottonseed=0.27,yes
+indonesia,cotton seed,tonnes,18,17,,,,,unattributable,dutch east indies/cottonseed=0.56,yes
+indonesia,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,yes
+indonesia,groundnuts with shell,ha,16,16,dutch java and madura,groundnut,yes,0.8750,attributable,total/hemp: fibre=0.12,yes
+indonesia,p,tonnes,12,12,dutch east indies,"fertilizers: phosphate, natural",unknown,1.0000,attributable,"peru/fertilizers: guano, natural=0.08",yes
+indonesia,rubber natural,ha,10,10,,,,,unattributable,dutch java and madura/rubber=0.20,yes
+indonesia,sesame seed,ha,12,10,dutch east indies,sesame,yes,0.8333,attributable,japanese korea/tobacco=0.25,yes
+indonesia,sesame seed,tonnes,12,9,dutch east indies,sesame,yes,1.0000,attributable,dutch guiana/coffee: raw=0.17,yes
+indonesia,soybeans,ha,12,12,dutch java and madura,soybean,yes,0.8333,attributable,total general including the ussr/linseed=0.08,yes
+indonesia,soybeans,tonnes,11,11,dutch java and madura,soybean,yes,0.8182,attributable,total south hemisphere aggregated/rye=0.09,yes
+indonesia,sugar raw centrifugal,tonnes,33,33,dutch java and madura,sugar: cane,yes,0.8788,attributable,switzerland/sugar: beet=0.03,yes
+indonesia,tea,ha,17,13,,,,,unattributable,dutch east indies/tea=0.53,yes
+indonesia,tobacco unmanufactured,ha,21,19,,,,,unattributable,dutch east indies/tobacco=0.52,yes
+indonesia,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,yes
+malaysia,coffee green,ha,23,19,,,,,unattributable,british federated malay states/coffee: raw=0.52,yes
+malaysia,coffee green,tonnes,14,14,british federated malay states,coffee: raw,yes,0.9286,attributable,hungary/flax: fibre=0.07,yes
+malaysia,rubber natural,ha,8,5,,,,,too_few_distinct,,yes
+malaysia,tea,ha,10,8,british malaya,tea,yes,1.0000,attributable,ireland/flax: fibre=0.50,yes
+malaysia,tea,tonnes,6,6,,,,,too_few_values,,yes
+malaysia,tobacco unmanufactured,ha,19,15,british borneo,tobacco,yes,0.8947,attributable,uruguay/rye=0.21,yes
+malaysia,tobacco unmanufactured,tonnes,16,16,british borneo,tobacco,yes,1.0000,attributable,spanish fernando po/cacao: raw=0.06,yes
+niger,cotton lint,ha,11,11,french west africa,cottonseed,yes,0.6364,attributable,french niger/cottonseed=0.36,yes
+niger,cotton lint,tonnes,17,17,french west africa,cotton: ginned,yes,0.6471,attributable,french niger/cotton=0.24,yes
+niger,cotton seed,ha,11,11,french west africa,cottonseed,yes,0.6364,attributable,french niger/cottonseed=0.36,yes
+niger,cotton seed,tonnes,15,15,french west africa,cottonseed,yes,0.7333,attributable,french niger/cottonseed=0.27,yes
+niger,eggs hen in shell,tonnes,9,6,french niger,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+niger,groundnuts with shell,ha,15,14,french niger,groundnut,yes,1.0000,attributable,total general excluding the ussr/hops=0.13,yes
+niger,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,yes
+niger,sesame seed,ha,7,4,,,,,too_few_values,,yes
+niger,sesame seed,tonnes,1,1,,,,,too_few_values,,yes
+niger,tobacco unmanufactured,ha,13,5,,,,,too_few_distinct,,yes
+niger,tobacco unmanufactured,tonnes,15,14,french niger,tobacco,yes,1.0000,attributable,paraguay/cottonseed=0.13,yes
+papua new guinea,cacao beans,ha,15,11,dutch new guinea,cacao: raw,yes,1.0000,attributable,union of south africa/tea=0.33,yes
+papua new guinea,cacao beans,tonnes,9,8,dutch new guinea,cacao: raw,yes,1.0000,attributable,us puerto rico/cottonseed=0.22,yes
+papua new guinea,coffee green,ha,5,5,,,,,too_few_values,,yes
+papua new guinea,rubber natural,ha,4,2,,,,,too_few_values,,yes
+papua new guinea,tobacco unmanufactured,ha,8,7,australian papua and new guinea,tobacco,yes,1.0000,attributable,british mauritius/coffee: raw=0.12,yes
+papua new guinea,tobacco unmanufactured,tonnes,5,5,,,,,too_few_values,,yes
+russian federation,beans dry,ha,1,1,,,,,too_few_values,,yes
+russian federation,castor beans seed,tonnes,1,1,,,,,too_few_values,,yes
+russian federation,cotton lint,ha,22,21,,,,,unattributable,ussr/cottonseed=0.50,yes
+russian federation,cotton lint,tonnes,22,22,,,,,unattributable,ussr/cotton: ginned=0.32,yes
+russian federation,cotton seed,ha,15,14,ussr,cottonseed,yes,0.7333,attributable,ussr in asia/cottonseed=0.27,yes
+russian federation,cotton seed,tonnes,15,15,ussr,cottonseed,yes,0.7333,attributable,ussr in asia/cottonseed=0.27,yes
+russian federation,eggs hen in shell,tonnes,7,7,,,,,too_few_values,,yes
+russian federation,fertilizer mixed,tonnes,1,1,,,,,too_few_values,,yes
+russian federation,flax fibre and tow,ha,26,26,,,,,unattributable,ussr/linseed=0.19,yes
+russian federation,flax fibre and tow,tonnes,20,20,,,,,unattributable,ussr/flax: fibre=0.25,yes
+russian federation,grapes,ha,7,7,,,,,too_few_values,,yes
+russian federation,grapes,tonnes,3,3,,,,,too_few_values,,yes
+russian federation,groundnuts with shell,ha,6,6,,,,,too_few_values,,yes
+russian federation,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,yes
+russian federation,hemp tow waste,ha,12,12,,,,,unattributable,ussr/hemp: fibre=0.08,yes
+russian federation,hemp tow waste,tonnes,2,2,,,,,too_few_values,,yes
+russian federation,hempseed,ha,14,14,ussr,hempseed,yes,0.6429,attributable,ussr in europe/hempseed=0.29,yes
+russian federation,hempseed,tonnes,19,16,,,,,unattributable,ussr/hempseed=0.37,yes
+russian federation,hops,tonnes,7,7,,,,,too_few_values,,yes
+russian federation,k,tonnes,2,2,,,,,too_few_values,,yes
+russian federation,linseed,ha,8,8,,,,,unattributable,ussr in europe/linseed=0.50,yes
+russian federation,linseed,tonnes,15,15,,,,,unattributable,ussr in europe/linseed=0.27,yes
+russian federation,n,tonnes,9,9,,,,,unattributable,ussr/fertilizers: ammonium sulfate=0.33,yes
+russian federation,oats,ha,1,1,,,,,too_few_values,,yes
+russian federation,oranges,ha,8,5,,,,,too_few_distinct,,yes
+russian federation,oranges,tonnes,7,7,,,,,too_few_values,,yes
+russian federation,p,tonnes,12,11,russia,"fertilizers: phosphate, natural",unknown,0.6667,attributable,yugoslavia/wine=0.00,yes
+russian federation,rapeseed,ha,12,12,,,,,unattributable,ussr/rapeseed=0.33,yes
+russian federation,rapeseed,tonnes,9,9,,,,,unattributable,japan: karafuto prefecture/rapeseed=0.44,yes
+russian federation,rye,ha,31,31,ussr,rye,yes,0.6452,attributable,total/rye=0.19,yes
+russian federation,rye,tonnes,28,28,ussr,rye,yes,0.6429,attributable,total/rye=0.11,yes
+russian federation,sesame seed,ha,9,9,ussr,sesame,yes,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.11",yes
+russian federation,sesame seed,tonnes,5,5,,,,,too_few_values,,yes
+russian federation,silk worm cocoons reelable,tonnes,16,16,ussr,sericulture,no,0.6250,attributable,switzerland/fertilizers: calcium superphosphate=0.06,yes
+russian federation,soybeans,ha,9,9,,,,,unattributable,ussr/soybean=0.56,yes
+russian federation,soybeans,tonnes,5,5,,,,,too_few_values,,yes
+russian federation,sugar raw centrifugal,tonnes,23,23,,,,,unattributable,ussr/sugar: beet=0.48,yes
+russian federation,tea,ha,6,6,,,,,too_few_values,,yes
+russian federation,tea,tonnes,6,6,,,,,too_few_values,,yes
+russian federation,tobacco unmanufactured,ha,21,20,ussr,tobacco,yes,0.6190,attributable,usa: california/vineyards: all=0.05,yes
+russian federation,tobacco unmanufactured,tonnes,17,17,,,,,unattributable,ussr/tobacco=0.53,yes
+russian federation,wheat,ha,6,6,,,,,too_few_values,,yes
+russian federation,wheat,tonnes,2,2,,,,,too_few_values,,yes
+russian federation,wine,ha,6,5,,,,,too_few_values,,yes
+russian federation,wine,tonnes,3,2,,,,,too_few_values,,yes
+russian federation,yarn of true hemp,ha,13,13,ussr,hemp: fibre,yes,0.6923,attributable,ussr in europe/hempseed=0.31,yes
+russian federation,yarn of true hemp,tonnes,21,20,,,,,unattributable,ussr/hemp: fibre=0.33,yes
+syrian arab republic,beans dry,ha,8,3,,,,,too_few_distinct,,yes
+syrian arab republic,beans dry,tonnes,9,7,french syria,beans: dried,unknown,0.7778,attributable,guatemala/oats=0.33,yes
+syrian arab republic,butter cow milk,tonnes,7,3,,,,,too_few_values,,yes
+syrian arab republic,cheese processed,tonnes,7,4,,,,,too_few_values,,yes
+syrian arab republic,cotton lint,ha,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
+syrian arab republic,cotton lint,tonnes,19,19,,,,,unattributable,french syria and lebanon/cotton=0.42,yes
+syrian arab republic,cotton seed,ha,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
+syrian arab republic,cotton seed,tonnes,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
+syrian arab republic,eggs hen in shell,tonnes,14,14,,,,,unattributable,french syria and lebanon/eggs=0.57,yes
+syrian arab republic,grapes,ha,16,16,,,,,unattributable,"french syria and lebanon/vineyards: grapes, raisins=0.31",yes
+syrian arab republic,grapes,tonnes,9,9,french syria and lebanon,"vineyards: grapes, raisins",yes,0.6667,attributable,turkey/cottonseed=0.11,yes
+syrian arab republic,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,yes
+syrian arab republic,hemp tow waste,ha,7,4,,,,,too_few_values,,yes
+syrian arab republic,hemp tow waste,tonnes,7,7,,,,,too_few_values,,yes
+syrian arab republic,hempseed,ha,16,13,french syria,hemp: fibre,yes,0.6250,attributable,french syria and lebanon/hempseed=0.31,yes
+syrian arab republic,hempseed,tonnes,18,16,,,,,unattributable,french syria/hemp=0.39,yes
+syrian arab republic,milk whole fresh cow,tonnes,4,4,,,,,too_few_values,,yes
+syrian arab republic,oats,ha,7,3,,,,,too_few_values,,yes
+syrian arab republic,oats,tonnes,7,7,,,,,too_few_values,,yes
+syrian arab republic,oil olive virgin,tonnes,4,4,,,,,too_few_values,,yes
+syrian arab republic,olives,ha,17,13,,,,,unattributable,french syria and lebanon/olive grove=0.59,yes
+syrian arab republic,olives,tonnes,18,18,,,,,unattributable,french syria/olive grove=0.39,yes
+syrian arab republic,oranges,ha,9,6,french syria and lebanon,"citrus fruits: oranges, other",yes,1.0000,attributable,portuguese angola/tobacco=0.44,yes
+syrian arab republic,oranges,tonnes,13,13,french syria and lebanon,"citrus fruits: oranges, other",yes,0.6923,attributable,yugoslavia/hemp: fibre=0.08,yes
+syrian arab republic,other berries and fruits of the genus vaccinium n e c,ha,5,5,,,,,too_few_values,,yes
+syrian arab republic,other berries and fruits of the genus vaccinium n e c,tonnes,5,5,,,,,too_few_values,,yes
+syrian arab republic,raisins,tonnes,3,3,,,,,too_few_values,,yes
+syrian arab republic,sesame seed,ha,20,12,,,,,unattributable,french syria and lebanon/sesame=0.45,yes
+syrian arab republic,sesame seed,tonnes,20,17,,,,,unattributable,french syria and lebanon/sesame=0.45,yes
+syrian arab republic,silk worm cocoons reelable,tonnes,20,20,french syria and lebanon,sericulture,no,0.6500,attributable,total/hops=0.05,yes
+syrian arab republic,tobacco unmanufactured,ha,16,10,french syria and lebanon,tobacco,yes,0.6875,attributable,french syria/tobacco=0.31,yes
+syrian arab republic,tobacco unmanufactured,tonnes,16,16,french syria and lebanon,tobacco,yes,0.6875,attributable,french syria/tobacco=0.31,yes
+syrian arab republic,wine,ha,3,2,,,,,too_few_values,,yes
+syrian arab republic,wine,tonnes,13,12,,,,,unattributable,yugoslavia/wine=0.00,yes
+syrian arab republic,yarn of true hemp,ha,11,10,french syria,hemp: fibre,yes,0.8182,attributable,french syria and lebanon/hempseed=0.36,yes
+syrian arab republic,yarn of true hemp,tonnes,10,10,french syria,hemp: fibre,yes,0.9000,attributable,yugoslavia/linseed=0.20,yes
+timor-leste,cacao beans,tonnes,8,8,portuguese timor,cacao: raw,yes,1.0000,attributable,yugoslavia/wine=0.00,yes
+timor-leste,coffee green,tonnes,9,8,portuguese timor and kambing,coffee: raw,yes,1.0000,attributable,siam/sesame=0.33,yes
+united states of america,cacao beans,tonnes,1,1,,,,,too_few_values,,yes
+united states of america,cheese processed,tonnes,7,7,,,,,too_few_values,,yes
+united states of america,coffee green,ha,28,25,,,,,unattributable,us puerto rico/coffee: raw=0.36,yes
+united states of america,coffee green,tonnes,29,28,,,,,unattributable,us puerto rico/coffee: raw=0.21,yes
+united states of america,cotton lint,ha,1,1,,,,,too_few_values,,yes
+united states of america,cotton seed,ha,20,20,,,,,unattributable,usa/cottonseed=0.55,yes
+united states of america,cotton seed,tonnes,1,1,,,,,too_few_values,,yes
+united states of america,eggs hen in shell,tonnes,17,17,usa,eggs,yes,0.7059,attributable,yugoslavia/wine=0.00,yes
+united states of america,fertilizer mixed,tonnes,17,17,usa,sulphur,no,1.0000,attributable,yugoslavia/wine=0.00,yes
+united states of america,flax fibre and tow,ha,1,1,,,,,too_few_values,,yes
+united states of america,flax fibre and tow,tonnes,6,6,,,,,too_few_values,,yes
+united states of america,hemp tow waste,ha,5,5,,,,,too_few_values,,yes
+united states of america,k,tonnes,4,4,,,,,too_few_values,,yes
+united states of america,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,yes
+united states of america,n,tonnes,17,12,usa and canada,fertilizers: calcium cyanamide,unknown,0.7647,attributable,usa/fertilizers: ammonium sulfate=0.24,yes
+united states of america,p,tonnes,17,17,,,,,unattributable,"usa/fertilizers: calcium superphosphate, mixed, unmixed=0.59",yes
+united states of america,raisins,ha,3,3,,,,,too_few_values,,yes
+united states of america,raisins,tonnes,16,15,usa,raisins,yes,0.7500,attributable,"total/vineyards: grapes, raisins=0.06",yes
+united states of america,sugar raw centrifugal,tonnes,33,33,,,,,unattributable,usa/sugar: beet=0.39,yes
+united states of america,wine,ha,7,6,,,,,too_few_values,,yes
+united states of america,wine,tonnes,13,13,,,,,unattributable,yugoslavia/wine=0.00,yes
+united states of america,yarn of true hemp,ha,1,1,,,,,too_few_values,,yes
+united states of america,yarn of true hemp,tonnes,3,3,,,,,too_few_values,,yes
+albania,beans dry,tonnes,1,1,,,,,too_few_values,,no
+albania,eggs hen in shell,tonnes,6,3,,,,,too_few_values,,no
+albania,rye,ha,1,1,,,,,too_few_values,,no
+algeria,beans dry,ha,11,2,,,,,too_few_distinct,,no
+algeria,beans dry,tonnes,13,4,,,,,too_few_distinct,,no
+algeria,cotton lint,ha,24,20,french algeria,cottonseed,yes,0.6667,attributable,austria/hemp: fibre=0.25,no
+algeria,cotton lint,tonnes,25,20,french algeria,cotton,yes,0.6400,attributable,british cyprus/hemp: fibre=0.24,no
+algeria,cotton seed,ha,16,12,french algeria,cottonseed,yes,1.0000,attributable,austria/hemp: fibre=0.38,no
+algeria,cotton seed,tonnes,17,12,french algeria,cottonseed,yes,1.0000,attributable,british cyprus/hemp: fibre=0.29,no
+algeria,flax fibre and tow,ha,18,18,french algeria,flax,yes,0.7222,attributable,british jamaica/tobacco=0.11,no
+algeria,flax fibre and tow,tonnes,5,5,,,,,too_few_values,,no
+algeria,grapes,ha,24,23,,,,,unattributable,french algeria/vineyards=0.50,no
+algeria,grapes,tonnes,10,10,french algeria,"vineyards: grapes, raisins",yes,0.9000,attributable,romania/flax: fibre=0.10,no
+algeria,groundnuts with shell,ha,3,3,,,,,too_few_values,,no
+algeria,groundnuts with shell,tonnes,3,3,,,,,too_few_values,,no
+algeria,lemons and limes,ha,7,2,,,,,too_few_values,,no
+algeria,lemons and limes,tonnes,11,11,french algeria,"citrus fruits: lemons, other",yes,1.0000,attributable,netherlands/flax: fibre=0.18,no
+algeria,linseed,ha,5,5,,,,,too_few_values,,no
+algeria,linseed,tonnes,18,18,french algeria,linseed,yes,1.0000,attributable,japanese taiwan/rapeseed=0.06,no
+algeria,n,tonnes,1,1,,,,,too_few_values,,no
+algeria,oats,tonnes,1,1,,,,,too_few_values,,no
+algeria,oil olive virgin,tonnes,2,2,,,,,too_few_values,,no
+algeria,olives,ha,15,13,french algeria,olive grove,yes,0.7333,attributable,"total/vineyards: grapes, raisins=0.13",no
+algeria,olives,tonnes,28,28,french algeria,olive grove,yes,0.6071,attributable,"greece/vineyards: grapes, raisins=0.04",no
+algeria,oranges,ha,14,9,french algeria,citrus fruits: oranges,yes,1.0000,attributable,french annam/groundnut=0.29,no
+algeria,oranges,tonnes,14,14,french algeria,citrus fruits: oranges,yes,1.0000,attributable,yugoslavia/beans: dried=0.07,no
+algeria,other berries and fruits of the genus vaccinium n e c,ha,2,1,,,,,too_few_values,,no
+algeria,other sugar crops n e c,ha,3,3,,,,,too_few_values,,no
+algeria,other sugar crops n e c,tonnes,3,3,,,,,too_few_values,,no
+algeria,p,tonnes,17,17,french algeria,"fertilizers: phosphate, natural",unknown,1.0000,attributable,total/fertilizers: ammonium sulfate=0.06,no
+algeria,rye,ha,33,20,french algeria,rye,yes,1.0000,attributable,british saint christopher and nevis/cottonseed=0.27,no
+algeria,rye,tonnes,33,28,french algeria,rye,yes,1.0000,attributable,czechoslovakia/soybean=0.12,no
+algeria,silk worm cocoons reelable,tonnes,14,12,french algeria,sericulture,no,1.0000,attributable,uruguay/rye=0.14,no
+algeria,tangerines mandarins clementines satsumas,ha,14,5,,,,,too_few_distinct,,no
+algeria,tangerines mandarins clementines satsumas,tonnes,14,13,french algeria,citrus fruits: mandarins,yes,1.0000,attributable,total/tobacco=0.21,no
+algeria,tobacco unmanufactured,ha,33,31,french algeria,tobacco,yes,1.0000,attributable,italy/citrus fruits: lemons=0.12,no
+algeria,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+algeria,wine,ha,20,19,french algeria,wine,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.10",no
+algeria,wine,tonnes,1,1,,,,,too_few_values,,no
+american samoa,tobacco unmanufactured,ha,5,4,,,,,too_few_values,,no
+american samoa,tobacco unmanufactured,tonnes,5,4,,,,,too_few_values,,no
+angola,beans dry,ha,9,9,portuguese angola,beans: dried,unknown,1.0000,attributable,venezuela/coffee: raw=0.11,no
+angola,beans dry,tonnes,12,12,portuguese angola,beans: dried,unknown,1.0000,attributable,uruguay/sunflower=0.08,no
+angola,castor beans seed,tonnes,7,6,,,,,too_few_values,,no
+angola,coffee green,ha,11,8,portuguese angola,coffee: raw,yes,1.0000,attributable,total north hemisphere aggregated excluding the ussr/hops=0.18,no
+angola,cotton lint,ha,11,10,portuguese angola,cottonseed,yes,1.0000,attributable,us philippines/groundnut=0.18,no
+angola,cotton lint,tonnes,14,11,portuguese angola,cotton: ginned,yes,0.8571,attributable,total/linseed=0.21,no
+angola,cotton seed,ha,11,10,portuguese angola,cottonseed,yes,1.0000,attributable,us philippines/groundnut=0.18,no
+angola,cotton seed,tonnes,14,13,portuguese angola,cottonseed,yes,1.0000,attributable,british southern rhodesia/groundnut=0.14,no
+angola,groundnuts with shell,ha,11,8,portuguese angola,groundnut,yes,1.0000,attributable,"spain/vineyards: grapes, raisins=0.36",no
+angola,groundnuts with shell,tonnes,14,13,portuguese angola,groundnut,yes,1.0000,attributable,total/cacao: raw=0.14,no
+angola,sesame seed,ha,10,6,portuguese angola,sesame,yes,1.0000,attributable,usa: hawaii/coffee: raw=0.50,no
+angola,sesame seed,tonnes,14,12,portuguese angola,sesame,yes,1.0000,attributable,french guadeloupe/coffee: raw=0.21,no
+angola,sugar raw centrifugal,tonnes,15,15,portuguese angola,sugar: cane,yes,1.0000,attributable,us philippines/sugar: cane=0.07,no
+angola,tobacco unmanufactured,ha,11,6,portuguese angola,tobacco,yes,1.0000,attributable,hungary/beans: dried=0.45,no
+angola,tobacco unmanufactured,tonnes,14,14,portuguese angola,tobacco,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+antigua and barbuda,cotton lint,ha,25,20,british antigua,cotton,yes,0.7200,attributable,netherlands/tobacco=0.20,no
+antigua and barbuda,cotton lint,tonnes,23,18,british antigua,cotton,yes,0.7391,attributable,french guadeloupe and dependencies: marie‑galante/cottonseed=0.26,no
+antigua and barbuda,cotton seed,ha,14,10,british antigua,cottonseed,yes,1.0000,attributable,switzerland/tobacco=0.29,no
+antigua and barbuda,cotton seed,tonnes,13,12,british antigua,cottonseed,yes,1.0000,attributable,new zealand/rye=0.23,no
+antigua and barbuda,sugar raw centrifugal,tonnes,30,30,british antigua,sugar: cane,yes,0.8667,attributable,total/cottonseed=0.03,no
+argentina,beans dry,ha,1,1,,,,,too_few_values,,no
+argentina,castor beans seed,ha,6,5,,,,,too_few_values,,no
+argentina,castor beans seed,tonnes,6,6,,,,,too_few_values,,no
+argentina,cheese processed,tonnes,6,6,,,,,too_few_values,,no
+argentina,coffee green,ha,1,1,,,,,too_few_values,,no
+argentina,cotton lint,ha,1,1,,,,,too_few_values,,no
+argentina,cotton seed,ha,20,20,argentina,cottonseed,yes,1.0000,attributable,total south hemisphere aggregated/wine=0.05,no
+argentina,cotton seed,tonnes,2,2,,,,,too_few_values,,no
+argentina,flax fibre and tow,ha,1,1,,,,,too_few_values,,no
+argentina,flax fibre and tow,tonnes,13,13,argentina,linseed,no,1.0000,attributable,yugoslavia/wine=0.00,no
+argentina,grapes,tonnes,6,6,,,,,too_few_values,,no
+argentina,oil olive virgin,tonnes,7,3,,,,,too_few_values,,no
+argentina,olives,tonnes,1,1,,,,,too_few_values,,no
+argentina,raisins,tonnes,8,8,argentina,raisins,yes,1.0000,attributable,hungary/beans: dried=0.25,no
+argentina,rapeseed,ha,1,1,,,,,too_few_values,,no
+argentina,rapeseed,tonnes,1,1,,,,,too_few_values,,no
+argentina,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+argentina,wine,ha,1,1,,,,,too_few_values,,no
+argentina,wine,tonnes,1,1,,,,,too_few_values,,no
+azerbaijan,tea,ha,11,11,ussr: transcaucasian sfsr,tea,yes,1.0000,attributable,italy/tobacco=0.18,no
+azerbaijan,tea,tonnes,10,10,ussr: transcaucasian sfsr,tea,yes,1.0000,attributable,british trinidad and tobago/coffee: raw=0.10,no
+barbados,cotton lint,ha,24,20,british barbados,cotton,yes,0.7917,attributable,british malta/cottonseed=0.25,no
+barbados,cotton lint,tonnes,23,19,british barbados,cotton,yes,0.7826,attributable,sweden/tobacco=0.22,no
+barbados,cotton seed,ha,12,8,british barbados,cottonseed,yes,1.0000,attributable,british malta/cottonseed=0.50,no
+barbados,cotton seed,tonnes,16,9,british barbados,cottonseed,yes,1.0000,attributable,british cyprus/hemp: fibre=0.56,no
+barbados,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+belgium,butter cow milk,tonnes,5,5,,,,,too_few_values,,no
+belgium,eggs hen in shell,tonnes,16,14,belgium,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+belgium,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,no
+belgium,flax fibre and tow,tonnes,1,1,,,,,too_few_values,,no
+belgium,grapes,ha,4,1,,,,,too_few_values,,no
+belgium,hempseed,ha,10,6,,,,,ambiguous,belgium/hempseed=1.00;british malta/cottonseed=0.60,no
+belgium,hempseed,tonnes,5,1,,,,,too_few_values,,no
+belgium,milk whole fresh cow,tonnes,6,6,,,,,too_few_values,,no
+belgium,n,tonnes,16,16,belgium,fertilizers: ammonium sulfate,unknown,1.0000,attributable,usa and canada/fertilizers: calcium cyanamide=0.06,no
+belgium,p,tonnes,17,16,belgium,"fertilizers: phosphate, natural",unknown,0.6471,attributable,yugoslavia/wine=0.00,no
+belgium,rapeseed,ha,8,4,,,,,too_few_distinct,,no
+belgium,rapeseed,tonnes,1,1,,,,,too_few_values,,no
+belgium,sugar raw centrifugal,tonnes,33,33,belgium,sugar: beet,yes,1.0000,attributable,total/fertilizers: calcium superphosphate=0.03,no
+belgium,yarn of true hemp,ha,13,9,belgium,hemp: fibre,yes,1.0000,attributable,british malta/cottonseed=0.46,no
+belgium,yarn of true hemp,tonnes,13,9,belgium,hemp: fibre,yes,1.0000,attributable,uruguay/rye=0.31,no
+belize,cacao beans,tonnes,8,8,british honduras,cacao: raw,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+belize,grapefruit inc pomelos,ha,3,2,,,,,too_few_values,,no
+belize,grapefruit inc pomelos,tonnes,11,7,british honduras,citrus fruits: grapefruits,yes,1.0000,attributable,"british saint vincent/cotton: ginned, sea island=0.45",no
+benin,cacao beans,ha,7,5,,,,,too_few_values,,no
+benin,cacao beans,tonnes,7,3,,,,,too_few_values,,no
+benin,coffee green,ha,7,2,,,,,too_few_values,,no
+benin,coffee green,tonnes,5,4,,,,,too_few_values,,no
+benin,cotton lint,ha,4,4,,,,,too_few_values,,no
+benin,cotton lint,tonnes,4,3,,,,,too_few_values,,no
+benin,cotton seed,ha,4,4,,,,,too_few_values,,no
+benin,cotton seed,tonnes,4,3,,,,,too_few_values,,no
+benin,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+benin,groundnuts with shell,ha,15,14,french dahomey,groundnut,yes,1.0000,attributable,uk: northern ireland/flax: fibre=0.20,no
+benin,groundnuts with shell,tonnes,15,14,french dahomey,groundnut,yes,1.0000,attributable,belgian ruanda-urundi/cotton: ginned=0.20,no
+benin,tobacco unmanufactured,ha,12,6,,,,,ambiguous,french dahomey/tobacco=1.00;french morocco/tobacco=0.67;austria/hemp: fibre=0.67,no
+benin,tobacco unmanufactured,tonnes,15,12,french dahomey,tobacco,yes,1.0000,attributable,"french tunisia/vineyards: grapes, raisins=0.27",no
+bermuda,eggs hen in shell,tonnes,16,6,british bermuda,eggs,yes,1.0000,attributable,british brunei/eggs=0.12,no
+bolivia,cacao beans,ha,1,1,,,,,too_few_values,,no
+bolivia,cacao beans,tonnes,1,1,,,,,too_few_values,,no
+bolivia,cotton lint,tonnes,2,2,,,,,too_few_values,,no
+bolivia,flax fibre and tow,tonnes,1,1,,,,,too_few_values,,no
+botswana,eggs hen in shell,tonnes,5,5,,,,,too_few_values,,no
+brazil,cacao beans,ha,9,7,brazil,cacao: raw,yes,1.0000,attributable,portugal/beans: dried=0.22,no
+brazil,cacao beans,tonnes,12,11,brazil,cacao: raw,yes,1.0000,attributable,total/coffee: raw=0.17,no
+brazil,castor beans seed,tonnes,7,7,,,,,too_few_values,,no
+brazil,coffee green,ha,2,2,,,,,too_few_values,,no
+brazil,cotton lint,ha,2,2,,,,,too_few_values,,no
+brazil,cotton seed,ha,20,19,brazil,cottonseed,yes,1.0000,attributable,ussr/sugar: beet=0.05,no
+brazil,cotton seed,tonnes,1,1,,,,,too_few_values,,no
+brazil,grapes,tonnes,1,1,,,,,too_few_values,,no
+brazil,rye,ha,1,1,,,,,too_few_values,,no
+brazil,silk worm cocoons reelable,tonnes,2,2,,,,,too_few_values,,no
+brazil,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+brazil,sunflower seed,ha,2,2,,,,,too_few_values,,no
+brazil,sunflower seed,tonnes,2,2,,,,,too_few_values,,no
+brazil,tea,tonnes,1,1,,,,,too_few_values,,no
+brazil,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+brazil,wine,ha,2,2,,,,,too_few_values,,no
+british virgin islands,cotton lint,ha,4,2,,,,,too_few_values,,no
+british virgin islands,cotton lint,tonnes,15,15,british virgin islands,cotton,yes,1.0000,attributable,switzerland/sericulture=0.07,no
+british virgin islands,cotton seed,ha,4,2,,,,,too_few_values,,no
+british virgin islands,cotton seed,tonnes,4,3,,,,,too_few_values,,no
+brunei darussalam,eggs hen in shell,tonnes,6,3,,,,,too_few_values,,no
+brunei darussalam,rubber natural,ha,9,8,,,,,unattributable,british brunei/rubber=0.33,no
+brunei darussalam,rubber natural,tonnes,3,3,,,,,too_few_values,,no
+bulgaria,butter cow milk,tonnes,7,3,,,,,too_few_values,,no
+bulgaria,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+bulgaria,cotton lint,ha,33,32,bulgaria,cotton,yes,0.6364,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.09",no
+bulgaria,cotton seed,ha,20,19,bulgaria,cottonseed,yes,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.15",no
+bulgaria,cotton seed,tonnes,20,20,bulgaria,cottonseed,yes,1.0000,attributable,total/tobacco=0.10,no
+bulgaria,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+bulgaria,groundnuts with shell,ha,3,3,,,,,too_few_values,,no
+bulgaria,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+bulgaria,hops,ha,7,3,,,,,too_few_values,,no
+bulgaria,hops,tonnes,9,7,bulgaria,hops,yes,1.0000,attributable,british mauritius/coffee: raw=0.11,no
+bulgaria,other berries and fruits of the genus vaccinium n e c,ha,19,10,bulgaria,blackberries,no,1.0000,attributable,italy/citrus fruits: other=0.47,no
+bulgaria,other berries and fruits of the genus vaccinium n e c,tonnes,18,18,bulgaria,blackberries,no,1.0000,attributable,france/flax: fibre=0.06,no
+bulgaria,rapeseed,ha,1,1,,,,,too_few_values,,no
+bulgaria,rye,tonnes,4,4,,,,,too_few_values,,no
+bulgaria,silk worm cocoons reelable,tonnes,33,32,bulgaria,sericulture,no,1.0000,attributable,french lebanon/blackberries=0.03,no
+bulgaria,soybeans,ha,4,3,,,,,too_few_values,,no
+bulgaria,sugar raw centrifugal,tonnes,33,33,bulgaria,sugar: beet,yes,1.0000,attributable,netherlands/linseed=0.09,no
+bulgaria,wine,ha,20,16,bulgaria,wine,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.10",no
+bulgaria,wine,tonnes,33,33,,,,,unattributable,yugoslavia/wine=0.00,no
+bulgaria,yarn of true hemp,ha,13,12,bulgaria,hempseed,yes,1.0000,attributable,uk: northern ireland/flax: fibre=0.23,no
+bulgaria,yarn of true hemp,tonnes,26,26,bulgaria,hemp: fibre,yes,1.0000,attributable,uk: northern ireland/flax: fibre=0.04,no
+burkina faso,cotton lint,ha,5,5,,,,,too_few_values,,no
+burkina faso,cotton lint,tonnes,5,5,,,,,too_few_values,,no
+burkina faso,cotton seed,ha,5,5,,,,,too_few_values,,no
+burkina faso,cotton seed,tonnes,5,5,,,,,too_few_values,,no
+burkina faso,eggs hen in shell,tonnes,4,4,,,,,too_few_values,,no
+burkina faso,groundnuts with shell,ha,6,6,,,,,too_few_values,,no
+burkina faso,groundnuts with shell,tonnes,7,7,,,,,too_few_values,,no
+burkina faso,sesame seed,ha,3,2,,,,,too_few_values,,no
+burkina faso,sesame seed,tonnes,5,3,,,,,too_few_values,,no
+burkina faso,tobacco unmanufactured,ha,3,3,,,,,too_few_values,,no
+burkina faso,tobacco unmanufactured,tonnes,3,3,,,,,too_few_values,,no
+burundi,cotton lint,ha,8,6,belgian ruanda-urundi,cottonseed,yes,1.0000,attributable,france/hempseed=0.50,no
+burundi,cotton lint,tonnes,8,7,,,,,unattributable,belgian ruanda-urundi/cotton: ginned=0.50,no
+burundi,cotton seed,ha,8,6,belgian ruanda-urundi,cottonseed,yes,1.0000,attributable,france/hempseed=0.50,no
+burundi,cotton seed,tonnes,7,7,,,,,too_few_values,,no
+burundi,groundnuts with shell,ha,7,6,,,,,too_few_values,,no
+burundi,groundnuts with shell,tonnes,7,7,,,,,too_few_values,,no
+burundi,tobacco unmanufactured,ha,7,5,,,,,too_few_values,,no
+burundi,tobacco unmanufactured,tonnes,7,6,,,,,too_few_values,,no
+cabo verde,beans dry,ha,4,2,,,,,too_few_values,,no
+cabo verde,beans dry,tonnes,6,5,,,,,too_few_values,,no
+cabo verde,coffee green,ha,3,3,,,,,too_few_values,,no
+cabo verde,coffee green,tonnes,5,2,,,,,too_few_values,,no
+cabo verde,oranges,tonnes,5,5,,,,,too_few_values,,no
+cabo verde,sugar raw centrifugal,tonnes,8,4,,,,,too_few_distinct,,no
+cabo verde,tobacco unmanufactured,tonnes,5,5,,,,,too_few_values,,no
+cambodia,beans dry,tonnes,3,2,,,,,too_few_values,,no
+cambodia,silk worm cocoons reelable,tonnes,1,1,,,,,too_few_values,,no
+cameroon,cacao beans,ha,15,7,british‑french cameroon,cacao: raw,yes,1.0000,attributable,total/hemp: fibre=0.47,no
+cameroon,coffee green,ha,7,1,,,,,too_few_values,,no
+cameroon,cotton lint,ha,5,1,,,,,too_few_values,,no
+cameroon,cotton lint,tonnes,4,1,,,,,too_few_values,,no
+cameroon,cotton seed,ha,12,1,,,,,too_few_distinct,,no
+cameroon,cotton seed,tonnes,11,2,,,,,too_few_distinct,,no
+cameroon,groundnuts with shell,ha,10,10,british‑french cameroon,groundnut,yes,1.0000,attributable,us puerto rico/coffee: raw=0.10,no
+cameroon,groundnuts with shell,tonnes,2,2,,,,,too_few_values,,no
+cameroon,rubber natural,ha,13,12,,,,,unattributable,usa/hemp: fibre=0.08,no
+cameroon,sesame seed,ha,17,12,british‑french cameroon,sesame,yes,1.0000,attributable,total/rye=0.29,no
+cameroon,sesame seed,tonnes,17,14,british‑french cameroon,sesame,yes,1.0000,attributable,uruguay/groundnut=0.12,no
+cameroon,tobacco unmanufactured,ha,4,1,,,,,too_few_values,,no
+cameroon,tobacco unmanufactured,tonnes,3,3,,,,,too_few_values,,no
+canada,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+canada,eggs hen in shell,tonnes,17,17,canada,eggs,yes,0.6471,attributable,yugoslavia/wine=0.00,no
+canada,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+canada,n,tonnes,12,12,canada,fertilizers: ammonium sulfate,unknown,0.6667,attributable,yugoslavia/wine=0.00,no
+canada,p,tonnes,17,16,canada,"fertilizers: phosphate, natural",unknown,1.0000,attributable,portugal/fertilizers: ammonium sulfate=0.06,no
+canada,sugar raw centrifugal,tonnes,32,32,canada,sugar: beet,yes,1.0000,attributable,portuguese mozambique/sugar: cane=0.03,no
+canada,wine,tonnes,14,14,,,,,unattributable,yugoslavia/wine=0.00,no
+central african republic,cacao beans,ha,2,2,,,,,too_few_values,,no
+central african republic,cacao beans,tonnes,2,2,,,,,too_few_values,,no
+central african republic,groundnuts with shell,ha,3,3,,,,,too_few_values,,no
+central african republic,groundnuts with shell,tonnes,3,3,,,,,too_few_values,,no
+chad,groundnuts with shell,ha,3,3,,,,,too_few_values,,no
+chad,groundnuts with shell,tonnes,3,3,,,,,too_few_values,,no
+chile,beans dry,ha,2,2,,,,,too_few_values,,no
+chile,eggs hen in shell,tonnes,9,8,chile,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+chile,fertilizer mixed,tonnes,14,14,chile,"fertilizers: guano, natural",yes,0.8571,attributable,yugoslavia/wine=0.00,no
+chile,flax fibre and tow,ha,4,4,,,,,too_few_values,,no
+chile,flax fibre and tow,tonnes,5,5,,,,,too_few_values,,no
+chile,grapes,tonnes,6,6,,,,,too_few_values,,no
+chile,hemp tow waste,ha,3,3,,,,,too_few_values,,no
+chile,hemp tow waste,tonnes,1,1,,,,,too_few_values,,no
+chile,hempseed,ha,1,1,,,,,too_few_values,,no
+chile,hempseed,tonnes,2,2,,,,,too_few_values,,no
+chile,n,tonnes,4,4,,,,,too_few_values,,no
+chile,no3,tonnes,13,13,chile,fertilizers: sodium nitrate,no,1.0000,attributable,yugoslavia/wine=0.00,no
+chile,oil olive virgin,tonnes,1,1,,,,,too_few_values,,no
+chile,olives,ha,1,1,,,,,too_few_values,,no
+chile,olives,tonnes,1,1,,,,,too_few_values,,no
+chile,raisins,tonnes,8,3,,,,,too_few_distinct,,no
+chile,rapeseed,tonnes,1,1,,,,,too_few_values,,no
+chile,rye,ha,1,1,,,,,too_few_values,,no
+chile,rye,tonnes,2,2,,,,,too_few_values,,no
+chile,sugar raw centrifugal,tonnes,2,2,,,,,too_few_values,,no
+chile,tobacco unmanufactured,ha,6,6,,,,,too_few_values,,no
+chile,tobacco unmanufactured,tonnes,3,3,,,,,too_few_values,,no
+chile,yarn of true hemp,ha,2,2,,,,,too_few_values,,no
+chile,yarn of true hemp,tonnes,13,13,chile,hemp: fibre,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+"china, hong kong sar",groundnuts with shell,ha,1,1,,,,,too_few_values,,no
+"china, hong kong sar",groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+"china, taiwan province of",fertilizer mixed,tonnes,12,12,japanese taiwan,sulphur,no,1.0000,attributable,yugoslavia/wine=0.00,no
+"china, taiwan province of",groundnuts with shell,ha,11,8,japanese taiwan,groundnut,yes,1.0000,attributable,austria/wine=0.18,no
+"china, taiwan province of",jute,ha,21,20,japanese taiwan,jute,yes,1.0000,attributable,japan/sesame=0.10,no
+"china, taiwan province of",jute,tonnes,21,21,japanese taiwan,jute,yes,1.0000,attributable,total/tea=0.05,no
+"china, taiwan province of",oranges,tonnes,5,5,,,,,too_few_values,,no
+"china, taiwan province of",other berries and fruits of the genus vaccinium n e c,ha,8,6,japanese taiwan,blackberries,no,1.0000,attributable,italian eritrea/groundnut=0.50,no
+"china, taiwan province of",other citrus fruit n e c,tonnes,3,3,,,,,too_few_values,,no
+"china, taiwan province of",p,tonnes,4,4,,,,,too_few_values,,no
+"china, taiwan province of",rapeseed,ha,17,13,japanese taiwan,rapeseed,yes,1.0000,attributable,sweden/tobacco=0.29,no
+"china, taiwan province of",rapeseed,tonnes,16,15,japanese taiwan,rapeseed,yes,1.0000,attributable,japan/cotton: ginned=0.19,no
+"china, taiwan province of",sesame seed,ha,10,8,japanese taiwan,sesame,yes,1.0000,attributable,us puerto rico/citrus fruits: oranges=0.40,no
+"china, taiwan province of",sesame seed,tonnes,11,10,japanese taiwan,sesame,yes,1.0000,attributable,british southern rhodesia/groundnut=0.27,no
+"china, taiwan province of",silk worm cocoons reelable,tonnes,16,16,japanese taiwan,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,no
+"china, taiwan province of",soybeans,ha,8,6,japanese taiwan,soybean,yes,1.0000,attributable,french annam/cottonseed=0.50,no
+"china, taiwan province of",soybeans,tonnes,8,8,japanese taiwan,soybean,yes,1.0000,attributable,uruguay/beans: dried=0.12,no
+"china, taiwan province of",sugar raw centrifugal,tonnes,33,33,japanese taiwan,sugar: cane,yes,0.8788,attributable,poland/tobacco=0.03,no
+"china, taiwan province of",tea,ha,24,22,japanese taiwan,tea,yes,1.0000,attributable,portuguese angola/coffee: raw=0.08,no
+"china, taiwan province of",tea,tonnes,1,1,,,,,too_few_values,,no
+"china, taiwan province of",tobacco unmanufactured,ha,21,19,japanese taiwan,tobacco,yes,1.0000,attributable,yugoslavia/sesame=0.14,no
+"china, taiwan province of",tobacco unmanufactured,tonnes,23,23,japanese taiwan,tobacco,yes,1.0000,attributable,belgium/rye=0.04,no
+colombia,cacao beans,ha,6,6,,,,,too_few_values,,no
+colombia,castor beans seed,tonnes,5,3,,,,,too_few_values,,no
+colombia,coffee green,ha,2,2,,,,,too_few_values,,no
+colombia,coffee green,tonnes,3,3,,,,,too_few_values,,no
+colombia,cotton lint,ha,14,12,colombia,cottonseed,yes,0.9286,attributable,uruguay/wine=0.14,no
+colombia,cotton seed,ha,13,11,colombia,cottonseed,yes,1.0000,attributable,uruguay/wine=0.15,no
+colombia,cotton seed,tonnes,3,3,,,,,too_few_values,,no
+colombia,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+congo,cacao beans,ha,9,7,french equatorial africa,cacao: raw,yes,0.7778,attributable,french morocco/vineyards: all=0.44,no
+congo,cacao beans,tonnes,17,11,french equatorial africa,cacao: raw,yes,0.8235,attributable,france/citrus fruits: oranges=0.18,no
+congo,coffee green,ha,12,11,french equatorial africa,coffee: raw,yes,1.0000,attributable,"spain/vineyards: grapes, raisins=0.17",no
+congo,coffee green,tonnes,19,18,french equatorial africa,coffee: raw,yes,1.0000,attributable,sweden/flax: fibre=0.11,no
+congo,cotton lint,ha,19,17,french equatorial africa,cotton,yes,0.7368,attributable,british sierra leone/coffee: raw=0.11,no
+congo,cotton lint,tonnes,18,17,french equatorial africa,cotton: ginned,yes,0.6111,attributable,yugoslavia/rapeseed=0.06,no
+congo,cotton seed,ha,11,11,french equatorial africa,cottonseed,yes,1.0000,attributable,venezuela/sugar: cane=0.09,no
+congo,cotton seed,tonnes,18,17,french equatorial africa,cottonseed,yes,1.0000,attributable,french madagascar/beans: dried=0.11,no
+congo,groundnuts with shell,ha,12,12,french equatorial africa,groundnut,yes,0.7500,attributable,ussr: transcaucasian sfsr/tea=0.17,no
+congo,groundnuts with shell,tonnes,10,10,french equatorial africa,groundnut,yes,0.7000,attributable,spanish spanish guinea/cacao: raw=0.10,no
+congo,sesame seed,ha,10,9,french equatorial africa,sesame,yes,0.7000,attributable,french annam/cottonseed=0.30,no
+congo,sesame seed,tonnes,11,10,french equatorial africa,sesame,yes,0.7273,attributable,portuguese cape verde/sugar: cane=0.18,no
+congo,tobacco unmanufactured,ha,14,13,french equatorial africa,tobacco,yes,1.0000,attributable,czechoslovakia/beans: dried=0.21,no
+congo,tobacco unmanufactured,tonnes,12,11,french equatorial africa,tobacco,yes,1.0000,attributable,turkey/meslin=0.08,no
+costa rica,cacao beans,ha,11,7,costa rica,cacao: raw,yes,1.0000,attributable,french syria/hemp: fibre=0.36,no
+costa rica,cacao beans,tonnes,28,28,costa rica,cacao: raw,yes,1.0000,attributable,spain/flax: fibre=0.07,no
+costa rica,coffee green,ha,4,4,,,,,too_few_values,,no
+costa rica,lemons and limes,tonnes,7,2,,,,,too_few_values,,no
+costa rica,oranges,tonnes,1,1,,,,,too_few_values,,no
+costa rica,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+cuba,cacao beans,ha,2,1,,,,,too_few_values,,no
+cuba,cacao beans,tonnes,13,12,cuba,cacao: raw,yes,1.0000,attributable,yugoslavia/rapeseed=0.08,no
+cuba,coffee green,ha,1,1,,,,,too_few_values,,no
+cuba,other citrus fruit n e c,tonnes,2,2,,,,,too_few_values,,no
+cuba,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+curaã§ao,p,tonnes,4,4,,,,,too_few_values,,no
+cyprus,beans dry,ha,9,3,,,,,too_few_distinct,,no
+cyprus,beans dry,tonnes,13,7,british cyprus,beans: dried,unknown,1.0000,attributable,french guadeloupe/coffee: raw=0.31,no
+cyprus,cotton lint,ha,24,17,british cyprus,cottonseed,yes,0.8333,attributable,spain/beans: dried=0.21,no
+cyprus,cotton lint,tonnes,33,28,british cyprus,cotton,yes,0.6364,attributable,french madagascar/cacao: raw=0.18,no
+cyprus,cotton seed,ha,20,13,british cyprus,cottonseed,yes,1.0000,attributable,spain/beans: dried=0.25,no
+cyprus,cotton seed,tonnes,20,16,british cyprus,cottonseed,yes,1.0000,attributable,new zealand western samoa/cacao: raw=0.15,no
+cyprus,flax fibre and tow,ha,13,6,,,,,ambiguous,british cyprus/flax: fibre=1.00;union of south africa/tea=0.62;new zealand/tobacco=0.62,no
+cyprus,flax fibre and tow,tonnes,15,13,british cyprus,linseed,no,0.6667,attributable,union of south africa/cotton: ginned=0.20,no
+cyprus,grapefruit inc pomelos,ha,5,1,,,,,too_few_values,,no
+cyprus,grapefruit inc pomelos,tonnes,10,8,british cyprus,citrus fruits: grapefruits,yes,1.0000,attributable,ireland/tobacco=0.40,no
+cyprus,grapes,ha,30,25,,,,,unattributable,british cyprus/vineyards: all=0.40,no
+cyprus,grapes,tonnes,28,28,,,,,unattributable,"british cyprus/vineyards: grapes, raisins=0.46",no
+cyprus,groundnuts with shell,ha,7,6,,,,,too_few_values,,no
+cyprus,groundnuts with shell,tonnes,7,7,,,,,too_few_values,,no
+cyprus,hemp tow waste,tonnes,6,1,,,,,too_few_values,,no
+cyprus,hempseed,ha,9,5,,,,,too_few_distinct,,no
+cyprus,hempseed,tonnes,9,5,,,,,too_few_distinct,,no
+cyprus,lemons and limes,ha,5,2,,,,,too_few_values,,no
+cyprus,lemons and limes,tonnes,15,13,,,,,unattributable,british cyprus/citrus fruits: lemons=0.27,no
+cyprus,linseed,ha,4,4,,,,,too_few_values,,no
+cyprus,linseed,tonnes,4,4,,,,,too_few_values,,no
+cyprus,oats,ha,7,4,,,,,too_few_values,,no
+cyprus,oats,tonnes,7,7,,,,,too_few_values,,no
+cyprus,oil olive virgin,tonnes,24,22,british cyprus,olive: oil,yes,1.0000,attributable,british saint lucia/cacao: raw=0.12,no
+cyprus,olives,tonnes,20,19,british cyprus,olive grove,yes,1.0000,attributable,french ivory coast/tobacco=0.10,no
+cyprus,oranges,ha,7,1,,,,,too_few_values,,no
+cyprus,oranges,tonnes,15,15,british cyprus,citrus fruits: oranges,yes,1.0000,attributable,"union of south africa/vineyards: grapes, raisins=0.07",no
+cyprus,raisins,ha,4,4,,,,,too_few_values,,no
+cyprus,raisins,tonnes,20,19,british cyprus,raisins,yes,0.8000,attributable,british ceylon/cacao: raw=0.10,no
+cyprus,sesame seed,ha,20,10,british cyprus,sesame,yes,1.0000,attributable,new zealand/tobacco=0.45,no
+cyprus,sesame seed,tonnes,20,13,british cyprus,sesame,yes,1.0000,attributable,british dominica/cacao: raw=0.30,no
+cyprus,silk worm cocoons reelable,tonnes,24,24,british cyprus,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,no
+cyprus,tangerines mandarins clementines satsumas,tonnes,11,5,,,,,too_few_distinct,,no
+cyprus,tobacco unmanufactured,ha,19,15,british cyprus,tobacco,yes,1.0000,attributable,french morocco/tobacco=0.21,no
+cyprus,tobacco unmanufactured,tonnes,29,29,british cyprus,tobacco,yes,1.0000,attributable,switzerland/sugar: beet=0.03,no
+cyprus,wine,ha,8,8,british cyprus,wine,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+cyprus,yarn of true hemp,ha,9,5,,,,,too_few_distinct,,no
+cyprus,yarn of true hemp,tonnes,9,6,british cyprus,hemp: fibre,yes,1.0000,attributable,french guadeloupe and dependencies: marie‑galante/cottonseed=0.56,no
+czech republic,beans dry,ha,13,4,,,,,too_few_distinct,,no
+czech republic,beans dry,tonnes,13,13,czechoslovakia,beans: dried,unknown,1.0000,attributable,total/cacao: raw=0.15,no
+czech republic,butter cow milk,tonnes,7,6,,,,,too_few_values,,no
+czech republic,cheese processed,tonnes,7,6,,,,,too_few_values,,no
+czech republic,eggs hen in shell,tonnes,5,5,,,,,too_few_values,,no
+czech republic,flax fibre and tow,ha,23,21,czechoslovakia,flax: fibre,yes,0.7826,attributable,total/groundnut=0.09,no
+czech republic,flax fibre and tow,tonnes,22,22,,,,,unattributable,czechoslovakia/linseed=0.50,no
+czech republic,grapes,ha,17,13,czechoslovakia,vineyards: all,no,0.6471,attributable,total/cotton: ginned=0.18,no
+czech republic,grapes,tonnes,15,14,czechoslovakia,"vineyards: grapes, raisins",yes,0.8000,attributable,venezuela/cotton: ginned=0.13,no
+czech republic,hemp tow waste,ha,10,5,,,,,too_few_distinct,,no
+czech republic,hemp tow waste,tonnes,7,6,,,,,too_few_values,,no
+czech republic,hempseed,ha,17,11,czechoslovakia,hemp: fibre,yes,0.7647,attributable,total/rye=0.35,no
+czech republic,hempseed,tonnes,22,21,czechoslovakia,hempseed,yes,0.6818,attributable,japan/linseed=0.09,no
+czech republic,hops,ha,23,23,czechoslovakia,hops,yes,1.0000,attributable,british iraq/sesame=0.09,no
+czech republic,hops,tonnes,21,21,czechoslovakia,hops,yes,1.0000,attributable,belgium/oats=0.05,no
+czech republic,linseed,ha,8,8,czechoslovakia,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+czech republic,linseed,tonnes,11,11,czechoslovakia,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+czech republic,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+czech republic,n,tonnes,4,4,,,,,too_few_values,,no
+czech republic,oats,ha,7,7,,,,,too_few_values,,no
+czech republic,oats,tonnes,7,7,,,,,too_few_values,,no
+czech republic,other forage products n e c,ha,4,4,,,,,too_few_values,,no
+czech republic,other forage products n e c,tonnes,4,4,,,,,too_few_values,,no
+czech republic,p,tonnes,4,4,,,,,too_few_values,,no
+czech republic,rapeseed,ha,23,22,czechoslovakia,rapeseed,yes,1.0000,attributable,german togoland/cacao: raw=0.13,no
+czech republic,rapeseed,tonnes,22,22,czechoslovakia,rapeseed,yes,1.0000,attributable,us philippines/groundnut=0.05,no
+czech republic,rye,ha,24,22,czechoslovakia,rye,yes,1.0000,attributable,yugoslavia/rye=0.17,no
+czech republic,rye,tonnes,23,23,czechoslovakia,rye,yes,1.0000,attributable,greece/cottonseed=0.09,no
+czech republic,silk worm cocoons reelable,tonnes,14,10,czechoslovakia,sericulture,no,1.0000,attributable,romania/cotton=0.07,no
+czech republic,soybeans,ha,9,1,,,,,too_few_distinct,,no
+czech republic,soybeans,tonnes,11,5,,,,,too_few_distinct,,no
+czech republic,sugar raw centrifugal,tonnes,23,23,czechoslovakia,sugar: beet,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+czech republic,tobacco unmanufactured,ha,21,16,czechoslovakia,tobacco,yes,1.0000,attributable,japanese korea/sesame=0.24,no
+czech republic,tobacco unmanufactured,tonnes,21,21,czechoslovakia,tobacco,yes,1.0000,attributable,total/hemp: fibre=0.05,no
+czech republic,wheat,ha,20,18,,,,,unattributable,czechoslovakia/meslin=0.55,no
+czech republic,wheat,tonnes,20,19,,,,,unattributable,czechoslovakia/meslin=0.55,no
+czech republic,wine,ha,20,15,czechoslovakia,wine,yes,1.0000,attributable,german togoland/cacao: raw=0.15,no
+czech republic,wine,tonnes,20,20,,,,,unattributable,yugoslavia/wine=0.00,no
+czech republic,yarn of true hemp,ha,13,9,czechoslovakia,hemp: fibre,yes,1.0000,attributable,switzerland/spelt=0.38,no
+czech republic,yarn of true hemp,tonnes,15,14,czechoslovakia,hemp: fibre,yes,1.0000,attributable,us philippines/groundnut=0.07,no
+denmark,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+denmark,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+denmark,eggs hen in shell,tonnes,15,15,denmark,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+denmark,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+denmark,n,tonnes,12,8,denmark,fertilizers: ammonium sulfate,unknown,1.0000,attributable,british saint lucia/cacao: raw=0.17,no
+denmark,p,tonnes,15,15,denmark,fertilizers: calcium superphosphate,unknown,1.0000,attributable,italy/hemp: fibre=0.07,no
+denmark,sugar raw centrifugal,tonnes,33,33,denmark,sugar: beet,yes,1.0000,attributable,french sudan/groundnut=0.03,no
+denmark,tobacco unmanufactured,ha,3,1,,,,,too_few_values,,no
+djibouti,coffee green,tonnes,4,4,,,,,too_few_values,,no
+djibouti,eggs hen in shell,tonnes,1,1,,,,,too_few_values,,no
+dominica,cacao beans,ha,8,4,,,,,too_few_distinct,,no
+dominica,cacao beans,tonnes,29,20,british dominica,cacao: raw,yes,1.0000,attributable,french annam/jute=0.24,no
+dominica,grapefruit inc pomelos,ha,4,1,,,,,too_few_values,,no
+dominica,grapefruit inc pomelos,tonnes,11,3,,,,,too_few_distinct,,no
+dominica,lemons and limes,ha,14,6,british dominica,citrus fruits: limes,yes,1.0000,attributable,new zealand/tobacco=0.57,no
+dominica,lemons and limes,tonnes,14,13,british dominica,citrus fruits: limes,yes,1.0000,attributable,egypt/flax: fibre=0.21,no
+dominica,oranges,ha,4,1,,,,,too_few_values,,no
+dominica,oranges,tonnes,11,3,,,,,too_few_distinct,,no
+dominican republic,cacao beans,ha,4,2,,,,,too_few_values,,no
+dominican republic,cacao beans,tonnes,1,1,,,,,too_few_values,,no
+dominican republic,coffee green,ha,3,3,,,,,too_few_values,,no
+dominican republic,coffee green,tonnes,1,1,,,,,too_few_values,,no
+dominican republic,cotton lint,tonnes,4,1,,,,,too_few_values,,no
+dominican republic,cotton seed,tonnes,5,2,,,,,too_few_values,,no
+dominican republic,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+dominican republic,tobacco unmanufactured,ha,1,1,,,,,too_few_values,,no
+dr congo,cacao beans,ha,17,10,belgian congo,cacao: raw,yes,1.0000,attributable,dutch east indies/cacao: raw=0.29,no
+dr congo,cacao beans,tonnes,17,13,belgian congo,cacao: raw,yes,1.0000,attributable,french annam/sesame=0.18,no
+dr congo,coffee green,ha,14,14,belgian congo,coffee: raw,yes,1.0000,attributable,greece/spelt=0.14,no
+dr congo,cotton lint,ha,23,23,belgian congo,cottonseed,yes,0.7826,attributable,usa/citrus fruits: oranges=0.04,no
+dr congo,cotton lint,tonnes,5,5,,,,,too_few_values,,no
+dr congo,cotton seed,ha,19,19,belgian congo,cottonseed,yes,1.0000,attributable,usa/citrus fruits: oranges=0.05,no
+dr congo,cotton seed,tonnes,19,19,belgian congo,cottonseed,yes,1.0000,attributable,greece/olive: oil=0.05,no
+dr congo,groundnuts with shell,ha,7,5,,,,,too_few_values,,no
+dr congo,groundnuts with shell,tonnes,4,2,,,,,too_few_values,,no
+dr congo,rubber natural,ha,6,6,,,,,too_few_values,,no
+dr congo,sesame seed,ha,4,4,,,,,too_few_values,,no
+dr congo,sesame seed,tonnes,7,7,,,,,too_few_values,,no
+dr congo,sugar raw centrifugal,tonnes,11,9,belgian congo,sugar: cane,yes,1.0000,attributable,switzerland/spelt=0.18,no
+dr congo,tobacco unmanufactured,ha,7,6,,,,,too_few_values,,no
+dr congo,tobacco unmanufactured,tonnes,7,6,,,,,too_few_values,,no
+ecuador,cacao beans,ha,1,1,,,,,too_few_values,,no
+ecuador,cacao beans,tonnes,1,1,,,,,too_few_values,,no
+ecuador,castor beans seed,tonnes,6,6,,,,,too_few_values,,no
+ecuador,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+ecuador,cotton seed,tonnes,7,6,,,,,too_few_values,,no
+ecuador,lemons and limes,tonnes,4,2,,,,,too_few_values,,no
+ecuador,oranges,tonnes,2,2,,,,,too_few_values,,no
+egypt,beans dry,tonnes,3,3,,,,,too_few_values,,no
+egypt,cotton lint,ha,33,33,,,,,unattributable,egypt/cotton=0.12,no
+egypt,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+egypt,cotton seed,ha,20,20,,,,,unattributable,sweden/oats=0.05,no
+egypt,cotton seed,tonnes,20,20,,,,,unattributable,dutch java and madura/tobacco=0.05,no
+egypt,eggs hen in shell,tonnes,12,12,egypt,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+egypt,flax fibre and tow,ha,29,23,egypt,linseed,no,0.6897,attributable,british uganda/tobacco=0.17,no
+egypt,flax fibre and tow,tonnes,22,21,,,,,unattributable,egypt/linseed=0.55,no
+egypt,grapes,ha,25,18,,,,,unattributable,egypt/vineyards: all=0.40,no
+egypt,grapes,tonnes,10,10,,,,,unattributable,"egypt/vineyards: grapes, raisins=0.50",no
+egypt,groundnuts with shell,ha,20,17,,,,,unattributable,czechoslovakia/linseed=0.15,no
+egypt,groundnuts with shell,tonnes,20,19,,,,,unattributable,total/hops=0.10,no
+egypt,lemons and limes,tonnes,11,11,egypt,citrus fruits: lemons,yes,1.0000,attributable,argentina/cotton: ginned=0.09,no
+egypt,linseed,ha,8,8,egypt,linseed,yes,1.0000,attributable,french cambodia/sesame=0.12,no
+egypt,linseed,tonnes,11,11,egypt,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+egypt,milk whole fresh cow,tonnes,4,4,,,,,too_few_values,,no
+egypt,n,tonnes,3,3,,,,,too_few_values,,no
+egypt,oil olive virgin,tonnes,4,1,,,,,too_few_values,,no
+egypt,olives,ha,5,1,,,,,too_few_values,,no
+egypt,olives,tonnes,7,6,,,,,too_few_values,,no
+egypt,oranges,ha,13,7,egypt,citrus fruits: oranges,yes,0.7692,attributable,usa/olive grove=0.31,no
+egypt,oranges,tonnes,11,11,egypt,citrus fruits: oranges,yes,1.0000,attributable,uruguay/linseed=0.09,no
+egypt,p,tonnes,17,17,egypt,"fertilizers: phosphate, natural",unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+egypt,sesame seed,ha,20,19,,,,,unattributable,egypt/sesame=0.35,no
+egypt,sesame seed,tonnes,20,20,,,,,unattributable,egypt/sesame=0.10,no
+egypt,silk worm cocoons reelable,tonnes,7,6,,,,,too_few_values,,no
+egypt,sugar raw centrifugal,tonnes,33,33,egypt,sugar: cane,yes,0.8788,attributable,total/cacao: raw=0.03,no
+egypt,tangerines mandarins clementines satsumas,tonnes,11,11,egypt,citrus fruits: mandarins,yes,1.0000,attributable,uruguay/linseed=0.09,no
+egypt,wine,ha,4,4,,,,,too_few_values,,no
+el salvador,coffee green,ha,1,1,,,,,too_few_values,,no
+el salvador,coffee green,tonnes,2,2,,,,,too_few_values,,no
+el salvador,cotton lint,ha,6,4,,,,,too_few_values,,no
+el salvador,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+el salvador,cotton seed,ha,11,6,el salvador,cottonseed,yes,0.6364,attributable,spain/linseed=0.45,no
+el salvador,cotton seed,tonnes,12,12,el salvador,cottonseed,yes,0.6667,attributable,el salvador: san salvador department/cottonseed=0.33,no
+el salvador,sugar raw centrifugal,tonnes,2,2,,,,,too_few_values,,no
+equatorial guinea,cacao beans,ha,10,7,,,,,unattributable,germany/beans: dried=0.20,no
+equatorial guinea,coffee green,ha,6,3,,,,,too_few_values,,no
+equatorial guinea,coffee green,tonnes,7,5,,,,,too_few_values,,no
+eritrea,coffee green,ha,3,3,,,,,too_few_values,,no
+eritrea,coffee green,tonnes,8,6,italian eritrea,coffee: raw,yes,1.0000,attributable,yugoslavia/cotton: ginned=0.12,no
+eritrea,cotton lint,ha,11,9,italian eritrea,cottonseed,yes,1.0000,attributable,us puerto rico/citrus fruits: grapefruits=0.36,no
+eritrea,cotton lint,tonnes,11,9,italian eritrea,cotton,yes,0.6364,attributable,romania/cottonseed=0.18,no
+eritrea,cotton seed,ha,11,9,italian eritrea,cottonseed,yes,1.0000,attributable,us puerto rico/citrus fruits: grapefruits=0.36,no
+eritrea,cotton seed,tonnes,11,10,italian eritrea,cottonseed,yes,1.0000,attributable,yugoslavia/sesame=0.27,no
+eritrea,eggs hen in shell,tonnes,3,2,,,,,too_few_values,,no
+eritrea,flax fibre and tow,ha,5,2,,,,,too_few_values,,no
+eritrea,flax fibre and tow,tonnes,5,5,,,,,too_few_values,,no
+eritrea,groundnuts with shell,ha,5,2,,,,,too_few_values,,no
+eritrea,groundnuts with shell,tonnes,5,2,,,,,too_few_values,,no
+eritrea,linseed,ha,4,4,,,,,too_few_values,,no
+eritrea,linseed,tonnes,4,3,,,,,too_few_values,,no
+eritrea,sesame seed,ha,6,4,,,,,too_few_values,,no
+eritrea,sesame seed,tonnes,7,6,,,,,too_few_values,,no
+eritrea,tobacco unmanufactured,ha,8,4,,,,,too_few_distinct,,no
+eritrea,tobacco unmanufactured,tonnes,8,8,italian eritrea,tobacco,yes,1.0000,attributable,turkey/hempseed=0.12,no
+estonia,butter cow milk,tonnes,1,1,,,,,too_few_values,,no
+estonia,cheese processed,tonnes,2,2,,,,,too_few_values,,no
+estonia,eggs hen in shell,tonnes,10,10,estonia,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+estonia,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+estonia,p,tonnes,4,4,,,,,too_few_values,,no
+eswatini,cotton seed,ha,2,2,,,,,too_few_values,,no
+eswatini,cotton seed,tonnes,2,2,,,,,too_few_values,,no
+eswatini,tobacco unmanufactured,ha,8,4,,,,,too_few_distinct,,no
+eswatini,tobacco unmanufactured,tonnes,14,13,british swaziland,tobacco,yes,1.0000,attributable,french algeria/tobacco=0.14,no
+ethiopia,coffee green,tonnes,1,1,,,,,too_few_values,,no
+ethiopia pdr,coffee green,tonnes,11,11,,,,,unattributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.18",no
+falkland islands (malvinas),fertilizer mixed,tonnes,6,6,,,,,too_few_values,,no
+faroe islands,eggs hen in shell,tonnes,5,4,,,,,too_few_values,,no
+fiji,cacao beans,ha,10,7,british fiji islands,cacao: raw,yes,1.0000,attributable,us philippines/coffee: raw=0.10,no
+fiji,cacao beans,tonnes,10,9,british fiji islands,cacao: raw,yes,1.0000,attributable,bulgaria/hops=0.10,no
+fiji,cotton lint,ha,17,12,british fiji islands,cotton,yes,0.7059,attributable,uruguay/rye=0.29,no
+fiji,cotton lint,tonnes,8,4,,,,,too_few_distinct,,no
+fiji,cotton seed,ha,8,4,,,,,too_few_distinct,,no
+fiji,cotton seed,tonnes,8,4,,,,,too_few_distinct,,no
+fiji,groundnuts with shell,ha,2,2,,,,,too_few_values,,no
+fiji,groundnuts with shell,tonnes,2,2,,,,,too_few_values,,no
+fiji,sugar raw centrifugal,tonnes,32,32,british fiji islands,sugar: cane,yes,0.8750,attributable,total/hempseed=0.03,no
+fiji,tea,ha,15,5,,,,,too_few_distinct,,no
+fiji,tea,tonnes,14,10,british fiji islands,tea,yes,1.0000,attributable,japan: karafuto prefecture/rye=0.07,no
+fiji,tobacco unmanufactured,ha,15,13,british fiji islands,tobacco,yes,1.0000,attributable,french algeria/rye=0.07,no
+fiji,tobacco unmanufactured,tonnes,15,14,british fiji islands,tobacco,yes,1.0000,attributable,bulgaria/flax: fibre=0.07,no
+finland,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+finland,cheese processed,tonnes,6,6,,,,,too_few_values,,no
+finland,eggs hen in shell,tonnes,4,4,,,,,too_few_values,,no
+finland,p,tonnes,4,4,,,,,too_few_values,,no
+finland,sugar raw centrifugal,tonnes,23,21,finland,sugar: beet,yes,1.0000,attributable,greece/sesame=0.09,no
+france,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+france,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+france,eggs hen in shell,tonnes,10,5,,,,,too_few_distinct,,no
+france,fertilizer mixed,tonnes,12,8,france,fertilizers: copper(ii) sulfate,yes,1.0000,attributable,switzerland/sugar: beet=0.08,no
+france,grapes,tonnes,28,28,,,,,unattributable,"france/vineyards: grapes, raisins=0.39",no
+france,k,tonnes,4,4,,,,,too_few_values,,no
+france,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+france,n,tonnes,17,17,france,fertilizers: calcium cyanamide,unknown,1.0000,attributable,usa and canada/fertilizers: calcium cyanamide=0.06,no
+france,other berries and fruits of the genus vaccinium n e c,tonnes,16,15,france,blackberries,no,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.06",no
+france,other citrus fruit n e c,tonnes,11,8,france,citrus fruits: cedrats,yes,1.0000,attributable,us puerto rico/citrus fruits: oranges=0.27,no
+france,p,tonnes,16,16,,,,,unattributable,"france/fertilizers: phosphate, natural=0.56",no
+france,silk worm cocoons reelable,tonnes,33,33,france,sericulture,no,1.0000,attributable,italy/raisins=0.03,no
+france,sugar raw centrifugal,tonnes,33,33,france,sugar: beet,yes,1.0000,attributable,netherlands/rye=0.03,no
+france,wine,ha,20,19,france,wine,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+france,wine,tonnes,33,33,,,,,unattributable,yugoslavia/wine=0.00,no
+france,yarn of true hemp,ha,13,10,france,hemp: fibre,yes,1.0000,attributable,hungary/beans: dried=0.31,no
+france,yarn of true hemp,tonnes,26,26,france,hemp: fibre,yes,1.0000,attributable,"ussr/citrus fruits: lemons, mandarins, oranges=0.04",no
+french guiana,cacao beans,ha,5,2,,,,,too_few_values,,no
+french guiana,cacao beans,tonnes,11,7,french guiana,cacao: raw,yes,1.0000,attributable,uruguay/rye=0.45,no
+french guiana,eggs hen in shell,tonnes,7,2,,,,,too_few_values,,no
+french guiana,p,tonnes,5,5,,,,,too_few_values,,no
+french guiana,sugar raw centrifugal,tonnes,5,2,,,,,too_few_values,,no
+french polynesia,cacao beans,ha,1,1,,,,,too_few_values,,no
+french polynesia,eggs hen in shell,tonnes,5,1,,,,,too_few_values,,no
+french polynesia,p,tonnes,16,15,french oceania: makatea island,"fertilizers: phosphate, natural",unknown,1.0000,attributable,total general excluding the ussr/hempseed=0.06,no
+french polynesia,sugar raw centrifugal,tonnes,3,2,,,,,too_few_values,,no
+french polynesia,tobacco unmanufactured,ha,8,3,,,,,too_few_distinct,,no
+french polynesia,tobacco unmanufactured,tonnes,8,3,,,,,too_few_distinct,,no
+gabon,cacao beans,ha,6,5,,,,,too_few_values,,no
+gabon,cacao beans,tonnes,16,16,french equatorial africa: gabon,cacao: raw,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+gabon,coffee green,ha,4,3,,,,,too_few_values,,no
+gabon,coffee green,tonnes,12,11,french equatorial africa: gabon,coffee: raw,yes,1.0000,attributable,british fiji islands/tea=0.08,no
+gabon,groundnuts with shell,ha,3,2,,,,,too_few_values,,no
+gabon,groundnuts with shell,tonnes,3,3,,,,,too_few_values,,no
+gabon,sesame seed,ha,3,1,,,,,too_few_values,,no
+gabon,sesame seed,tonnes,3,1,,,,,too_few_values,,no
+gambia,groundnuts with shell,ha,7,7,,,,,too_few_values,,no
+gambia,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+germany,butter cow milk,tonnes,3,3,,,,,too_few_values,,no
+germany,cheese processed,tonnes,3,3,,,,,too_few_values,,no
+germany,eggs hen in shell,tonnes,4,2,,,,,too_few_values,,no
+germany,fertilizer mixed,tonnes,12,12,germany,fertilizers: copper(ii) sulfate,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+germany,grapes,tonnes,4,4,,,,,too_few_values,,no
+germany,k,tonnes,4,4,,,,,too_few_values,,no
+germany,milk whole fresh cow,tonnes,4,4,,,,,too_few_values,,no
+germany,n,tonnes,17,17,germany,fertilizers: calcium cyanamide,unknown,1.0000,attributable,usa and canada/fertilizers: calcium cyanamide=0.06,no
+germany,p,tonnes,17,11,germany,"fertilizers: phosphate, natural",unknown,0.6471,attributable,"french morocco/fertilizers: phosphate, natural=0.41",no
+germany,sugar raw centrifugal,tonnes,32,32,germany,sugar: beet,yes,1.0000,attributable,usa/rye=0.03,no
+germany,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+germany,wine,ha,15,12,germany,wine,yes,1.0000,attributable,usa/wine=0.13,no
+germany,wine,tonnes,28,28,,,,,unattributable,yugoslavia/wine=0.00,no
+germany,yarn of true hemp,ha,9,9,germany,hemp: fibre,yes,1.0000,attributable,italy/linseed=0.33,no
+germany,yarn of true hemp,tonnes,4,4,,,,,too_few_values,,no
+ghana,cacao beans,ha,16,9,,,,,unattributable,british gold coast/cacao: raw=0.50,no
+ghana,cotton lint,ha,13,8,german togoland,cotton,yes,1.0000,attributable,italy/flax=0.08,no
+ghana,cotton lint,tonnes,19,12,,,,,unattributable,british gold coast/cotton=0.53,no
+ghana,cotton seed,ha,3,3,,,,,too_few_values,,no
+ghana,cotton seed,tonnes,9,9,german togoland,cottonseed,yes,1.0000,attributable,romania/linseed=0.11,no
+ghana,groundnuts with shell,ha,9,7,german togoland,groundnut,yes,1.0000,attributable,yugoslavia/cottonseed=0.22,no
+ghana,groundnuts with shell,tonnes,12,11,german togoland,groundnut,yes,1.0000,attributable,italy/linseed=0.17,no
+ghana,rubber natural,ha,4,1,,,,,too_few_values,,no
+greece,cotton lint,ha,26,26,greece,cottonseed,yes,0.6923,attributable,czechoslovakia/rye=0.08,no
+greece,cotton seed,ha,18,18,greece,cottonseed,yes,1.0000,attributable,czechoslovakia/rye=0.11,no
+greece,cotton seed,tonnes,20,20,greece,cottonseed,yes,1.0000,attributable,french syria/oats=0.10,no
+greece,eggs hen in shell,tonnes,7,7,,,,,too_few_values,,no
+greece,fertilizer mixed,tonnes,2,2,,,,,too_few_values,,no
+greece,grapes,tonnes,10,7,,,,,unattributable,lithuania/sugar: beet=0.30,no
+greece,lemons and limes,tonnes,1,1,,,,,too_few_values,,no
+greece,other berries and fruits of the genus vaccinium n e c,tonnes,7,7,,,,,too_few_values,,no
+greece,other citrus fruit n e c,tonnes,10,7,greece,citrus fruits: cedrats,yes,1.0000,attributable,spanish spanish guinea/cacao: raw=0.30,no
+greece,p,tonnes,4,4,,,,,too_few_values,,no
+greece,raisins,ha,6,6,,,,,too_few_values,,no
+greece,raisins,tonnes,16,15,greece,raisins,yes,0.7500,attributable,yugoslavia/hemp: fibre=0.06,no
+greece,rye,ha,1,1,,,,,too_few_values,,no
+greece,silk worm cocoons reelable,tonnes,11,10,,,,,unattributable,greece/sericulture=0.27,no
+greece,wine,ha,14,13,greece,wine,yes,0.9286,attributable,total general excluding the ussr/hempseed=0.07,no
+greece,wine,tonnes,23,23,,,,,unattributable,lithuania/flax: fibre=0.04,no
+grenada,cacao beans,ha,7,2,,,,,too_few_values,,no
+grenada,cacao beans,tonnes,31,30,british grenada,cacao: raw,yes,1.0000,attributable,uruguay/beans: dried=0.06,no
+grenada,cotton lint,ha,18,9,british grenada,cottonseed,yes,0.6667,attributable,new zealand western samoa/cacao: raw=0.28,no
+grenada,cotton lint,tonnes,31,20,,,,,unattributable,british grenada/cotton=0.58,no
+grenada,cotton seed,ha,12,4,,,,,too_few_distinct,,no
+grenada,cotton seed,tonnes,18,10,british grenada,cottonseed,yes,1.0000,attributable,british saint lucia/cacao: raw=0.39,no
+grenada,lemons and limes,ha,4,2,,,,,too_few_values,,no
+guadeloupe,cacao beans,ha,22,6,french guadeloupe,cacao: raw,yes,1.0000,attributable,french tonkin/coffee: raw=0.32,no
+guadeloupe,cacao beans,tonnes,30,21,french guadeloupe,cacao: raw,yes,1.0000,attributable,british‑french cameroon/cottonseed=0.23,no
+guadeloupe,coffee green,ha,23,8,french guadeloupe,coffee: raw,yes,0.8261,attributable,czechoslovakia/hemp: fibre=0.30,no
+guadeloupe,coffee green,tonnes,30,25,french guadeloupe,coffee: raw,yes,0.6000,attributable,french guadeloupe and dependencies/coffee: raw=0.40,no
+guadeloupe,cotton lint,ha,14,8,,,,,unattributable,french guadeloupe/cottonseed=0.50,no
+guadeloupe,cotton lint,tonnes,12,8,,,,,unattributable,french guadeloupe/cotton=0.58,no
+guadeloupe,cotton seed,ha,10,4,,,,,too_few_distinct,,no
+guadeloupe,cotton seed,tonnes,15,9,,,,,unattributable,french guadeloupe and dependencies: marie‑galante/cottonseed=0.47,no
+guadeloupe,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+guatemala,butter cow milk,tonnes,6,3,,,,,too_few_values,,no
+guatemala,cacao beans,ha,15,9,guatemala,cacao: raw,yes,1.0000,attributable,french algeria/rye=0.47,no
+guatemala,cacao beans,tonnes,17,15,guatemala,cacao: raw,yes,1.0000,attributable,total/hops=0.18,no
+guatemala,cheese processed,tonnes,6,4,,,,,too_few_values,,no
+guatemala,coffee green,ha,3,3,,,,,too_few_values,,no
+guatemala,cotton lint,ha,15,10,guatemala,cottonseed,yes,0.9333,attributable,french morocco/tobacco=0.33,no
+guatemala,cotton lint,tonnes,4,2,,,,,too_few_values,,no
+guatemala,cotton seed,ha,15,11,guatemala,cottonseed,yes,1.0000,attributable,french morocco/tobacco=0.33,no
+guatemala,cotton seed,tonnes,13,12,guatemala,cottonseed,yes,1.0000,attributable,austria/hemp: fibre=0.31,no
+guatemala,eggs hen in shell,tonnes,5,5,,,,,too_few_values,,no
+guatemala,groundnuts with shell,ha,6,5,,,,,too_few_values,,no
+guatemala,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+guatemala,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+guatemala,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+guatemala,tobacco unmanufactured,ha,1,1,,,,,too_few_values,,no
+guatemala,tobacco unmanufactured,tonnes,7,7,,,,,too_few_values,,no
+guinea,coffee green,ha,6,3,,,,,too_few_values,,no
+guinea,coffee green,tonnes,7,5,,,,,too_few_values,,no
+guinea,cotton lint,ha,7,7,,,,,too_few_values,,no
+guinea,cotton lint,tonnes,7,7,,,,,too_few_values,,no
+guinea,cotton seed,ha,7,7,,,,,too_few_values,,no
+guinea,cotton seed,tonnes,7,7,,,,,too_few_values,,no
+guinea,groundnuts with shell,ha,10,9,french guinea,groundnut,yes,1.0000,attributable,yugoslavia/beans: dried=0.10,no
+guinea,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+guinea,sesame seed,ha,6,2,,,,,too_few_values,,no
+guinea,sesame seed,tonnes,16,13,french guinea,sesame,yes,1.0000,attributable,french guadeloupe/cacao: raw=0.19,no
+guinea,tobacco unmanufactured,ha,4,1,,,,,too_few_values,,no
+guinea,tobacco unmanufactured,tonnes,12,12,french guinea,tobacco,yes,1.0000,attributable,uruguay/beans: dried=0.17,no
+guinea-bissau,groundnuts with shell,ha,3,2,,,,,too_few_values,,no
+guinea-bissau,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+guyana,cacao beans,ha,24,20,british guiana,cacao: raw,yes,1.0000,attributable,french cambodia/groundnut=0.17,no
+guyana,cacao beans,tonnes,3,1,,,,,too_few_values,,no
+guyana,coffee green,ha,31,22,british guiana,coffee: raw,yes,1.0000,attributable,british dominica/citrus fruits: limes=0.29,no
+guyana,coffee green,tonnes,11,8,british guiana,coffee: raw,yes,1.0000,attributable,french annam/jute=0.36,no
+guyana,lemons and limes,ha,6,5,,,,,too_few_values,,no
+haiti,cacao beans,ha,6,1,,,,,too_few_values,,no
+haiti,cacao beans,tonnes,24,19,haiti,cacao: raw,yes,1.0000,attributable,belgian ruanda-urundi/groundnut=0.12,no
+haiti,castor beans seed,tonnes,4,4,,,,,too_few_values,,no
+haiti,coffee green,ha,1,1,,,,,too_few_values,,no
+haiti,coffee green,tonnes,2,2,,,,,too_few_values,,no
+haiti,cotton lint,ha,6,6,,,,,too_few_values,,no
+haiti,cotton seed,ha,6,6,,,,,too_few_values,,no
+haiti,cotton seed,tonnes,16,14,haiti,cottonseed,yes,1.0000,attributable,"french lebanon/citrus fruits: oranges, other=0.12",no
+haiti,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+honduras,coffee green,tonnes,2,2,,,,,too_few_values,,no
+honduras,tobacco unmanufactured,ha,1,1,,,,,too_few_values,,no
+hungary,butter cow milk,tonnes,4,4,,,,,too_few_values,,no
+hungary,cheese processed,tonnes,4,3,,,,,too_few_values,,no
+hungary,fertilizer mixed,tonnes,3,3,,,,,too_few_values,,no
+hungary,grapes,tonnes,6,6,,,,,too_few_values,,no
+hungary,hops,ha,4,4,,,,,too_few_values,,no
+hungary,hops,tonnes,1,1,,,,,too_few_values,,no
+hungary,milk whole fresh cow,tonnes,4,4,,,,,too_few_values,,no
+hungary,n,tonnes,4,4,,,,,too_few_values,,no
+hungary,p,tonnes,4,4,,,,,too_few_values,,no
+hungary,silk worm cocoons reelable,tonnes,21,20,hungary,sericulture,no,1.0000,attributable,french tunisia/wine=0.05,no
+hungary,sugar raw centrifugal,tonnes,29,29,hungary,sugar: beet,yes,1.0000,attributable,japan/rapeseed=0.03,no
+hungary,sunflower seed,tonnes,1,1,,,,,too_few_values,,no
+hungary,wine,ha,17,16,hungary,wine,yes,1.0000,attributable,usa: california/vineyards: all=0.06,no
+hungary,wine,tonnes,26,26,,,,,unattributable,yugoslavia/wine=0.00,no
+hungary,yarn of true hemp,ha,13,13,hungary,hemp: fibre,yes,1.0000,attributable,total/groundnut=0.23,no
+hungary,yarn of true hemp,tonnes,19,19,hungary,hemp: fibre,yes,1.0000,attributable,"ussr/citrus fruits: lemons, mandarins, oranges=0.05",no
+india,coffee green,ha,17,17,,,,,unattributable,british india/coffee: raw=0.18,no
+india,cotton lint,ha,25,22,,,,,unattributable,uruguay/rye=0.16,no
+india,cotton seed,ha,12,10,,,,,unattributable,uruguay/rye=0.17,no
+india,cotton seed,tonnes,13,13,,,,,unattributable,us philippines/cacao: raw=0.15,no
+india,eggs hen in shell,tonnes,7,5,,,,,too_few_values,,no
+india,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,no
+india,flax fibre and tow,ha,13,13,british india,flax,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+india,groundnuts with shell,ha,18,10,,,,,unattributable,french india/groundnut=0.56,no
+india,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+india,jute,ha,21,21,british india,jute,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+india,jute,tonnes,21,21,british india,jute,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+india,k,tonnes,4,4,,,,,too_few_values,,no
+india,linseed,ha,8,8,british india,linseed,yes,1.0000,attributable,[error] inde/linseed=0.12,no
+india,linseed,tonnes,1,1,,,,,too_few_values,,no
+india,n,tonnes,4,4,,,,,too_few_values,,no
+india,p,tonnes,4,4,,,,,too_few_values,,no
+india,rapeseed,ha,21,21,british india,rapeseed,yes,1.0000,attributable,[error] inde/rapeseed=0.05,no
+india,rapeseed,tonnes,20,20,british india,rapeseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+india,rubber natural,ha,4,4,,,,,too_few_values,,no
+india,sesame seed,ha,18,9,,,,,unattributable,new zealand/tobacco=0.56,no
+india,sesame seed,tonnes,18,10,,,,,unattributable,french india/sesame=0.56,no
+india,sugar raw centrifugal,tonnes,21,21,british india,sugar: cane,yes,0.6667,attributable,yugoslavia/wine=0.00,no
+india,tea,ha,19,19,,,,,unattributable,british india/tea=0.42,no
+india,tea,tonnes,20,20,british india,tea,yes,0.8500,attributable,yugoslavia/wine=0.00,no
+india,tobacco unmanufactured,ha,19,19,,,,,unattributable,british india/tobacco=0.21,no
+iran,castor beans seed,tonnes,4,4,,,,,too_few_values,,no
+iran,cotton lint,ha,13,10,iran,cottonseed,yes,1.0000,attributable,total/groundnut=0.31,no
+iran,cotton seed,ha,13,10,iran,cottonseed,yes,1.0000,attributable,total/groundnut=0.31,no
+iran,cotton seed,tonnes,17,17,iran,cottonseed,yes,1.0000,attributable,turkey/tobacco=0.06,no
+iran,grapes,tonnes,4,3,,,,,too_few_values,,no
+iran,jute,ha,4,2,,,,,too_few_values,,no
+iran,jute,tonnes,6,6,,,,,too_few_values,,no
+iran,oranges,tonnes,4,4,,,,,too_few_values,,no
+iran,raisins,tonnes,12,10,iran,raisins,yes,0.9167,attributable,yugoslavia/spelt=0.08,no
+iran,sesame seed,ha,4,3,,,,,too_few_values,,no
+iran,sesame seed,tonnes,6,6,,,,,too_few_values,,no
+iran,silk worm cocoons reelable,tonnes,8,8,iran,sericulture,no,1.0000,attributable,venezuela/cotton: ginned=0.12,no
+iran,sugar raw centrifugal,tonnes,12,12,iran,sugar: beet,yes,1.0000,attributable,uk: great britain/flax: fibre=0.17,no
+iran,tea,ha,6,5,,,,,too_few_values,,no
+iran,tea,tonnes,6,6,,,,,too_few_values,,no
+iran,tobacco unmanufactured,ha,14,8,iran,tobacco,yes,1.0000,attributable,total/tea=0.29,no
+iran,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+iran,wine,tonnes,1,1,,,,,too_few_values,,no
+iraq,beans dry,ha,1,1,,,,,too_few_values,,no
+iraq,beans dry,tonnes,5,4,,,,,too_few_values,,no
+iraq,cotton lint,ha,11,8,british iraq,cottonseed,yes,1.0000,attributable,"usa: california/vineyards: grapes, raisins=0.18",no
+iraq,cotton lint,tonnes,20,16,british iraq,cotton: ginned,yes,0.6000,attributable,british southern rhodesia/beans: dried=0.15,no
+iraq,cotton seed,ha,11,8,british iraq,cottonseed,yes,1.0000,attributable,"usa: california/vineyards: grapes, raisins=0.18",no
+iraq,cotton seed,tonnes,19,18,british iraq,cottonseed,yes,1.0000,attributable,nicaragua/cottonseed=0.16,no
+iraq,sesame seed,ha,9,7,british iraq,sesame,yes,1.0000,attributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.33",no
+iraq,sesame seed,tonnes,9,9,british iraq,sesame,yes,1.0000,attributable,total/cottonseed=0.22,no
+iraq,silk worm cocoons reelable,tonnes,3,3,,,,,too_few_values,,no
+iraq,tobacco unmanufactured,ha,8,7,british iraq,tobacco,yes,1.0000,attributable,total/tea=0.38,no
+iraq,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+ireland,butter cow milk,tonnes,7,6,,,,,too_few_values,,no
+ireland,eggs hen in shell,tonnes,15,14,ireland,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+ireland,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+ireland,n,tonnes,4,1,,,,,too_few_values,,no
+ireland,p,tonnes,4,4,,,,,too_few_values,,no
+ireland,rye,ha,3,2,,,,,too_few_values,,no
+ireland,rye,tonnes,2,2,,,,,too_few_values,,no
+ireland,sugar raw centrifugal,tonnes,16,16,ireland,sugar: beet,yes,1.0000,attributable,total/olive: oil=0.06,no
+ireland,tobacco unmanufactured,ha,6,1,,,,,too_few_values,,no
+israel,eggs hen in shell,tonnes,7,7,,,,,too_few_values,,no
+israel,grapefruit inc pomelos,tonnes,7,7,,,,,too_few_values,,no
+israel,grapes,ha,7,3,,,,,too_few_values,,no
+israel,grapes,tonnes,20,20,,,,,unattributable,british palestine/vineyards: all=0.35,no
+israel,lemons and limes,tonnes,9,9,british palestine,citrus fruits: lemons,yes,1.0000,attributable,us puerto rico/citrus fruits: oranges=0.22,no
+israel,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+israel,oats,ha,6,1,,,,,too_few_values,,no
+israel,oats,tonnes,7,5,,,,,too_few_values,,no
+israel,oil olive virgin,tonnes,17,16,british palestine,olive: oil,yes,1.0000,attributable,canada/flax: fibre=0.12,no
+israel,olives,ha,11,9,british palestine,olive grove,yes,1.0000,attributable,uruguay/sunflower=0.18,no
+israel,olives,tonnes,20,20,british palestine,olive grove,yes,1.0000,attributable,usa/olive grove=0.05,no
+israel,oranges,ha,5,4,,,,,too_few_values,,no
+israel,oranges,tonnes,9,9,british palestine,citrus fruits: oranges,yes,1.0000,attributable,romania/cotton: ginned=0.11,no
+israel,raisins,tonnes,1,1,,,,,too_few_values,,no
+israel,sesame seed,ha,11,9,british palestine,sesame,yes,1.0000,attributable,total/flax: fibre=0.18,no
+israel,sesame seed,tonnes,20,20,british palestine,sesame,yes,1.0000,attributable,germany/beans: dried=0.10,no
+israel,tobacco unmanufactured,ha,19,12,british palestine,tobacco,yes,1.0000,attributable,mexico/vineyards: all=0.32,no
+israel,tobacco unmanufactured,tonnes,19,19,british palestine,tobacco,yes,1.0000,attributable,turkey/meslin=0.05,no
+israel,wine,ha,4,2,,,,,too_few_values,,no
+israel,wine,tonnes,18,16,,,,,unattributable,yugoslavia/wine=0.00,no
+italy,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+italy,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+italy,cotton lint,ha,20,16,italy,cottonseed,yes,1.0000,attributable,yugoslavia/rye=0.10,no
+italy,cotton seed,ha,20,16,italy,cottonseed,yes,1.0000,attributable,yugoslavia/rye=0.10,no
+italy,cotton seed,tonnes,19,17,italy,cottonseed,yes,1.0000,attributable,egypt/linseed=0.11,no
+italy,eggs hen in shell,tonnes,7,7,,,,,too_few_values,,no
+italy,fertilizer mixed,tonnes,17,17,italy,sulphur,no,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,lemons and limes,ha,2,2,,,,,too_few_values,,no
+italy,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+italy,n,tonnes,16,16,italy,fertilizers: calcium cyanamide,unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,olives,ha,1,1,,,,,too_few_values,,no
+italy,oranges,ha,2,2,,,,,too_few_values,,no
+italy,other berries and fruits of the genus vaccinium n e c,tonnes,20,20,italy,blackberries,no,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,other citrus fruit n e c,ha,4,1,,,,,too_few_values,,no
+italy,other citrus fruit n e c,tonnes,8,8,italy,citrus fruits: other,yes,0.6250,attributable,"union of south africa/vineyards: grapes, raisins=0.12",no
+italy,other sugar crops n e c,ha,7,1,,,,,too_few_values,,no
+italy,other sugar crops n e c,tonnes,7,7,,,,,too_few_values,,no
+italy,p,tonnes,16,16,italy,fertilizers: calcium superphosphate,unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,sesame seed,tonnes,1,1,,,,,too_few_values,,no
+italy,silk worm cocoons reelable,tonnes,33,33,italy,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,sugar raw centrifugal,tonnes,33,33,italy,sugar: beet,yes,1.0000,attributable,uruguay/beans: dried=0.03,no
+italy,wine,ha,11,11,italy,wine,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+italy,wine,tonnes,33,33,,,,,unattributable,yugoslavia/wine=0.00,no
+italy,yarn of true hemp,ha,13,13,italy,hemp: fibre,yes,1.0000,attributable,turkey/beans: dried=0.08,no
+italy,yarn of true hemp,tonnes,26,26,italy,hemp: fibre,yes,1.0000,attributable,denmark/fertilizers: calcium superphosphate=0.04,no
+ivory coast,beans dry,ha,2,1,,,,,too_few_values,,no
+ivory coast,cacao beans,ha,14,12,french ivory coast,cacao: raw,yes,1.0000,attributable,total/tobacco=0.07,no
+ivory coast,coffee green,ha,14,13,french ivory coast,coffee: raw,yes,1.0000,attributable,total/hops=0.14,no
+ivory coast,cotton lint,ha,3,3,,,,,too_few_values,,no
+ivory coast,cotton lint,tonnes,3,3,,,,,too_few_values,,no
+ivory coast,cotton seed,ha,3,3,,,,,too_few_values,,no
+ivory coast,cotton seed,tonnes,3,3,,,,,too_few_values,,no
+ivory coast,eggs hen in shell,tonnes,4,4,,,,,too_few_values,,no
+ivory coast,groundnuts with shell,ha,14,11,french ivory coast,groundnut,yes,1.0000,attributable,usa/olive grove=0.14,no
+ivory coast,groundnuts with shell,tonnes,12,9,french ivory coast,groundnut,yes,1.0000,attributable,italy/citrus fruits: other=0.25,no
+ivory coast,sesame seed,ha,6,6,,,,,too_few_values,,no
+ivory coast,sesame seed,tonnes,4,4,,,,,too_few_values,,no
+ivory coast,tobacco unmanufactured,ha,11,5,,,,,too_few_distinct,,no
+ivory coast,tobacco unmanufactured,tonnes,11,7,french ivory coast,tobacco,yes,1.0000,attributable,spain/hemp: fibre=0.27,no
+jamaica,cacao beans,ha,20,20,british jamaica,cacao: raw,yes,1.0000,attributable,total/tea=0.05,no
+jamaica,cacao beans,tonnes,29,25,british jamaica,cacao: raw,yes,1.0000,attributable,guatemala/cottonseed=0.10,no
+jamaica,coffee green,ha,20,20,british jamaica,coffee: raw,yes,1.0000,attributable,usa/flax: fibre=0.05,no
+jamaica,coffee green,tonnes,28,27,british jamaica,coffee: raw,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.07",no
+jamaica,cotton lint,ha,20,17,british jamaica,cotton,yes,0.6500,attributable,netherlands/beans: dried=0.10,no
+jamaica,cotton lint,tonnes,14,13,,,,,unattributable,british jamaica/cotton=0.50,no
+jamaica,cotton seed,ha,7,5,,,,,too_few_values,,no
+jamaica,cotton seed,tonnes,7,6,,,,,too_few_values,,no
+jamaica,grapefruit inc pomelos,ha,2,2,,,,,too_few_values,,no
+jamaica,grapefruit inc pomelos,tonnes,14,13,british jamaica,citrus fruits: grapefruits,yes,1.0000,attributable,british saint vincent/groundnut=0.21,no
+jamaica,lemons and limes,tonnes,4,2,,,,,too_few_values,,no
+jamaica,oranges,ha,2,2,,,,,too_few_values,,no
+jamaica,oranges,tonnes,14,14,british jamaica,citrus fruits: oranges,yes,1.0000,attributable,union of south africa/cottonseed=0.14,no
+jamaica,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+jamaica,tobacco unmanufactured,ha,13,13,british jamaica,tobacco,yes,1.0000,attributable,french algeria/flax=0.15,no
+jamaica,tobacco unmanufactured,tonnes,3,3,,,,,too_few_values,,no
+japan,beans dry,ha,5,5,,,,,too_few_values,,no
+japan,beans dry,tonnes,5,5,,,,,too_few_values,,no
+japan,cotton lint,ha,22,20,japan,cotton,yes,0.8636,attributable,yugoslavia/soybean=0.14,no
+japan,cotton lint,tonnes,23,21,japan,cotton,yes,0.8261,attributable,japanese taiwan/rapeseed=0.13,no
+japan,cotton seed,ha,11,8,japan,cottonseed,yes,1.0000,attributable,yugoslavia/sesame=0.36,no
+japan,cotton seed,tonnes,10,9,japan,cottonseed,yes,1.0000,attributable,french cambodia/cotton: ginned=0.30,no
+japan,eggs hen in shell,tonnes,11,11,japan,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,fertilizer mixed,tonnes,16,16,japan,sulphur,no,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,flax fibre and tow,ha,23,21,,,,,unattributable,japan/linseed=0.52,no
+japan,flax fibre and tow,tonnes,24,24,japan,flax: fibre,yes,0.8333,attributable,czechoslovakia/hempseed=0.08,no
+japan,grapes,ha,6,3,,,,,too_few_values,,no
+japan,grapes,tonnes,22,22,,,,,unattributable,japan/vineyards: grapes=0.50,no
+japan,groundnuts with shell,ha,11,8,japan,groundnut,yes,1.0000,attributable,mexico/cacao: raw=0.36,no
+japan,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+japan,hemp tow waste,ha,12,12,japan,hemp,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,jute,ha,16,13,japan,jute,yes,1.0000,attributable,yugoslavia/sesame=0.25,no
+japan,jute,tonnes,16,14,japan,jute,yes,1.0000,attributable,japanese taiwan/sulphur=0.19,no
+japan,k,tonnes,3,3,,,,,too_few_values,,no
+japan,lemons and limes,ha,3,1,,,,,too_few_values,,no
+japan,lemons and limes,tonnes,4,3,,,,,too_few_values,,no
+japan,linseed,ha,8,8,japan,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,linseed,tonnes,18,18,japan,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,n,tonnes,16,15,japan,fertilizers: calcium cyanamide,unknown,0.8750,attributable,usa and canada/fertilizers: calcium cyanamide=0.12,no
+japan,oranges,ha,7,5,,,,,too_few_values,,no
+japan,oranges,tonnes,7,7,,,,,too_few_values,,no
+japan,other berries and fruits of the genus vaccinium n e c,ha,11,11,japan,blackberries,no,1.0000,attributable,total/flax: fibre=0.09,no
+japan,other sugar crops n e c,ha,3,2,,,,,too_few_values,,no
+japan,other sugar crops n e c,tonnes,3,3,,,,,too_few_values,,no
+japan,p,tonnes,16,16,japan,"fertilizers: phosphate, natural",unknown,0.8750,attributable,british saint vincent/cacao: raw=0.06,no
+japan,rapeseed,ha,25,24,japan,rapeseed,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.04",no
+japan,rapeseed,tonnes,30,30,japan,rapeseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,sesame seed,ha,11,8,japan,sesame,yes,1.0000,attributable,french cambodia/cottonseed=0.36,no
+japan,sesame seed,tonnes,14,13,japan,sesame,yes,1.0000,attributable,france/hemp: fibre=0.14,no
+japan,silk worm cocoons reelable,tonnes,32,32,,,,,unattributable,japan/sericulture: spring cocoons=0.53,no
+japan,soybeans,ha,9,9,japan,soybean,yes,1.0000,attributable,total south hemisphere aggregated/wine=0.11,no
+japan,soybeans,tonnes,13,13,japan,soybean,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+japan,sugar raw centrifugal,tonnes,26,26,japan,sugar: cane,yes,0.7692,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.04",no
+japan,tangerines mandarins clementines satsumas,ha,7,7,,,,,too_few_values,,no
+japan,tangerines mandarins clementines satsumas,tonnes,7,7,,,,,too_few_values,,no
+japan,tea,ha,26,22,japan,tea,yes,1.0000,attributable,uk: england and wales/spelt=0.08,no
+japan,tobacco unmanufactured,ha,27,24,japan,tobacco,yes,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.07",no
+japan,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+japan,wine,tonnes,5,5,,,,,too_few_values,,no
+japan,yarn of true hemp,ha,12,9,japan,hemp: fibre,yes,1.0000,attributable,us philippines/groundnut=0.33,no
+japan,yarn of true hemp,tonnes,22,21,japan,hemp: fibre,yes,1.0000,attributable,us virgin islands/sugar: cane=0.05,no
+jordan,eggs hen in shell,tonnes,8,7,british transjordan,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+jordan,grapes,ha,1,1,,,,,too_few_values,,no
+jordan,grapes,tonnes,4,4,,,,,too_few_values,,no
+jordan,oil olive virgin,tonnes,1,1,,,,,too_few_values,,no
+jordan,olives,tonnes,1,1,,,,,too_few_values,,no
+jordan,raisins,tonnes,3,2,,,,,too_few_values,,no
+jordan,sesame seed,tonnes,8,6,,,,,ambiguous,british transjordan/sesame=1.00;british antigua/cottonseed=0.62,no
+jordan,tobacco unmanufactured,ha,1,1,,,,,too_few_values,,no
+jordan,tobacco unmanufactured,tonnes,10,10,british transjordan,tobacco,yes,1.0000,attributable,usa: hawaii/coffee: raw=0.10,no
+kenya,beans dry,ha,9,3,,,,,too_few_distinct,,no
+kenya,beans dry,tonnes,2,1,,,,,too_few_values,,no
+kenya,coffee green,ha,15,14,british kenya,coffee: raw,yes,1.0000,attributable,british burma/tobacco=0.13,no
+kenya,cotton lint,tonnes,16,15,british kenya,cotton: ginned,yes,0.6875,attributable,switzerland/tobacco=0.12,no
+kenya,cotton seed,tonnes,17,17,british kenya,cottonseed,yes,1.0000,attributable,nepal/jute=0.12,no
+kenya,eggs hen in shell,tonnes,5,3,,,,,too_few_values,,no
+kenya,flax fibre and tow,ha,7,6,,,,,too_few_values,,no
+kenya,flax fibre and tow,tonnes,7,7,,,,,too_few_values,,no
+kenya,groundnuts with shell,tonnes,17,17,british kenya,groundnut,yes,1.0000,attributable,guatemala/groundnut=0.12,no
+kenya,linseed,ha,3,3,,,,,too_few_values,,no
+kenya,linseed,tonnes,4,4,,,,,too_few_values,,no
+kenya,oats,ha,4,2,,,,,too_few_values,,no
+kenya,oats,tonnes,3,3,,,,,too_few_values,,no
+kenya,sesame seed,tonnes,16,16,british kenya,sesame,yes,1.0000,attributable,french annam/sesame=0.12,no
+kenya,sugar raw centrifugal,tonnes,8,8,british kenya,sugar: cane,yes,1.0000,attributable,ussr/sesame=0.12,no
+kenya,tea,ha,15,8,british kenya,tea,yes,1.0000,attributable,french cambodia/cottonseed=0.33,no
+kenya,tea,tonnes,5,5,,,,,too_few_values,,no
+kiribati,p,tonnes,4,4,,,,,too_few_values,,no
+latvia,butter cow milk,tonnes,1,1,,,,,too_few_values,,no
+latvia,cheese processed,tonnes,1,1,,,,,too_few_values,,no
+latvia,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+latvia,p,tonnes,4,4,,,,,too_few_values,,no
+latvia,sugar raw centrifugal,tonnes,16,11,latvia,sugar: beet,yes,1.0000,attributable,lithuania/sugar: beet=0.38,no
+latvia,yarn of true hemp,ha,1,1,,,,,too_few_values,,no
+latvia,yarn of true hemp,tonnes,1,1,,,,,too_few_values,,no
+lebanon,beans dry,ha,4,3,,,,,too_few_values,,no
+lebanon,beans dry,tonnes,4,4,,,,,too_few_values,,no
+lebanon,butter cow milk,tonnes,5,1,,,,,too_few_values,,no
+lebanon,cheese processed,tonnes,5,2,,,,,too_few_values,,no
+lebanon,eggs hen in shell,tonnes,3,3,,,,,too_few_values,,no
+lebanon,grapes,ha,6,3,,,,,too_few_values,,no
+lebanon,grapes,tonnes,6,5,,,,,too_few_values,,no
+lebanon,groundnuts with shell,ha,1,1,,,,,too_few_values,,no
+lebanon,groundnuts with shell,tonnes,3,3,,,,,too_few_values,,no
+lebanon,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+lebanon,oats,ha,4,1,,,,,too_few_values,,no
+lebanon,oats,tonnes,6,5,,,,,too_few_values,,no
+lebanon,oil olive virgin,tonnes,4,4,,,,,too_few_values,,no
+lebanon,olives,ha,4,2,,,,,too_few_values,,no
+lebanon,olives,tonnes,6,6,,,,,too_few_values,,no
+lebanon,oranges,ha,5,2,,,,,too_few_values,,no
+lebanon,oranges,tonnes,5,5,,,,,too_few_values,,no
+lebanon,other berries and fruits of the genus vaccinium n e c,ha,3,2,,,,,too_few_values,,no
+lebanon,other berries and fruits of the genus vaccinium n e c,tonnes,3,3,,,,,too_few_values,,no
+lebanon,sesame seed,ha,2,2,,,,,too_few_values,,no
+lebanon,sesame seed,tonnes,4,4,,,,,too_few_values,,no
+lebanon,silk worm cocoons reelable,tonnes,6,5,,,,,too_few_values,,no
+lebanon,tobacco unmanufactured,ha,6,1,,,,,too_few_values,,no
+lebanon,tobacco unmanufactured,tonnes,7,7,,,,,too_few_values,,no
+lebanon,wine,ha,4,2,,,,,too_few_values,,no
+lebanon,wine,tonnes,8,8,,,,,unattributable,yugoslavia/wine=0.00,no
+liberia,coffee green,tonnes,2,2,,,,,too_few_values,,no
+liberia,rubber natural,ha,7,6,,,,,too_few_values,,no
+libya,grapes,ha,8,7,,,,,unattributable,italian libya/vineyards: all=0.50,no
+libya,grapes,tonnes,6,6,,,,,too_few_values,,no
+libya,oil olive virgin,tonnes,18,16,italian libya,olive: oil,yes,0.6111,attributable,nicaragua/cottonseed=0.22,no
+libya,olives,ha,8,8,,,,,unattributable,italian libya/olive grove=0.50,no
+libya,olives,tonnes,10,10,,,,,unattributable,italian libya/olive grove=0.40,no
+libya,other berries and fruits of the genus vaccinium n e c,ha,6,5,,,,,too_few_values,,no
+libya,other berries and fruits of the genus vaccinium n e c,tonnes,4,2,,,,,too_few_values,,no
+libya,silk worm cocoons reelable,tonnes,5,5,,,,,too_few_values,,no
+libya,tobacco unmanufactured,ha,7,4,,,,,too_few_values,,no
+libya,tobacco unmanufactured,tonnes,6,6,,,,,too_few_values,,no
+libya,wine,ha,6,6,,,,,too_few_values,,no
+libya,wine,tonnes,7,7,,,,,too_few_values,,no
+lithuania,butter cow milk,tonnes,1,1,,,,,too_few_values,,no
+lithuania,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+lithuania,p,tonnes,4,4,,,,,too_few_values,,no
+lithuania,sugar raw centrifugal,tonnes,15,10,lithuania,sugar: beet,yes,1.0000,attributable,latvia/sugar: beet=0.40,no
+luxembourg,eggs hen in shell,tonnes,4,4,,,,,too_few_values,,no
+luxembourg,flax fibre and tow,ha,7,6,,,,,too_few_values,,no
+luxembourg,flax fibre and tow,tonnes,2,2,,,,,too_few_values,,no
+luxembourg,hemp tow waste,ha,5,4,,,,,too_few_values,,no
+luxembourg,p,tonnes,12,12,luxembourg,slag: dephosphorization,unknown,0.6667,attributable,"british nauru/fertilizers: phosphate, natural=0.08",no
+luxembourg,rye,ha,6,4,,,,,too_few_values,,no
+luxembourg,rye,tonnes,5,4,,,,,too_few_values,,no
+luxembourg,wine,ha,9,9,luxembourg,wine,yes,1.0000,attributable,usa/hemp: fibre=0.11,no
+luxembourg,wine,tonnes,32,32,,,,,unattributable,yugoslavia/wine=0.00,no
+madagascar,beans dry,ha,12,10,french madagascar,beans: dried,unknown,1.0000,attributable,"usa: california/vineyards: grapes, raisins=0.25",no
+madagascar,beans dry,tonnes,12,11,french madagascar,beans: dried,unknown,1.0000,attributable,yugoslavia/fertilizers: calcium superphosphate=0.08,no
+madagascar,cacao beans,ha,9,4,,,,,too_few_distinct,,no
+madagascar,cacao beans,tonnes,15,5,,,,,too_few_distinct,,no
+madagascar,castor beans seed,ha,7,4,,,,,too_few_values,,no
+madagascar,castor beans seed,tonnes,7,7,,,,,too_few_values,,no
+madagascar,coffee green,ha,25,20,french madagascar,coffee: raw,yes,1.0000,attributable,"usa: california/vineyards: grapes, raisins=0.04",no
+madagascar,cotton lint,ha,6,5,,,,,too_few_values,,no
+madagascar,cotton lint,tonnes,4,3,,,,,too_few_values,,no
+madagascar,cotton seed,ha,6,5,,,,,too_few_values,,no
+madagascar,cotton seed,tonnes,4,4,,,,,too_few_values,,no
+madagascar,eggs hen in shell,tonnes,9,6,,,,,unattributable,yugoslavia/wine=0.00,no
+madagascar,grapes,ha,6,4,,,,,too_few_values,,no
+madagascar,grapes,tonnes,2,2,,,,,too_few_values,,no
+madagascar,groundnuts with shell,ha,16,12,french madagascar,groundnut,yes,1.0000,attributable,hungary/flax: fibre=0.31,no
+madagascar,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+madagascar,p,tonnes,4,4,,,,,too_few_values,,no
+madagascar,silk worm cocoons reelable,tonnes,4,4,,,,,too_few_values,,no
+madagascar,sugar raw centrifugal,tonnes,18,15,french madagascar,sugar: cane,yes,0.8889,attributable,germany/hemp: fibre=0.17,no
+madagascar,tobacco unmanufactured,ha,23,16,french madagascar,tobacco,yes,1.0000,attributable,norway/rye=0.26,no
+madagascar,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+madagascar,wine,ha,6,2,,,,,too_few_values,,no
+madagascar,wine,tonnes,12,4,,,,,too_few_distinct,,no
+malawi,coffee green,ha,25,21,british nyasaland,coffee: raw,yes,1.0000,attributable,sweden/tobacco=0.20,no
+malawi,coffee green,tonnes,22,20,british nyasaland,coffee: raw,yes,1.0000,attributable,sweden/flax: fibre=0.18,no
+malawi,cotton lint,ha,30,27,british nyasaland,cotton,yes,0.6333,attributable,romania/cottonseed=0.13,no
+malawi,cotton lint,tonnes,30,26,british nyasaland,cotton,yes,0.6333,attributable,austria/hemp: fibre=0.17,no
+malawi,cotton seed,ha,19,16,british nyasaland,cottonseed,yes,1.0000,attributable,romania/cottonseed=0.21,no
+malawi,cotton seed,tonnes,19,17,british nyasaland,cottonseed,yes,1.0000,attributable,british cyprus/flax: fibre=0.16,no
+malawi,groundnuts with shell,ha,13,8,british nyasaland,groundnut,yes,1.0000,attributable,french cochinchina/coffee: raw=0.46,no
+malawi,groundnuts with shell,tonnes,13,10,british nyasaland,groundnut,yes,1.0000,attributable,uruguay/rye=0.31,no
+malawi,rubber natural,ha,13,2,,,,,too_few_distinct,,no
+malawi,tea,ha,32,24,british nyasaland,tea,yes,1.0000,attributable,french madagascar/groundnut=0.22,no
+malawi,tea,tonnes,3,3,,,,,too_few_values,,no
+malawi,tobacco unmanufactured,ha,30,22,british nyasaland,tobacco,yes,1.0000,attributable,french cochinchina/tobacco=0.27,no
+malawi,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+mali,cotton lint,ha,5,5,,,,,too_few_values,,no
+mali,cotton lint,tonnes,6,6,,,,,too_few_values,,no
+mali,cotton seed,ha,5,5,,,,,too_few_values,,no
+mali,cotton seed,tonnes,5,5,,,,,too_few_values,,no
+mali,groundnuts with shell,ha,8,8,french sudan,groundnut,yes,1.0000,attributable,"turkey/vineyards: grapes, raisins=0.12",no
+mali,tobacco unmanufactured,ha,9,7,french sudan,tobacco,yes,0.8889,attributable,yugoslavia/soybean=0.22,no
+mali,tobacco unmanufactured,tonnes,9,8,french sudan,tobacco,yes,0.8889,attributable,turkey/sericulture=0.11,no
+malta,cotton lint,ha,26,22,british malta,cotton,yes,0.8077,attributable,british barbados/cottonseed=0.23,no
+malta,cotton lint,tonnes,8,4,,,,,too_few_distinct,,no
+malta,cotton seed,ha,13,9,british malta,cottonseed,yes,1.0000,attributable,british barbados/cottonseed=0.46,no
+malta,cotton seed,tonnes,13,9,british malta,cottonseed,yes,1.0000,attributable,sweden/tobacco=0.46,no
+malta,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+malta,oranges,ha,4,2,,,,,too_few_values,,no
+malta,oranges,tonnes,10,6,british malta,"citrus fruits: lemons, mandarins, oranges",yes,0.6000,attributable,france/hops=0.50,no
+malta,wine,ha,15,8,british malta,wine,yes,1.0000,attributable,switzerland/tobacco=0.47,no
+malta,wine,tonnes,19,18,,,,,unattributable,yugoslavia/wine=0.00,no
+martinique,cacao beans,ha,7,3,,,,,too_few_values,,no
+martinique,cacao beans,tonnes,29,21,french martinique,cacao: raw,yes,1.0000,attributable,portugal/citrus fruits: oranges=0.24,no
+martinique,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+mauritania,beans dry,ha,11,7,french mauritania,beans: dried,unknown,1.0000,attributable,total/tea=0.36,no
+mauritania,beans dry,tonnes,11,9,french mauritania,beans: dried,unknown,1.0000,attributable,usa: hawaii/coffee: raw=0.27,no
+mauritania,cotton lint,ha,3,3,,,,,too_few_values,,no
+mauritania,cotton lint,tonnes,3,3,,,,,too_few_values,,no
+mauritania,cotton seed,ha,3,3,,,,,too_few_values,,no
+mauritania,cotton seed,tonnes,3,3,,,,,too_few_values,,no
+mauritania,groundnuts with shell,ha,18,8,french mauritania,groundnut,yes,1.0000,attributable,french guadeloupe/cacao: raw=0.39,no
+mauritania,groundnuts with shell,tonnes,19,16,french mauritania,groundnut,yes,1.0000,attributable,french annam/cotton: ginned=0.16,no
+mauritania,tobacco unmanufactured,ha,9,6,french mauritania,tobacco,yes,1.0000,attributable,sweden/linseed=0.44,no
+mauritania,tobacco unmanufactured,tonnes,14,12,french mauritania,tobacco,yes,1.0000,attributable,french annam/jute=0.29,no
+mauritius,coffee green,ha,10,7,british mauritius,coffee: raw,yes,1.0000,attributable,netherlands/hops=0.10,no
+mauritius,coffee green,tonnes,6,6,,,,,too_few_values,,no
+mauritius,groundnuts with shell,ha,11,4,,,,,too_few_distinct,,no
+mauritius,groundnuts with shell,tonnes,18,5,,,,,too_few_distinct,,no
+mauritius,sugar raw centrifugal,tonnes,33,33,british mauritius,sugar: cane,yes,0.8788,attributable,bulgaria/sunflower=0.03,no
+mauritius,tea,ha,28,11,british mauritius,tea,yes,1.0000,attributable,french morocco/tobacco=0.25,no
+mauritius,tea,tonnes,27,19,british mauritius,tea,yes,1.0000,attributable,british sierra leone/cacao: raw=0.04,no
+mauritius,tobacco unmanufactured,ha,16,11,british mauritius,tobacco,yes,1.0000,attributable,uruguay/rye=0.25,no
+mauritius,tobacco unmanufactured,tonnes,20,18,british mauritius,tobacco,yes,1.0000,attributable,french tunisia/citrus fruits: lemons=0.10,no
+mexico,cacao beans,ha,14,10,mexico,cacao: raw,yes,1.0000,attributable,luxembourg/rye=0.29,no
+mexico,castor beans seed,tonnes,6,6,,,,,too_few_values,,no
+mexico,coffee green,ha,3,2,,,,,too_few_values,,no
+mexico,cotton lint,ha,12,12,mexico,cotton,yes,0.9167,attributable,netherlands/fertilizers: calcium superphosphate=0.08,no
+mexico,cotton seed,ha,19,18,mexico,cottonseed,yes,1.0000,attributable,finland/rye=0.05,no
+mexico,cotton seed,tonnes,4,4,,,,,too_few_values,,no
+mexico,flax fibre and tow,ha,9,7,mexico,linseed,no,1.0000,attributable,spain/hempseed=0.33,no
+mexico,flax fibre and tow,tonnes,11,10,mexico,linseed,no,1.0000,attributable,italy/flax: fibre=0.18,no
+mexico,lemons and limes,tonnes,1,1,,,,,too_few_values,,no
+mexico,oranges,tonnes,1,1,,,,,too_few_values,,no
+mexico,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+mexico,wine,tonnes,6,5,,,,,too_few_values,,no
+micronesia (federated states of),eggs hen in shell,tonnes,6,2,,,,,too_few_values,,no
+micronesia (federated states of),sugar raw centrifugal,tonnes,6,6,,,,,too_few_values,,no
+micronesia (federated states of),tobacco unmanufactured,ha,5,1,,,,,too_few_values,,no
+micronesia (federated states of),tobacco unmanufactured,tonnes,5,5,,,,,too_few_values,,no
+montserrat,cotton lint,ha,33,22,british montserrat,cotton,yes,0.6364,attributable,usa: hawaii/coffee: raw=0.21,no
+montserrat,cotton lint,tonnes,33,25,british montserrat,cotton,yes,0.6364,attributable,french madagascar/cacao: raw=0.15,no
+montserrat,cotton seed,ha,20,10,british montserrat,cottonseed,yes,1.0000,attributable,usa: hawaii/coffee: raw=0.35,no
+montserrat,cotton seed,tonnes,20,12,british montserrat,cottonseed,yes,1.0000,attributable,total/hops=0.15,no
+montserrat,lemons and limes,ha,6,5,,,,,too_few_values,,no
+montserrat,lemons and limes,tonnes,15,8,british montserrat,citrus fruits: limes,yes,1.0000,attributable,french tonkin/coffee: raw=0.20,no
+montserrat,sugar raw centrifugal,tonnes,14,5,,,,,too_few_distinct,,no
+morocco,beans dry,ha,6,1,,,,,too_few_values,,no
+morocco,beans dry,tonnes,12,8,french morocco,beans: dried,unknown,1.0000,attributable,french india/sesame=0.33,no
+morocco,cotton lint,ha,10,6,french morocco,cottonseed,yes,1.0000,attributable,usa: hawaii/coffee: raw=0.40,no
+morocco,cotton lint,tonnes,9,7,french morocco,cotton: ginned,yes,0.8889,attributable,austria/hemp: fibre=0.44,no
+morocco,cotton seed,ha,12,7,french morocco,cottonseed,yes,1.0000,attributable,french niger/sesame=0.42,no
+morocco,cotton seed,tonnes,10,7,french morocco,cottonseed,yes,1.0000,attributable,new zealand/rye=0.30,no
+morocco,eggs hen in shell,tonnes,7,4,,,,,too_few_values,,no
+morocco,flax fibre and tow,ha,19,17,french morocco,linseed,no,0.6316,attributable,turkey/linseed=0.11,no
+morocco,flax fibre and tow,tonnes,12,12,french morocco,linseed,no,1.0000,attributable,usa/olive grove=0.08,no
+morocco,grapes,ha,13,12,,,,,unattributable,french morocco/vineyards: all=0.38,no
+morocco,grapes,tonnes,8,8,french morocco,vineyards: all,no,0.6250,attributable,total/beans: dried=0.12,no
+morocco,hempseed,ha,3,3,,,,,too_few_values,,no
+morocco,lemons and limes,tonnes,1,1,,,,,too_few_values,,no
+morocco,linseed,ha,7,7,,,,,too_few_values,,no
+morocco,linseed,tonnes,14,14,french morocco,linseed,yes,1.0000,attributable,paraguay/cottonseed=0.07,no
+morocco,oats,ha,7,6,,,,,too_few_values,,no
+morocco,oats,tonnes,7,7,,,,,too_few_values,,no
+morocco,oil olive virgin,tonnes,1,1,,,,,too_few_values,,no
+morocco,olives,tonnes,12,12,french morocco,olive grove,yes,1.0000,attributable,usa/hops=0.08,no
+morocco,p,tonnes,17,6,french morocco,"fertilizers: phosphate, natural",unknown,1.0000,attributable,"france/fertilizers: potassium oxide, pure=0.59",no
+morocco,raisins,ha,1,1,,,,,too_few_values,,no
+morocco,raisins,tonnes,5,5,,,,,too_few_values,,no
+morocco,rye,ha,9,8,french morocco,rye,yes,1.0000,attributable,bulgaria/linseed=0.56,no
+morocco,rye,tonnes,9,8,french morocco,rye,yes,1.0000,attributable,french annam/cotton: ginned=0.22,no
+morocco,sesame seed,ha,1,1,,,,,too_few_values,,no
+morocco,sesame seed,tonnes,1,1,,,,,too_few_values,,no
+morocco,silk worm cocoons reelable,tonnes,4,4,,,,,too_few_values,,no
+morocco,sunflower seed,ha,2,2,,,,,too_few_values,,no
+morocco,sunflower seed,tonnes,2,2,,,,,too_few_values,,no
+morocco,tobacco unmanufactured,ha,14,6,,,,,ambiguous,french morocco/tobacco=1.00;french cochinchina/coffee: raw=0.64;austria/hemp: fibre=0.64,no
+morocco,tobacco unmanufactured,tonnes,14,14,french morocco,tobacco,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+morocco,wine,ha,12,12,french morocco,wine,yes,1.0000,attributable,french equatorial africa/cacao: raw=0.17,no
+morocco,yarn of true hemp,ha,6,6,,,,,too_few_values,,no
+morocco,yarn of true hemp,tonnes,3,3,,,,,too_few_values,,no
+mozambique,beans dry,ha,1,1,,,,,too_few_values,,no
+mozambique,beans dry,tonnes,1,1,,,,,too_few_values,,no
+mozambique,cotton lint,ha,11,9,,,,,unattributable,portuguese mozambique: company concession/cotton: ginned=0.36,no
+mozambique,cotton lint,tonnes,10,8,,,,,unattributable,portuguese mozambique: company concession/cotton: ginned=0.40,no
+mozambique,cotton seed,ha,6,6,,,,,too_few_values,,no
+mozambique,cotton seed,tonnes,6,6,,,,,too_few_values,,no
+mozambique,eggs hen in shell,tonnes,7,4,,,,,too_few_values,,no
+mozambique,groundnuts with shell,ha,3,3,,,,,too_few_values,,no
+mozambique,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+mozambique,sugar raw centrifugal,tonnes,7,7,,,,,too_few_values,,no
+mozambique,tea,ha,5,2,,,,,too_few_values,,no
+mozambique,tea,tonnes,5,3,,,,,too_few_values,,no
+mozambique,tobacco unmanufactured,ha,4,3,,,,,too_few_values,,no
+mozambique,tobacco unmanufactured,tonnes,5,4,,,,,too_few_values,,no
+myanmar,beans dry,ha,6,6,,,,,too_few_values,,no
+myanmar,cotton lint,ha,11,11,british burma,cottonseed,yes,1.0000,attributable,yugoslavia/hops=0.09,no
+myanmar,cotton lint,tonnes,11,11,british burma,cotton: ginned,yes,1.0000,attributable,us puerto rico/citrus fruits: grapefruits=0.09,no
+myanmar,cotton seed,ha,11,11,british burma,cottonseed,yes,1.0000,attributable,yugoslavia/hops=0.09,no
+myanmar,cotton seed,tonnes,11,11,british burma,cottonseed,yes,1.0000,attributable,uk: england and wales/meslin=0.09,no
+myanmar,groundnuts with shell,ha,11,11,british burma,groundnut,yes,1.0000,attributable,turkey/rye=0.09,no
+myanmar,groundnuts with shell,tonnes,11,8,british burma,groundnut,yes,1.0000,attributable,brazil/vineyards: all=0.09,no
+myanmar,rapeseed,ha,3,2,,,,,too_few_values,,no
+myanmar,rubber natural,ha,6,5,,,,,too_few_values,,no
+myanmar,sesame seed,ha,12,12,british burma,sesame,yes,1.0000,attributable,total general including the ussr/linseed=0.08,no
+myanmar,sesame seed,tonnes,10,10,british burma,sesame,yes,1.0000,attributable,greece/rye=0.10,no
+myanmar,tea,ha,5,1,,,,,too_few_values,,no
+myanmar,tobacco unmanufactured,ha,12,11,british burma,tobacco,yes,1.0000,attributable,british kenya/coffee: raw=0.25,no
+myanmar,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+namibia,tobacco unmanufactured,tonnes,8,8,german south west africa,tobacco,yes,1.0000,attributable,yugoslavia/hempseed=0.12,no
+nauru,p,tonnes,15,11,british nauru,"fertilizers: phosphate, natural",unknown,1.0000,attributable,uruguay/rye=0.07,no
+nepal,jute,tonnes,18,16,nepal,jute,yes,1.0000,attributable,japanese korea/sesame=0.11,no
+netherlands,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+netherlands,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+netherlands,eggs hen in shell,tonnes,17,15,netherlands,eggs,yes,1.0000,attributable,switzerland/eggs=0.06,no
+netherlands,grapes,ha,10,1,,,,,too_few_distinct,,no
+netherlands,hemp tow waste,ha,11,8,netherlands,hemp,yes,1.0000,attributable,japan: karafuto prefecture/rapeseed=0.09,no
+netherlands,hops,ha,10,7,netherlands,hops,yes,1.0000,attributable,bulgaria/hops=0.10,no
+netherlands,milk whole fresh cow,tonnes,4,4,,,,,too_few_values,,no
+netherlands,n,tonnes,13,10,netherlands,fertilizers: ammonium sulfate,unknown,1.0000,attributable,paraguay/tobacco=0.08,no
+netherlands,p,tonnes,16,16,netherlands,fertilizers: calcium superphosphate,unknown,1.0000,attributable,mexico/cotton=0.06,no
+netherlands,sugar raw centrifugal,tonnes,33,33,netherlands,sugar: beet,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+netherlands,tobacco unmanufactured,ha,8,5,,,,,too_few_distinct,,no
+netherlands,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+netherlands,yarn of true hemp,tonnes,12,12,netherlands,hemp: fibre,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+new caledonia,coffee green,ha,16,5,,,,,too_few_distinct,,no
+new caledonia,coffee green,tonnes,18,14,french new caledonia,coffee: raw,yes,1.0000,attributable,spain/flax: fibre=0.17,no
+new caledonia,cotton lint,ha,4,2,,,,,too_few_values,,no
+new caledonia,cotton lint,tonnes,6,4,,,,,too_few_values,,no
+new caledonia,cotton seed,ha,4,2,,,,,too_few_values,,no
+new caledonia,cotton seed,tonnes,7,4,,,,,too_few_values,,no
+new caledonia,p,tonnes,4,3,,,,,too_few_values,,no
+new zealand,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+new zealand,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+new zealand,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+new zealand,flax fibre and tow,ha,17,11,,,,,unattributable,new zealand/linseed=0.53,no
+new zealand,flax fibre and tow,tonnes,6,5,,,,,too_few_values,,no
+new zealand,grapes,ha,16,8,new zealand,vineyards,no,0.6875,attributable,uruguay/rye=0.31,no
+new zealand,hops,ha,27,17,new zealand,hops,yes,1.0000,attributable,french guadeloupe/cacao: raw=0.30,no
+new zealand,hops,tonnes,8,8,new zealand,hops,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+new zealand,lemons and limes,tonnes,3,3,,,,,too_few_values,,no
+new zealand,linseed,ha,7,7,,,,,too_few_values,,no
+new zealand,linseed,tonnes,9,9,new zealand,linseed,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+new zealand,milk whole fresh cow,tonnes,5,5,,,,,too_few_values,,no
+new zealand,oranges,tonnes,2,2,,,,,too_few_values,,no
+new zealand,p,tonnes,4,4,,,,,too_few_values,,no
+new zealand,rye,ha,14,11,new zealand,rye,yes,1.0000,attributable,uruguay/rye=0.29,no
+new zealand,rye,tonnes,21,15,new zealand,rye,yes,1.0000,attributable,british‑french cameroon/cottonseed=0.24,no
+new zealand,tobacco unmanufactured,ha,20,9,new zealand,tobacco,yes,1.0000,attributable,british‑french cameroon/cottonseed=0.55,no
+new zealand,tobacco unmanufactured,tonnes,15,15,new zealand,tobacco,yes,1.0000,attributable,germany/rapeseed=0.07,no
+new zealand,wine,ha,10,7,new zealand,wine,yes,1.0000,attributable,sweden/linseed=0.50,no
+new zealand,wine,tonnes,3,3,,,,,too_few_values,,no
+nicaragua,cacao beans,ha,4,3,,,,,too_few_values,,no
+nicaragua,cacao beans,tonnes,18,12,nicaragua,cacao: raw,yes,1.0000,attributable,french annam/jute=0.33,no
+nicaragua,coffee green,ha,1,1,,,,,too_few_values,,no
+nicaragua,coffee green,tonnes,1,1,,,,,too_few_values,,no
+nicaragua,cotton lint,ha,7,4,,,,,too_few_values,,no
+nicaragua,cotton seed,ha,7,4,,,,,too_few_values,,no
+nicaragua,cotton seed,tonnes,7,7,,,,,too_few_values,,no
+nicaragua,eggs hen in shell,tonnes,2,1,,,,,too_few_values,,no
+nicaragua,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+nigeria,cotton lint,ha,9,3,,,,,too_few_distinct,,no
+nigeria,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+nigeria,cotton seed,tonnes,17,16,british nigeria,cottonseed,yes,1.0000,attributable,spain/blackberries=0.06,no
+nigeria,groundnuts with shell,ha,2,2,,,,,too_few_values,,no
+nigeria,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+nigeria,rubber natural,ha,5,4,,,,,too_few_values,,no
+nigeria,sesame seed,ha,4,4,,,,,too_few_values,,no
+nigeria,sesame seed,tonnes,19,19,british nigeria,sesame,yes,1.0000,attributable,sweden/slag: basic=0.05,no
+norway,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+norway,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+norway,eggs hen in shell,tonnes,10,10,norway,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+norway,milk whole fresh cow,tonnes,2,2,,,,,too_few_values,,no
+norway,n,tonnes,15,14,norway,fertilizers: calcium cyanamide,unknown,0.7333,attributable,sweden/fertilizers: calcium cyanamide=0.07,no
+norway,no3,tonnes,13,13,norway,fertilizers: calcium nitrate,no,1.0000,attributable,yugoslavia/wine=0.00,no
+norway,p,tonnes,14,14,norway,"fertilizers: phosphate, natural",unknown,0.7143,attributable,yugoslavia/wine=0.00,no
+palau,p,tonnes,13,9,japanese south pacific: palau-angaur,"fertilizers: phosphate, natural",unknown,1.0000,attributable,"usa/fertilizers: potassium oxide, pure=0.08",no
+panama,cacao beans,tonnes,23,22,panama,cacao: raw,yes,1.0000,attributable,yugoslavia/olive: oil=0.09,no
+panama,coffee green,ha,1,1,,,,,too_few_values,,no
+panama,eggs hen in shell,tonnes,6,6,,,,,too_few_values,,no
+paraguay,beans dry,ha,1,1,,,,,too_few_values,,no
+paraguay,beans dry,tonnes,1,1,,,,,too_few_values,,no
+paraguay,coffee green,ha,2,2,,,,,too_few_values,,no
+paraguay,coffee green,tonnes,3,3,,,,,too_few_values,,no
+paraguay,cotton lint,ha,12,11,paraguay,cottonseed,yes,0.9167,attributable,french niger/tobacco=0.17,no
+paraguay,cotton lint,tonnes,4,4,,,,,too_few_values,,no
+paraguay,cotton seed,ha,12,11,paraguay,cottonseed,yes,1.0000,attributable,french niger/tobacco=0.17,no
+paraguay,cotton seed,tonnes,13,13,paraguay,cottonseed,yes,1.0000,attributable,us puerto rico/coffee: raw=0.08,no
+paraguay,groundnuts with shell,ha,2,2,,,,,too_few_values,,no
+paraguay,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+paraguay,lemons and limes,tonnes,6,3,,,,,too_few_values,,no
+paraguay,oranges,ha,1,1,,,,,too_few_values,,no
+paraguay,oranges,tonnes,2,2,,,,,too_few_values,,no
+paraguay,sugar raw centrifugal,tonnes,27,25,paraguay,sugar: cane,yes,0.8889,attributable,uruguay/rye=0.07,no
+paraguay,tangerines mandarins clementines satsumas,tonnes,2,2,,,,,too_few_values,,no
+peru,coffee green,tonnes,1,1,,,,,too_few_values,,no
+peru,cotton lint,ha,1,1,,,,,too_few_values,,no
+peru,cotton seed,ha,18,18,peru,cottonseed,yes,1.0000,attributable,total/tobacco=0.11,no
+peru,cotton seed,tonnes,1,1,,,,,too_few_values,,no
+peru,fertilizer mixed,tonnes,17,17,peru,"fertilizers: guano, natural",yes,1.0000,attributable,yugoslavia/wine=0.00,no
+peru,grapes,ha,1,1,,,,,too_few_values,,no
+peru,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+peru,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+peru,wine,ha,3,2,,,,,too_few_values,,no
+peru,wine,tonnes,9,9,,,,,unattributable,yugoslavia/wine=0.00,no
+philippines,cacao beans,ha,16,14,us philippines,cacao: raw,yes,1.0000,attributable,french tonkin/groundnut=0.25,no
+philippines,cacao beans,tonnes,16,14,us philippines,cacao: raw,yes,1.0000,attributable,total/linseed=0.12,no
+philippines,coffee green,ha,16,13,us philippines,coffee: raw,yes,1.0000,attributable,french tonkin/groundnut=0.31,no
+philippines,coffee green,tonnes,20,17,us philippines,coffee: raw,yes,1.0000,attributable,union of south africa/tea=0.15,no
+philippines,cotton lint,ha,9,6,us philippines,cottonseed,yes,0.8889,attributable,british montserrat/cottonseed=0.56,no
+philippines,cotton lint,tonnes,9,7,us philippines,cotton: ginned,yes,0.6667,attributable,nicaragua/cacao: raw=0.33,no
+philippines,cotton seed,ha,8,6,us philippines,cottonseed,yes,1.0000,attributable,ireland/flax: fibre=0.50,no
+philippines,cotton seed,tonnes,8,8,us philippines,cottonseed,yes,1.0000,attributable,japanese taiwan/sulphur=0.25,no
+philippines,eggs hen in shell,tonnes,9,9,us philippines,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+philippines,grapefruit inc pomelos,ha,7,4,,,,,too_few_values,,no
+philippines,grapefruit inc pomelos,tonnes,7,7,,,,,too_few_values,,no
+philippines,groundnuts with shell,ha,11,8,us philippines,groundnut,yes,1.0000,attributable,spanish spanish guinea/cacao: raw=0.36,no
+philippines,groundnuts with shell,tonnes,11,10,us philippines,groundnut,yes,1.0000,attributable,british southern rhodesia/citrus fruits: oranges=0.18,no
+philippines,hemp tow waste,ha,7,7,,,,,too_few_values,,no
+philippines,manila fibre abaca,ha,13,13,us philippines,hemp: manila,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+philippines,manila fibre abaca,tonnes,13,12,us philippines,hemp: manila,yes,1.0000,attributable,total general excluding the ussr/flax: fibre=0.08,no
+philippines,oranges,ha,7,4,,,,,too_few_values,,no
+philippines,oranges,tonnes,7,7,,,,,too_few_values,,no
+philippines,rubber natural,ha,6,3,,,,,too_few_values,,no
+philippines,sugar raw centrifugal,tonnes,30,30,us philippines,sugar: cane,yes,0.8000,attributable,spanish spanish guinea/cacao: raw=0.03,no
+philippines,tangerines mandarins clementines satsumas,ha,7,4,,,,,too_few_values,,no
+philippines,tangerines mandarins clementines satsumas,tonnes,7,6,,,,,too_few_values,,no
+philippines,tobacco unmanufactured,ha,26,25,us philippines,tobacco,yes,1.0000,attributable,turkey/beans: dried=0.04,no
+philippines,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+philippines,yarn of true hemp,tonnes,8,8,us philippines,hemp: fibre,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+poland,hops,ha,1,1,,,,,too_few_values,,no
+poland,hops,tonnes,1,1,,,,,too_few_values,,no
+poland,k,tonnes,4,4,,,,,too_few_values,,no
+poland,n,tonnes,4,4,,,,,too_few_values,,no
+poland,p,tonnes,4,4,,,,,too_few_values,,no
+poland,soybeans,ha,3,2,,,,,too_few_values,,no
+poland,sugar raw centrifugal,tonnes,23,23,poland,sugar: beet,yes,1.0000,attributable,total general excluding the ussr/hemp: fibre=0.04,no
+poland,tobacco unmanufactured,ha,1,1,,,,,too_few_values,,no
+poland,yarn of true hemp,ha,13,11,poland,hemp: fibre,yes,1.0000,attributable,italy/hempseed=0.23,no
+poland,yarn of true hemp,tonnes,15,15,poland,hemp: fibre,yes,1.0000,attributable,yugoslavia/meslin=0.07,no
+portugal,eggs hen in shell,tonnes,1,1,,,,,too_few_values,,no
+portugal,fertilizer mixed,tonnes,5,4,,,,,too_few_values,,no
+portugal,lemons and limes,tonnes,8,4,,,,,too_few_distinct,,no
+portugal,n,tonnes,8,7,portugal,fertilizers: ammonium sulfate,unknown,1.0000,attributable,ireland/tobacco=0.12,no
+portugal,olives,ha,1,1,,,,,too_few_values,,no
+portugal,oranges,tonnes,14,5,,,,,too_few_distinct,,no
+portugal,p,tonnes,15,13,portugal,fertilizers: calcium superphosphate,unknown,1.0000,attributable,portuguese mozambique/sugar: cane=0.07,no
+portugal,silk worm cocoons reelable,tonnes,1,1,,,,,too_few_values,,no
+portugal,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+portugal,wine,ha,4,1,,,,,too_few_values,,no
+portugal,wine,tonnes,29,29,,,,,unattributable,yugoslavia/wine=0.00,no
+reunion,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+reunion,sugar raw centrifugal,tonnes,33,32,french reunion,sugar: cane,yes,0.8788,attributable,"total/vineyards: grapes, raisins=0.03",no
+reunion,tobacco unmanufactured,tonnes,11,8,french reunion,tobacco,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.27",no
+romania,cotton lint,ha,16,13,romania,cottonseed,yes,0.9375,attributable,ireland/flax: fibre=0.25,no
+romania,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+romania,cotton seed,ha,16,13,romania,cottonseed,yes,1.0000,attributable,ireland/flax: fibre=0.25,no
+romania,cotton seed,tonnes,15,15,romania,cottonseed,yes,1.0000,attributable,total/linseed=0.13,no
+romania,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,no
+romania,hops,ha,4,4,,,,,too_few_values,,no
+romania,n,tonnes,3,3,,,,,too_few_values,,no
+romania,p,tonnes,2,2,,,,,too_few_values,,no
+romania,silk worm cocoons reelable,tonnes,20,20,romania,sericulture,no,1.0000,attributable,sweden/flax: fibre=0.10,no
+romania,soybeans,ha,4,4,,,,,too_few_values,,no
+romania,sugar raw centrifugal,tonnes,29,29,romania,sugar: beet,yes,1.0000,attributable,switzerland/sugar: beet=0.03,no
+romania,wine,ha,8,6,romania,wine,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+romania,wine,tonnes,28,28,,,,,unattributable,yugoslavia/wine=0.00,no
+romania,yarn of true hemp,ha,13,11,romania,hemp: fibre,yes,1.0000,attributable,poland/hempseed=0.23,no
+romania,yarn of true hemp,tonnes,21,21,romania,hemp: fibre,yes,1.0000,attributable,"total south hemisphere aggregated/vineyards: grapes, raisins=0.05",no
+saint kitts and nevis,cotton lint,ha,33,20,british saint christopher and nevis,cotton,yes,0.6364,attributable,british saint vincent/cottonseed: sea island=0.27,no
+saint kitts and nevis,cotton lint,tonnes,33,26,british saint christopher and nevis,cotton,yes,0.6364,attributable,"british saint vincent/cotton: ginned, sea island=0.18",no
+saint kitts and nevis,cotton seed,ha,20,9,british saint christopher and nevis,cottonseed,yes,1.0000,attributable,british saint vincent/cottonseed: sea island=0.45,no
+saint kitts and nevis,cotton seed,tonnes,18,15,british saint christopher and nevis,cottonseed,yes,1.0000,attributable,nicaragua/cotton: ginned=0.17,no
+saint kitts and nevis,sugar raw centrifugal,tonnes,32,32,british saint christopher and nevis,sugar: cane,yes,0.8750,attributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.03",no
+saint lucia,cacao beans,ha,28,6,british saint lucia,cacao: raw,yes,1.0000,attributable,british guiana/coffee: raw=0.32,no
+saint lucia,cacao beans,tonnes,31,22,british saint lucia,cacao: raw,yes,1.0000,attributable,france/citrus fruits: mandarins=0.23,no
+saint lucia,lemons and limes,ha,13,3,,,,,too_few_distinct,,no
+saint lucia,lemons and limes,tonnes,14,9,british saint lucia,citrus fruits: limes,yes,1.0000,attributable,portugal/citrus fruits: oranges=0.43,no
+saint lucia,sugar raw centrifugal,tonnes,27,25,british saint lucia,sugar: cane,yes,0.8889,attributable,hungary/rapeseed=0.04,no
+saint vincent and the grenadines,cacao beans,ha,19,6,british saint vincent,cacao: raw,yes,1.0000,attributable,canada/flax: fibre=0.16,no
+saint vincent and the grenadines,cacao beans,tonnes,20,20,british saint vincent,cacao: raw,yes,1.0000,attributable,sweden/flax: fibre=0.10,no
+saint vincent and the grenadines,cotton lint,ha,33,23,british saint vincent,cotton,yes,0.6364,attributable,british saint christopher and nevis/cottonseed=0.27,no
+saint vincent and the grenadines,cotton lint,tonnes,32,24,british saint vincent,cotton,yes,0.6562,attributable,british saint christopher and nevis/cotton: ginned=0.19,no
+saint vincent and the grenadines,cotton seed,ha,20,10,british saint vincent,cottonseed: sea island,yes,0.6000,attributable,british saint christopher and nevis/cottonseed=0.45,no
+saint vincent and the grenadines,cotton seed,tonnes,18,15,,,,,unattributable,british saint vincent/cottonseed: sea island=0.56,no
+saint vincent and the grenadines,grapefruit inc pomelos,tonnes,5,1,,,,,too_few_values,,no
+saint vincent and the grenadines,groundnuts with shell,ha,7,5,,,,,too_few_values,,no
+saint vincent and the grenadines,groundnuts with shell,tonnes,13,8,british saint vincent,groundnut,yes,1.0000,attributable,new zealand/rye=0.46,no
+saint vincent and the grenadines,lemons and limes,tonnes,13,3,,,,,too_few_distinct,,no
+saint vincent and the grenadines,oranges,tonnes,5,1,,,,,too_few_values,,no
+saint vincent and the grenadines,sugar raw centrifugal,tonnes,14,12,british saint vincent,sugar: cane,yes,1.0000,attributable,luxembourg/meslin=0.21,no
+samoa,cacao beans,ha,13,7,new zealand western samoa,cacao: raw,yes,0.6923,attributable,us philippines/coffee: raw=0.31,no
+samoa,cacao beans,tonnes,26,25,new zealand western samoa,cacao: raw,yes,0.7308,attributable,british samoa/cacao: raw=0.27,no
+sao tome and principe,coffee green,tonnes,10,9,portuguese sao tome and principe,coffee: raw,yes,1.0000,attributable,sweden/linseed=0.20,no
+senegal,beans dry,ha,12,11,french senegal,beans: dried,unknown,1.0000,attributable,total/beans: dried=0.25,no
+senegal,beans dry,tonnes,12,11,french senegal,beans: dried,unknown,1.0000,attributable,total/cottonseed=0.25,no
+senegal,cotton lint,ha,8,6,french senegal,cottonseed,yes,1.0000,attributable,french annam/sesame=0.38,no
+senegal,cotton lint,tonnes,7,5,,,,,too_few_values,,no
+senegal,cotton seed,ha,8,6,french senegal,cottonseed,yes,1.0000,attributable,french annam/sesame=0.38,no
+senegal,cotton seed,tonnes,7,5,,,,,too_few_values,,no
+senegal,eggs hen in shell,tonnes,4,3,,,,,too_few_values,,no
+senegal,groundnuts with shell,ha,19,18,french senegal,groundnut,yes,0.7895,attributable,"total/vineyards: grapes, raisins=0.11",no
+senegal,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+senegal,other citrus fruit n e c,ha,2,1,,,,,too_few_values,,no
+senegal,other citrus fruit n e c,tonnes,4,1,,,,,too_few_values,,no
+senegal,tobacco unmanufactured,ha,4,4,,,,,too_few_values,,no
+senegal,tobacco unmanufactured,tonnes,4,4,,,,,too_few_values,,no
+serbia,beans dry,ha,7,4,,,,,too_few_values,,no
+serbia,beans dry,tonnes,7,6,,,,,too_few_values,,no
+serbia,castor beans seed,tonnes,1,1,,,,,too_few_values,,no
+serbia,cotton lint,ha,14,12,yugoslavia,cottonseed,yes,0.7143,attributable,uruguay/groundnut=0.29,no
+serbia,cotton lint,tonnes,14,13,,,,,unattributable,yugoslavia/cotton: ginned=0.43,no
+serbia,cotton seed,ha,15,13,yugoslavia,cottonseed,yes,0.7333,attributable,uruguay/groundnut=0.27,no
+serbia,cotton seed,tonnes,14,13,yugoslavia,cottonseed,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/cottonseed=0.29",no
+serbia,flax fibre and tow,ha,17,15,,,,,unattributable,yugoslavia/flax: fibre=0.59,no
+serbia,flax fibre and tow,tonnes,16,15,,,,,unattributable,yugoslavia/linseed=0.38,no
+serbia,grapes,ha,9,9,yugoslavia,wine,no,0.7778,attributable,usa: california/vineyards: all=0.11,no
+serbia,grapes,tonnes,5,5,,,,,too_few_values,,no
+serbia,hemp tow waste,ha,7,7,,,,,too_few_values,,no
+serbia,hemp tow waste,tonnes,2,2,,,,,too_few_values,,no
+serbia,hempseed,tonnes,10,10,yugoslavia,hempseed,yes,0.9000,attributable,bulgaria/hempseed=0.20,no
+serbia,hops,ha,14,14,yugoslavia,hops,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/hops=0.29",no
+serbia,hops,tonnes,14,14,yugoslavia,hops,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/hops=0.29",no
+serbia,lemons and limes,tonnes,6,2,,,,,too_few_values,,no
+serbia,linseed,tonnes,4,4,,,,,too_few_values,,no
+serbia,n,tonnes,4,4,,,,,too_few_values,,no
+serbia,oats,ha,2,2,,,,,too_few_values,,no
+serbia,oats,tonnes,6,6,,,,,too_few_values,,no
+serbia,oil olive virgin,tonnes,20,18,yugoslavia,olive: oil,yes,0.8000,attributable,albania/vineyards: all=0.15,no
+serbia,olives,tonnes,7,7,,,,,too_few_values,,no
+serbia,oranges,tonnes,6,5,,,,,too_few_values,,no
+serbia,p,tonnes,3,3,,,,,too_few_values,,no
+serbia,rapeseed,ha,14,13,yugoslavia,rapeseed,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/rapeseed=0.29",no
+serbia,rapeseed,tonnes,16,16,yugoslavia,rapeseed,yes,0.7500,attributable,"kingdom of serbs, croats and slovenes/rapeseed=0.25",no
+serbia,rye,ha,22,20,yugoslavia,rye,yes,0.7273,attributable,"kingdom of serbs, croats and slovenes/rye=0.27",no
+serbia,rye,tonnes,22,22,yugoslavia,rye,yes,0.7273,attributable,"kingdom of serbs, croats and slovenes/rye=0.27",no
+serbia,sesame seed,ha,10,6,yugoslavia,sesame,yes,1.0000,attributable,uk: great britain/flax: fibre=0.50,no
+serbia,sesame seed,tonnes,10,8,yugoslavia,sesame,yes,1.0000,attributable,british cyprus/sesame=0.40,no
+serbia,silk worm cocoons reelable,tonnes,16,15,yugoslavia,sericulture,no,0.6875,attributable,venezuela/sugar: cane=0.00,no
+serbia,soybeans,ha,7,5,,,,,too_few_values,,no
+serbia,soybeans,tonnes,7,7,,,,,too_few_values,,no
+serbia,sugar raw centrifugal,tonnes,25,25,yugoslavia,sugar: beet,yes,0.6000,attributable,"kingdom of serbs, croats and slovenes/sugar: beet=0.40",no
+serbia,sunflower seed,ha,1,1,,,,,too_few_values,,no
+serbia,sunflower seed,tonnes,1,1,,,,,too_few_values,,no
+serbia,tobacco unmanufactured,ha,17,16,yugoslavia,tobacco,yes,0.6471,attributable,"kingdom of serbs, croats and slovenes/tobacco=0.35",no
+serbia,tobacco unmanufactured,tonnes,17,17,yugoslavia,tobacco,yes,0.6471,attributable,"kingdom of serbs, croats and slovenes/tobacco=0.35",no
+serbia,wheat,ha,14,13,yugoslavia,spelt,no,0.7143,attributable,"kingdom of serbs, croats and slovenes/spelt=0.29",no
+serbia,wheat,tonnes,14,14,yugoslavia,spelt,no,0.7143,attributable,"kingdom of serbs, croats and slovenes/spelt=0.29",no
+serbia,wine,ha,14,14,yugoslavia,wine,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/wine=0.29",no
+serbia,wine,tonnes,18,18,,,,,unattributable,yugoslavia/wine=0.00,no
+serbia,yarn of true hemp,ha,13,13,yugoslavia,hemp: fibre,yes,0.6923,attributable,"kingdom of serbs, croats and slovenes/hemp: fibre=0.31",no
+serbia,yarn of true hemp,tonnes,18,18,,,,,unattributable,yugoslavia/hemp: fibre=0.50,no
+seychelles,cacao beans,tonnes,7,6,,,,,too_few_values,,no
+seychelles,fertilizer mixed,tonnes,11,11,british seychelles,"fertilizers: guano, natural",yes,1.0000,attributable,yugoslavia/wine=0.00,no
+sierra leone,cacao beans,ha,9,8,british sierra leone,cacao: raw,yes,1.0000,attributable,total/cottonseed=0.11,no
+sierra leone,cacao beans,tonnes,17,14,british sierra leone,cacao: raw,yes,1.0000,attributable,"british malta/citrus fruits: lemons, mandarins, oranges=0.24",no
+sierra leone,coffee green,ha,10,2,,,,,too_few_distinct,,no
+sierra leone,coffee green,tonnes,13,5,,,,,too_few_distinct,,no
+sierra leone,groundnuts with shell,ha,7,1,,,,,too_few_values,,no
+sierra leone,groundnuts with shell,tonnes,3,1,,,,,too_few_values,,no
+sierra leone,rubber natural,ha,6,1,,,,,too_few_values,,no
+sierra leone,sesame seed,tonnes,15,11,british sierra leone,sesame,yes,1.0000,attributable,french cambodia/cotton: ginned=0.20,no
+singapore,coffee green,ha,11,10,british straits settlements,coffee: raw,yes,1.0000,attributable,french india/cotton=0.09,no
+somalia,cotton lint,ha,9,8,italian somaliland,cottonseed,yes,0.6667,attributable,canada/hops=0.33,no
+somalia,cotton lint,tonnes,9,8,,,,,unattributable,italian somaliland/cotton=0.56,no
+somalia,cotton seed,ha,6,6,,,,,too_few_values,,no
+somalia,cotton seed,tonnes,5,5,,,,,too_few_values,,no
+somalia,eggs hen in shell,tonnes,3,2,,,,,too_few_values,,no
+somalia,groundnuts with shell,ha,4,2,,,,,too_few_values,,no
+somalia,groundnuts with shell,tonnes,4,4,,,,,too_few_values,,no
+somalia,sesame seed,ha,5,4,,,,,too_few_values,,no
+somalia,sesame seed,tonnes,4,4,,,,,too_few_values,,no
+somalia,sugar raw centrifugal,tonnes,2,2,,,,,too_few_values,,no
+south africa,beans dry,tonnes,2,2,,,,,too_few_values,,no
+south africa,butter cow milk,tonnes,7,6,,,,,too_few_values,,no
+south africa,cheese processed,tonnes,7,6,,,,,too_few_values,,no
+south africa,cotton lint,ha,16,16,union of south africa,cotton,yes,1.0000,attributable,paraguay/coffee: raw=0.06,no
+south africa,cotton lint,tonnes,18,14,,,,,unattributable,union of south africa/cotton: ginned=0.56,no
+south africa,cotton seed,ha,6,6,,,,,too_few_values,,no
+south africa,cotton seed,tonnes,19,16,union of south africa,cottonseed,yes,1.0000,attributable,"british saint vincent/cotton: ginned, sea island=0.26",no
+south africa,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,no
+south africa,grapefruit inc pomelos,tonnes,6,6,,,,,too_few_values,,no
+south africa,grapes,ha,7,7,,,,,too_few_values,,no
+south africa,grapes,tonnes,5,5,,,,,too_few_values,,no
+south africa,groundnuts with shell,ha,6,6,,,,,too_few_values,,no
+south africa,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+south africa,lemons and limes,tonnes,9,8,union of south africa,citrus fruits: lemons,yes,1.0000,attributable,japanese taiwan/sesame=0.22,no
+south africa,n,tonnes,4,4,,,,,too_few_values,,no
+south africa,oats,tonnes,7,7,,,,,too_few_values,,no
+south africa,oranges,tonnes,6,6,,,,,too_few_values,,no
+south africa,raisins,tonnes,11,8,union of south africa,raisins,yes,1.0000,attributable,portuguese angola/cottonseed=0.27,no
+south africa,rye,ha,8,8,union of south africa,rye,yes,1.0000,attributable,total/olive: oil=0.12,no
+south africa,rye,tonnes,17,16,union of south africa,rye,yes,1.0000,attributable,argentina/tobacco=0.12,no
+south africa,sugar raw centrifugal,tonnes,32,32,union of south africa,sugar: cane,yes,0.8750,attributable,yugoslavia/wine=0.00,no
+south africa,tangerines mandarins clementines satsumas,tonnes,8,5,,,,,too_few_distinct,,no
+south africa,tea,ha,27,16,union of south africa,tea,yes,1.0000,attributable,new zealand/tobacco=0.37,no
+south africa,tea,tonnes,27,27,union of south africa,tea,yes,1.0000,attributable,british uganda/tea=0.04,no
+south africa,tobacco unmanufactured,ha,10,9,union of south africa,tobacco,yes,1.0000,attributable,yugoslavia/flax: fibre=0.20,no
+south africa,tobacco unmanufactured,tonnes,2,2,,,,,too_few_values,,no
+south africa,wine,ha,3,3,,,,,too_few_values,,no
+south africa,wine,tonnes,1,1,,,,,too_few_values,,no
+south korea,beans dry,ha,3,3,,,,,too_few_values,,no
+south korea,beans dry,tonnes,3,3,,,,,too_few_values,,no
+south korea,cotton lint,ha,33,33,japanese korea,cotton,yes,0.6364,attributable,usa/citrus fruits: oranges=0.03,no
+south korea,cotton lint,tonnes,32,32,japanese korea,cotton,yes,0.6250,attributable,total/hemp: fibre=0.03,no
+south korea,cotton seed,ha,20,20,japanese korea,cottonseed,yes,1.0000,attributable,usa/citrus fruits: oranges=0.05,no
+south korea,cotton seed,tonnes,20,20,japanese korea,cottonseed,yes,1.0000,attributable,us puerto rico/coffee: raw=0.05,no
+south korea,eggs hen in shell,tonnes,7,6,,,,,too_few_values,,no
+south korea,grapes,ha,6,6,,,,,too_few_values,,no
+south korea,grapes,tonnes,17,17,,,,,unattributable,japanese korea/vineyards: grapes=0.29,no
+south korea,groundnuts with shell,ha,11,9,japanese korea,groundnut,yes,1.0000,attributable,new zealand/hops=0.36,no
+south korea,groundnuts with shell,tonnes,11,11,japanese korea,groundnut,yes,1.0000,attributable,turkey/hempseed=0.09,no
+south korea,hemp tow waste,ha,12,12,japanese korea,hemp,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+south korea,n,tonnes,4,4,,,,,too_few_values,,no
+south korea,other berries and fruits of the genus vaccinium n e c,ha,12,11,japanese korea,blackberries,no,1.0000,attributable,"greece/vineyards: grapes, raisins=0.17",no
+south korea,sesame seed,ha,12,9,japanese korea,sesame,yes,1.0000,attributable,czechoslovakia/tobacco=0.42,no
+south korea,sesame seed,tonnes,12,12,japanese korea,sesame,yes,1.0000,attributable,france/hemp: fibre=0.17,no
+south korea,silk worm cocoons reelable,tonnes,28,28,japanese korea,sericulture,no,1.0000,attributable,yugoslavia/wine=0.00,no
+south korea,soybeans,ha,9,9,japanese korea,soybean,yes,1.0000,attributable,usa/groundnut=0.11,no
+south korea,soybeans,tonnes,10,10,japanese korea,soybean,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+south korea,sugar raw centrifugal,tonnes,8,7,japanese korea,sugar: beet,yes,1.0000,attributable,costa rica/citrus fruits: lemons=0.25,no
+south korea,tobacco unmanufactured,ha,28,26,japanese korea,tobacco,yes,1.0000,attributable,total/linseed=0.11,no
+south korea,tobacco unmanufactured,tonnes,28,28,japanese korea,tobacco,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+south korea,yarn of true hemp,ha,11,10,japanese korea,hemp: fibre,yes,1.0000,attributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.18",no
+south korea,yarn of true hemp,tonnes,24,23,japanese korea,hemp: fibre,yes,1.0000,attributable,yugoslavia/tobacco=0.04,no
+spain,cotton lint,ha,17,17,spain,cottonseed,yes,1.0000,attributable,total/cottonseed=0.12,no
+spain,cotton seed,ha,17,17,spain,cottonseed,yes,1.0000,attributable,total/cottonseed=0.12,no
+spain,cotton seed,tonnes,16,16,spain,cottonseed,yes,1.0000,attributable,yugoslavia/olive: oil=0.06,no
+spain,eggs hen in shell,tonnes,1,1,,,,,too_few_values,,no
+spain,fertilizer mixed,tonnes,14,14,spain,sulphur,no,1.0000,attributable,yugoslavia/wine=0.00,no
+spain,grapes,ha,1,1,,,,,too_few_values,,no
+spain,k,tonnes,4,4,,,,,too_few_values,,no
+spain,milk whole fresh cow,tonnes,1,1,,,,,too_few_values,,no
+spain,n,tonnes,15,14,spain,fertilizers: ammonium sulfate,unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+spain,other berries and fruits of the genus vaccinium n e c,ha,1,1,,,,,too_few_values,,no
+spain,other berries and fruits of the genus vaccinium n e c,tonnes,13,12,spain,blackberries,no,1.0000,attributable,usa/fertilizers: copper(ii) sulfate=0.08,no
+spain,p,tonnes,15,15,spain,"fertilizers: phosphate, natural",unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+spain,raisins,ha,2,2,,,,,too_few_values,,no
+spain,raisins,tonnes,13,13,spain,raisins,yes,0.7692,attributable,total north hemisphere aggregated/hops=0.08,no
+spain,silk worm cocoons reelable,tonnes,29,28,spain,sericulture,no,1.0000,attributable,french upper volta/tobacco=0.03,no
+spain,sugar raw centrifugal,tonnes,31,31,spain,sugar: beet,yes,0.7097,attributable,finland/spelt=0.06,no
+spain,wine,ha,17,16,spain,wine,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+spain,wine,tonnes,32,32,,,,,unattributable,yugoslavia/wine=0.00,no
+spain,yarn of true hemp,ha,10,9,spain,hempseed,yes,1.0000,attributable,mexico/linseed=0.30,no
+spain,yarn of true hemp,tonnes,17,17,spain,hemp: fibre,yes,1.0000,attributable,us philippines/groundnut=0.06,no
+sri lanka,cacao beans,ha,20,12,british ceylon,cacao: raw,yes,1.0000,attributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.15",no
+sri lanka,cacao beans,tonnes,31,30,british ceylon,cacao: raw,yes,1.0000,attributable,"ussr/citrus fruits: lemons, mandarins, oranges=0.06",no
+sri lanka,coffee green,ha,14,11,british ceylon,coffee: raw,yes,1.0000,attributable,sweden/tobacco=0.07,no
+sri lanka,coffee green,tonnes,8,6,british ceylon,coffee: raw,yes,1.0000,attributable,british virgin islands/cottonseed=0.12,no
+sri lanka,cotton lint,ha,12,7,british ceylon,cottonseed,yes,1.0000,attributable,total/linseed=0.42,no
+sri lanka,cotton lint,tonnes,11,5,,,,,too_few_distinct,,no
+sri lanka,cotton seed,ha,12,7,british ceylon,cottonseed,yes,1.0000,attributable,total/linseed=0.42,no
+sri lanka,cotton seed,tonnes,11,6,british ceylon,cottonseed,yes,1.0000,attributable,french annam/jute=0.45,no
+sri lanka,rubber natural,ha,13,8,,,,,unattributable,british ceylon/rubber=0.54,no
+sri lanka,sugar raw centrifugal,tonnes,8,7,,,,,unattributable,french mauritania/groundnut=0.12,no
+sri lanka,tea,ha,32,20,british ceylon,tea,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.03",no
+sri lanka,tea,tonnes,1,1,,,,,too_few_values,,no
+sri lanka,tobacco unmanufactured,ha,22,13,british ceylon,tobacco,yes,1.0000,attributable,us philippines/groundnut=0.18,no
+sri lanka,tobacco unmanufactured,tonnes,3,1,,,,,too_few_values,,no
+suriname,cacao beans,ha,20,17,dutch guiana,cacao: raw,yes,1.0000,attributable,switzerland/tobacco=0.20,no
+suriname,cacao beans,tonnes,24,20,dutch guiana,cacao: raw,yes,1.0000,attributable,british grenada/cotton: ginned=0.25,no
+suriname,coffee green,ha,18,9,dutch guiana,coffee: raw,yes,1.0000,attributable,luxembourg/rye=0.22,no
+suriname,coffee green,tonnes,32,31,dutch guiana,coffee: raw,yes,1.0000,attributable,canada/flax: fibre=0.12,no
+suriname,groundnuts with shell,tonnes,4,2,,,,,too_few_values,,no
+suriname,oranges,ha,12,5,,,,,too_few_distinct,,no
+suriname,oranges,tonnes,14,11,dutch guiana,citrus fruits: oranges,yes,1.0000,attributable,uruguay/groundnut=0.21,no
+suriname,sugar raw centrifugal,tonnes,31,31,dutch guiana,sugar: cane,yes,0.8710,attributable,french morocco/olive: oil=0.06,no
+suriname,tobacco unmanufactured,tonnes,6,6,,,,,too_few_values,,no
+sweden,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+sweden,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+sweden,eggs hen in shell,tonnes,2,2,,,,,too_few_values,,no
+sweden,fertilizer mixed,tonnes,9,9,sweden,fertilizers: copper(ii) sulfate,yes,1.0000,attributable,spain/flax=0.11,no
+sweden,flax fibre and tow,ha,4,1,,,,,too_few_values,,no
+sweden,flax fibre and tow,tonnes,1,1,,,,,too_few_values,,no
+sweden,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+sweden,n,tonnes,12,11,sweden,fertilizers: calcium cyanamide,unknown,1.0000,attributable,usa and canada/fertilizers: calcium cyanamide=0.17,no
+sweden,p,tonnes,16,16,sweden,fertilizers: calcium superphosphate,unknown,0.8125,attributable,yugoslavia/wine=0.00,no
+sweden,rapeseed,tonnes,1,1,,,,,too_few_values,,no
+sweden,sugar raw centrifugal,tonnes,33,33,sweden,sugar: beet,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+sweden,tobacco unmanufactured,ha,2,1,,,,,too_few_values,,no
+switzerland,butter cow milk,tonnes,7,7,,,,,too_few_values,,no
+switzerland,cheese processed,tonnes,7,7,,,,,too_few_values,,no
+switzerland,eggs hen in shell,tonnes,15,12,switzerland,eggs,yes,1.0000,attributable,netherlands/eggs=0.07,no
+switzerland,fertilizer mixed,tonnes,4,4,,,,,too_few_values,,no
+switzerland,grapes,tonnes,1,1,,,,,too_few_values,,no
+switzerland,hemp tow waste,ha,4,2,,,,,too_few_values,,no
+switzerland,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+switzerland,n,tonnes,16,10,switzerland,fertilizers: calcium cyanamide,unknown,1.0000,attributable,"usa/fertilizers: potassium oxide, pure=0.19",no
+switzerland,p,tonnes,4,4,,,,,too_few_values,,no
+switzerland,rapeseed,ha,3,2,,,,,too_few_values,,no
+switzerland,rapeseed,tonnes,2,2,,,,,too_few_values,,no
+switzerland,silk worm cocoons reelable,tonnes,16,15,switzerland,sericulture,no,1.0000,attributable,british virgin islands/cotton=0.06,no
+switzerland,sugar raw centrifugal,tonnes,33,32,switzerland,sugar: beet,yes,1.0000,attributable,dominican republic/beans: dried=0.06,no
+switzerland,wine,ha,13,9,switzerland,wine,yes,1.0000,attributable,germany/tobacco=0.23,no
+switzerland,wine,tonnes,33,33,,,,,unattributable,yugoslavia/wine=0.00,no
+switzerland,yarn of true hemp,tonnes,3,3,,,,,too_few_values,,no
+tanzania,cacao beans,ha,4,4,,,,,too_few_values,,no
+tanzania,coffee green,ha,11,9,british tanganyika,coffee: raw,yes,1.0000,attributable,french niger/groundnut=0.27,no
+tanzania,cotton lint,ha,17,15,,,,,unattributable,british tanganyika/cottonseed=0.59,no
+tanzania,cotton lint,tonnes,1,1,,,,,too_few_values,,no
+tanzania,cotton seed,ha,10,9,british tanganyika,cottonseed,yes,1.0000,attributable,uk: northern ireland/flax: fibre=0.10,no
+tanzania,cotton seed,tonnes,20,20,british tanganyika,cottonseed,yes,1.0000,attributable,turkey/hemp: fibre=0.05,no
+tanzania,groundnuts with shell,ha,7,7,,,,,too_few_values,,no
+tanzania,rubber natural,ha,4,2,,,,,too_few_values,,no
+tanzania,sesame seed,ha,7,6,,,,,too_few_values,,no
+tanzania,sesame seed,tonnes,20,18,british tanganyika,sesame,yes,1.0000,attributable,venezuela/cotton: ginned=0.10,no
+tanzania,tea,ha,5,2,,,,,too_few_values,,no
+tanzania,tea,tonnes,7,7,,,,,too_few_values,,no
+tanzania,tobacco unmanufactured,ha,7,3,,,,,too_few_values,,no
+tanzania,tobacco unmanufactured,tonnes,7,7,,,,,too_few_values,,no
+thailand,cotton lint,ha,26,25,siam,cottonseed,yes,0.6154,attributable,spain/hemp: fibre=0.12,no
+thailand,cotton lint,tonnes,16,15,siam,cotton: ginned,yes,0.6875,attributable,turkey/hempseed=0.12,no
+thailand,cotton seed,ha,16,15,siam,cottonseed,yes,1.0000,attributable,spain/hemp: fibre=0.19,no
+thailand,cotton seed,tonnes,15,15,siam,cottonseed,yes,1.0000,attributable,total/rye=0.13,no
+thailand,rubber natural,ha,4,4,,,,,too_few_values,,no
+thailand,sesame seed,ha,16,9,siam,sesame,yes,1.0000,attributable,french tonkin/cottonseed=0.44,no
+thailand,sesame seed,tonnes,16,13,siam,sesame,yes,1.0000,attributable,austria/flax: fibre=0.19,no
+thailand,tobacco unmanufactured,ha,26,24,siam,tobacco,yes,1.0000,attributable,luxembourg/rye=0.12,no
+thailand,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+togo,cacao beans,ha,3,3,,,,,too_few_values,,no
+togo,cacao beans,tonnes,5,5,,,,,too_few_values,,no
+togo,groundnuts with shell,ha,1,1,,,,,too_few_values,,no
+togo,groundnuts with shell,tonnes,1,1,,,,,too_few_values,,no
+trinidad and tobago,cacao beans,ha,23,18,british trinidad and tobago,cacao: raw,yes,1.0000,attributable,turkey/beans: dried=0.04,no
+trinidad and tobago,cacao beans,tonnes,1,1,,,,,too_few_values,,no
+trinidad and tobago,coffee green,ha,20,8,british trinidad and tobago,coffee: raw,yes,1.0000,attributable,switzerland/tobacco=0.15,no
+trinidad and tobago,coffee green,tonnes,17,14,british trinidad and tobago,coffee: raw,yes,1.0000,attributable,french syria/beans: dried=0.18,no
+trinidad and tobago,grapefruit inc pomelos,ha,2,2,,,,,too_few_values,,no
+trinidad and tobago,grapefruit inc pomelos,tonnes,7,7,,,,,too_few_values,,no
+trinidad and tobago,rubber natural,ha,13,1,,,,,too_few_distinct,,no
+trinidad and tobago,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+tunisia,cotton lint,ha,6,3,,,,,too_few_values,,no
+tunisia,eggs hen in shell,tonnes,8,1,,,,,too_few_distinct,,no
+tunisia,flax fibre and tow,ha,15,9,,,,,unattributable,french tunisia/flax=0.53,no
+tunisia,flax fibre and tow,tonnes,8,3,,,,,too_few_distinct,,no
+tunisia,grapes,ha,29,24,,,,,unattributable,french tunisia/vineyards=0.45,no
+tunisia,grapes,tonnes,18,14,,,,,unattributable,"french tunisia/vineyards: grapes, raisins=0.39",no
+tunisia,lemons and limes,ha,3,1,,,,,too_few_values,,no
+tunisia,lemons and limes,tonnes,14,10,french tunisia,citrus fruits: lemons,yes,1.0000,attributable,british southern rhodesia/groundnut=0.29,no
+tunisia,linseed,ha,8,8,french tunisia,linseed,yes,1.0000,attributable,us philippines/cottonseed=0.12,no
+tunisia,linseed,tonnes,21,18,french tunisia,linseed,yes,1.0000,attributable,total/fertilizers: ammonium sulfate=0.10,no
+tunisia,oats,tonnes,7,7,,,,,too_few_values,,no
+tunisia,oil olive virgin,tonnes,3,3,,,,,too_few_values,,no
+tunisia,olives,ha,5,4,,,,,too_few_values,,no
+tunisia,olives,tonnes,6,5,,,,,too_few_values,,no
+tunisia,oranges,ha,3,2,,,,,too_few_values,,no
+tunisia,oranges,tonnes,14,11,,,,,unattributable,french tunisia/citrus fruits: oranges=0.57,no
+tunisia,p,tonnes,17,17,french tunisia,"fertilizers: phosphate, natural",unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+tunisia,tobacco unmanufactured,ha,25,23,french tunisia,tobacco,yes,1.0000,attributable,japanese south pacific/tobacco=0.16,no
+tunisia,tobacco unmanufactured,tonnes,32,32,french tunisia,tobacco,yes,1.0000,attributable,turkey/spelt=0.03,no
+tunisia,wine,ha,20,15,french tunisia,wine,yes,1.0000,attributable,total/tobacco=0.15,no
+tunisia,wine,tonnes,1,1,,,,,too_few_values,,no
+turkey,beans dry,ha,11,9,turkey,beans: dried,unknown,1.0000,attributable,us philippines/tobacco=0.09,no
+turkey,beans dry,tonnes,12,12,turkey,beans: dried,unknown,1.0000,attributable,"spain/vineyards: grapes, raisins=0.08",no
+turkey,cotton lint,ha,19,19,turkey,cottonseed,yes,0.8421,attributable,turkey in asia/cotton=0.11,no
+turkey,cotton seed,ha,18,18,turkey,cottonseed,yes,0.8889,attributable,turkey in asia/cotton=0.11,no
+turkey,cotton seed,tonnes,17,17,turkey,cottonseed,yes,0.8824,attributable,union of south africa: cape province/vineyards: all=0.06,no
+turkey,eggs hen in shell,tonnes,12,11,turkey,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+turkey,flax fibre and tow,ha,13,13,turkey,linseed,no,1.0000,attributable,total/flax: fibre=0.23,no
+turkey,flax fibre and tow,tonnes,13,12,turkey,linseed,no,0.9231,attributable,usa/hops=0.08,no
+turkey,grapes,ha,13,11,turkey,vineyards: all,no,0.8462,attributable,"total/citrus fruits: cedrats, lemons, limes, sweet limes, other=0.08",no
+turkey,grapes,tonnes,13,13,,,,,unattributable,turkey/vineyards: all=0.54,no
+turkey,hemp tow waste,ha,7,4,,,,,too_few_values,,no
+turkey,hemp tow waste,tonnes,7,6,,,,,too_few_values,,no
+turkey,hempseed,ha,11,7,turkey,hemp: fibre,yes,0.9091,attributable,total/groundnut=0.36,no
+turkey,hempseed,tonnes,13,11,,,,,unattributable,turkey/hemp=0.54,no
+turkey,lemons and limes,tonnes,6,5,,,,,too_few_values,,no
+turkey,linseed,ha,4,4,,,,,too_few_values,,no
+turkey,linseed,tonnes,4,4,,,,,too_few_values,,no
+turkey,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+turkey,oats,ha,1,1,,,,,too_few_values,,no
+turkey,oil olive virgin,tonnes,1,1,,,,,too_few_values,,no
+turkey,olives,ha,7,4,,,,,too_few_values,,no
+turkey,olives,tonnes,15,15,turkey,olive grove,yes,1.0000,attributable,total/tobacco=0.07,no
+turkey,oranges,tonnes,6,6,,,,,too_few_values,,no
+turkey,raisins,ha,2,2,,,,,too_few_values,,no
+turkey,raisins,tonnes,13,13,turkey,raisins,yes,0.7692,attributable,"total/vineyards: grapes, raisins=0.08",no
+turkey,rye,ha,19,19,turkey,rye,yes,0.9474,attributable,"total north hemisphere aggregated/vineyards: grapes, raisins=0.05",no
+turkey,rye,tonnes,18,18,turkey,rye,yes,0.9444,attributable,dutch java and madura/rubber=0.06,no
+turkey,sesame seed,ha,17,14,turkey,sesame,yes,1.0000,attributable,"total/vineyards: grapes, raisins=0.06",no
+turkey,sesame seed,tonnes,16,16,turkey,sesame,yes,1.0000,attributable,uk: england and wales/meslin=0.06,no
+turkey,silk worm cocoons reelable,tonnes,19,19,turkey,sericulture,no,1.0000,attributable,french tonkin/groundnut=0.05,no
+turkey,sugar raw centrifugal,tonnes,16,14,turkey,sugar: beet,yes,1.0000,attributable,"netherlands/cheese: farm, factory=0.06",no
+turkey,sunflower seed,ha,1,1,,,,,too_few_values,,no
+turkey,sunflower seed,tonnes,1,1,,,,,too_few_values,,no
+turkey,tangerines mandarins clementines satsumas,tonnes,6,6,,,,,too_few_values,,no
+turkey,tobacco unmanufactured,ha,16,14,turkey,tobacco,yes,1.0000,attributable,"spain/vineyards: grapes, raisins=0.12",no
+turkey,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+turkey,wheat,ha,1,1,,,,,too_few_values,,no
+turkey,wine,ha,2,2,,,,,too_few_values,,no
+turkey,yarn of true hemp,ha,6,5,,,,,too_few_values,,no
+turkey,yarn of true hemp,tonnes,6,5,,,,,too_few_values,,no
+united kingdom,butter cow milk,tonnes,7,4,,,,,too_few_values,,no
+united kingdom,cheese processed,tonnes,7,6,,,,,too_few_values,,no
+united kingdom,eggs hen in shell,tonnes,11,11,,,,,unattributable,uk: scotland/eggs=0.09,no
+united kingdom,fertilizer mixed,tonnes,17,17,uk,fertilizers: copper(ii) sulfate,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+united kingdom,milk whole fresh cow,tonnes,7,7,,,,,too_few_values,,no
+united kingdom,n,tonnes,17,17,uk,fertilizers: ammonium sulfate,unknown,1.0000,attributable,yugoslavia/wine=0.00,no
+united kingdom,p,tonnes,17,17,uk,fertilizers: calcium superphosphate,unknown,0.7059,attributable,yugoslavia/wine=0.00,no
+united kingdom,sugar raw centrifugal,tonnes,20,20,uk,sugar: beet,yes,0.8000,attributable,uk: england and wales/sugar: beet=0.15,no
+united states virgin islands,sugar raw centrifugal,tonnes,32,31,us virgin islands,sugar: cane,yes,0.8750,attributable,french annam/cottonseed=0.06,no
+uruguay,beans dry,ha,3,2,,,,,too_few_values,,no
+uruguay,beans dry,tonnes,3,3,,,,,too_few_values,,no
+uruguay,eggs hen in shell,tonnes,3,3,,,,,too_few_values,,no
+uruguay,flax fibre and tow,ha,1,1,,,,,too_few_values,,no
+uruguay,flax fibre and tow,tonnes,13,13,uruguay,linseed,no,1.0000,attributable,french west africa/cottonseed=0.08,no
+uruguay,grapes,tonnes,6,6,,,,,too_few_values,,no
+uruguay,groundnuts with shell,ha,1,1,,,,,too_few_values,,no
+uruguay,lemons and limes,tonnes,2,2,,,,,too_few_values,,no
+uruguay,olives,ha,1,1,,,,,too_few_values,,no
+uruguay,olives,tonnes,2,2,,,,,too_few_values,,no
+uruguay,oranges,tonnes,2,2,,,,,too_few_values,,no
+uruguay,rye,ha,4,2,,,,,too_few_values,,no
+uruguay,rye,tonnes,10,6,,,,,ambiguous,uruguay/rye=1.00;british cyprus/hemp: fibre=0.60,no
+uruguay,sugar raw centrifugal,tonnes,4,4,,,,,too_few_values,,no
+uruguay,sunflower seed,ha,1,1,,,,,too_few_values,,no
+uruguay,sunflower seed,tonnes,1,1,,,,,too_few_values,,no
+uruguay,tobacco unmanufactured,ha,4,4,,,,,too_few_values,,no
+uruguay,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no
+vanuatu,cacao beans,ha,6,4,,,,,too_few_values,,no
+vanuatu,cacao beans,tonnes,21,18,british‑french new hebrides,cacao: raw,yes,1.0000,attributable,yugoslavia/linseed=0.10,no
+vanuatu,coffee green,ha,8,4,,,,,too_few_distinct,,no
+vanuatu,coffee green,tonnes,19,14,british‑french new hebrides,coffee: raw,yes,1.0000,attributable,french algeria/beans: dried=0.26,no
+vanuatu,cotton lint,ha,5,3,,,,,too_few_values,,no
+vanuatu,cotton lint,tonnes,17,13,british‑french new hebrides,cotton,yes,0.6471,attributable,british cyprus/hemp: fibre=0.41,no
+vanuatu,cotton seed,ha,5,3,,,,,too_few_values,,no
+vanuatu,cotton seed,tonnes,12,10,british‑french new hebrides,cottonseed,yes,1.0000,attributable,sweden/flax: fibre=0.33,no
+venezuela,cacao beans,tonnes,1,1,,,,,too_few_values,,no
+venezuela,coffee green,ha,1,1,,,,,too_few_values,,no
+venezuela,cotton lint,ha,7,6,,,,,too_few_values,,no
+venezuela,cotton seed,ha,7,6,,,,,too_few_values,,no
+venezuela,cotton seed,tonnes,7,6,,,,,too_few_values,,no
+venezuela,sugar raw centrifugal,tonnes,1,1,,,,,too_few_values,,no
+viet nam,coffee green,ha,13,6,french tonkin,coffee: raw,yes,1.0000,attributable,french ivory coast/tobacco=0.46,no
+viet nam,coffee green,tonnes,11,9,french tonkin,coffee: raw,yes,1.0000,attributable,british cyprus/beans: dried=0.36,no
+viet nam,cotton lint,ha,14,6,french tonkin,cottonseed,yes,1.0000,attributable,union of south africa/tea=0.57,no
+viet nam,cotton lint,tonnes,14,5,,,,,too_few_distinct,,no
+viet nam,cotton seed,ha,14,6,french tonkin,cottonseed,yes,1.0000,attributable,union of south africa/tea=0.57,no
+viet nam,cotton seed,tonnes,12,8,french tonkin,cottonseed,yes,1.0000,attributable,new zealand/rye=0.33,no
+viet nam,groundnuts with shell,ha,14,7,french tonkin,groundnut,yes,1.0000,attributable,australia/citrus fruits: lemons=0.50,no
+viet nam,groundnuts with shell,tonnes,13,11,french tonkin,groundnut,yes,1.0000,attributable,usa: hawaii/coffee: raw=0.15,no
+viet nam,jute,ha,11,7,french tonkin,jute,yes,1.0000,attributable,french india/cottonseed=0.45,no
+viet nam,jute,tonnes,7,6,,,,,too_few_values,,no
+viet nam,other berries and fruits of the genus vaccinium n e c,ha,14,6,french tonkin,blackberries,no,1.0000,attributable,british southern rhodesia/groundnut=0.57,no
+viet nam,other berries and fruits of the genus vaccinium n e c,tonnes,4,4,,,,,too_few_values,,no
+viet nam,sesame seed,ha,7,4,,,,,too_few_values,,no
+viet nam,sesame seed,tonnes,7,7,,,,,too_few_values,,no
+viet nam,silk worm cocoons reelable,tonnes,4,4,,,,,too_few_values,,no
+viet nam,sugar raw centrifugal,tonnes,6,6,,,,,too_few_values,,no
+viet nam,tea,ha,14,9,french tonkin,tea,yes,1.0000,attributable,french algeria/citrus fruits: mandarins=0.29,no
+viet nam,tea,tonnes,10,9,french tonkin,tea,yes,1.0000,attributable,yugoslavia/olive: oil=0.10,no
+viet nam,tobacco unmanufactured,ha,13,6,french tonkin,tobacco,yes,1.0000,attributable,us puerto rico/cottonseed=0.38,no
+viet nam,tobacco unmanufactured,tonnes,13,13,french tonkin,tobacco,yes,1.0000,attributable,turkey/cottonseed=0.08,no
+yemen,coffee green,tonnes,17,17,british aden,coffee: raw,yes,1.0000,attributable,belgium/spelt=0.12,no
+zambia,cotton lint,ha,7,7,,,,,too_few_values,,no
+zambia,cotton lint,tonnes,7,7,,,,,too_few_values,,no
+zambia,cotton seed,ha,7,7,,,,,too_few_values,,no
+zambia,cotton seed,tonnes,7,7,,,,,too_few_values,,no
+zambia,groundnuts with shell,ha,10,6,british northern rhodesia,groundnut,yes,1.0000,attributable,uruguay/rye=0.50,no
+zambia,groundnuts with shell,tonnes,9,7,british northern rhodesia,groundnut,yes,1.0000,attributable,british montserrat/sugar: cane=0.44,no
+zambia,lemons and limes,ha,5,1,,,,,too_few_values,,no
+zambia,lemons and limes,tonnes,5,2,,,,,too_few_values,,no
+zambia,oranges,ha,8,4,,,,,too_few_distinct,,no
+zambia,oranges,tonnes,8,5,,,,,too_few_distinct,,no
+zambia,other sugar crops n e c,ha,3,2,,,,,too_few_values,,no
+zambia,other sugar crops n e c,tonnes,3,3,,,,,too_few_values,,no
+zambia,tobacco unmanufactured,ha,11,7,british northern rhodesia,tobacco,yes,1.0000,attributable,french laos/cottonseed=0.45,no
+zambia,tobacco unmanufactured,tonnes,17,17,british northern rhodesia,tobacco,yes,1.0000,attributable,latvia/fertilizers: calcium superphosphate=0.06,no
+zimbabwe,beans dry,ha,9,3,,,,,too_few_distinct,,no
+zimbabwe,beans dry,tonnes,12,6,british southern rhodesia,beans: dried,unknown,1.0000,attributable,french guadeloupe/coffee: raw=0.33,no
+zimbabwe,butter cow milk,tonnes,7,3,,,,,too_few_values,,no
+zimbabwe,cheese processed,tonnes,7,2,,,,,too_few_values,,no
+zimbabwe,cotton lint,ha,16,8,british southern rhodesia,cottonseed,yes,0.9375,attributable,french algeria/rye=0.56,no
+zimbabwe,cotton lint,tonnes,14,10,,,,,unattributable,british southern rhodesia/cotton: ginned=0.57,no
+zimbabwe,cotton seed,ha,16,9,british southern rhodesia,cottonseed,yes,1.0000,attributable,french algeria/rye=0.50,no
+zimbabwe,cotton seed,tonnes,16,13,british southern rhodesia,cottonseed,yes,1.0000,attributable,french tonkin/cottonseed=0.25,no
+zimbabwe,eggs hen in shell,tonnes,8,7,british southern rhodesia,eggs,yes,1.0000,attributable,yugoslavia/wine=0.00,no
+zimbabwe,flax fibre and tow,ha,6,5,,,,,too_few_values,,no
+zimbabwe,groundnuts with shell,ha,18,9,british southern rhodesia,groundnut,yes,1.0000,attributable,french tonkin/blackberries=0.50,no
+zimbabwe,groundnuts with shell,tonnes,2,2,,,,,too_few_values,,no
+zimbabwe,linseed,ha,3,3,,,,,too_few_values,,no
+zimbabwe,linseed,tonnes,5,5,,,,,too_few_values,,no
+zimbabwe,oats,tonnes,4,2,,,,,too_few_values,,no
+zimbabwe,oranges,tonnes,13,13,british southern rhodesia,citrus fruits: oranges,yes,1.0000,attributable,us philippines/groundnut=0.15,no
+zimbabwe,other sugar crops n e c,tonnes,6,4,,,,,too_few_values,,no
+zimbabwe,rye,ha,6,6,,,,,too_few_values,,no
+zimbabwe,soybeans,tonnes,4,2,,,,,too_few_values,,no
+zimbabwe,sunflower seed,ha,7,2,,,,,too_few_values,,no
+zimbabwe,sunflower seed,tonnes,7,2,,,,,too_few_values,,no
+zimbabwe,tea,ha,7,3,,,,,too_few_values,,no
+zimbabwe,tea,tonnes,7,7,,,,,too_few_values,,no
+zimbabwe,tobacco unmanufactured,ha,28,24,british southern rhodesia,tobacco,yes,1.0000,attributable,yugoslavia/meslin=0.11,no
+zimbabwe,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,no

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1539,6 +1539,39 @@ def mutate_constant_run_shortened(root, gpd, make_valid, affinity):
             f"to be a rounding floor stops being pinned while the total stays put")
 
 
+def mutate_provenance_raw_product_erased(root, gpd, make_valid, affinity):
+    """Blank the raw_product on every attributable row, as an index built per LABEL would leave it.
+
+    20_item_provenance.py indexed raw fingerprints by label alone until 2026-08-19, unioning every
+    product that label carries -- `french syria and lebanon` carries 18, so a layer-B `grapes`
+    series could score against values belonging to `wine`. Switching to a per-(label, product) index
+    withdrew 25 attributions and resolved 25 ambiguities, so the looser version was measurably
+    wrong, not merely coarser.
+
+    A regression to it would leave `raw_product` empty while EVERY OTHER SIGNAL stayed healthy: the
+    series count, the status counts, the 11 pinned mixtures and the distinctness filter are all
+    computed the same way either side of the change. This mutation reproduces exactly that state --
+    statuses, labels and shares untouched, only the per-product evidence gone -- so nothing but
+    check D can see it.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/item_provenance.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    n = 0
+    for r in rows:
+        if r["status"] == "attributable" and r.get("raw_product"):
+            r["raw_product"] = ""
+            n += 1
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"erased raw_product on all {n} attributable rows, the state a label-level index would "
+            f"leave, while every status, share, pinned mixture and filter count stays exactly as it "
+            f"was")
+
+
 def mutate_label_provenance_hides_mixing(root, gpd, make_valid, affinity):
     """Mark a span whose values come from ONE territory as coming from two.
 
@@ -2871,6 +2904,15 @@ CASES = (
         "cells are present on BOTH sides",
         "a pair declared `separate_series` whose measured shared-cell count has risen above zero, "
         "so a real double count sits behind a disposition that says a sum is safe",
+    ),
+    (
+        "validate_item_provenance.py",
+        mutate_provenance_raw_product_erased,
+        "the per-product index did not run",
+        "every attributable row stripped of its raw_product — the state a regression to the "
+        "label-level index would leave, which withdrew 25 attributions and resolved 25 ambiguities "
+        "when it was fixed, while the series count, status counts, 11 pinned mixtures and "
+        "distinctness filter all stay identical",
     ),
     (
         "validate_iia_label_provenance.py",

--- a/scripts/validate_item_provenance.py
+++ b/scripts/validate_item_provenance.py
@@ -67,6 +67,14 @@ BASELINE_MIXED = frozenset({
 })
 
 
+AGREE_VALUES = frozenset({"yes", "no", "unknown"})
+
+# Measured 2026-08-19 on the first per-product run: 670 yes, 54 no, 55 unknown over 779 attributable
+# rows. BIDIRECTIONAL, like every other ceiling here — closing a vocabulary gap must lower it with a
+# note, so the count cannot quietly refill with genuinely bad matches.
+BASELINE_DISAGREE = 54
+
+
 def main() -> int:
     if not os.path.exists(TABLE):
         print(f"SKIP: {os.path.relpath(TABLE, REPO)} missing — run 20_item_provenance.py --write")
@@ -141,6 +149,39 @@ def main() -> int:
             f"A {label!r} is pinned as an item-level mixture but is not one any more — remove its "
             f"entry, saying what was repaired, or whether a threshold moved and hid it"
         )
+
+    # --- D: the commodity cross-check ---
+    # The fingerprint matches NUMBERS. Since 2026-08-19 the tool indexes raw (label, PRODUCT) rather
+    # than raw label, which makes a second, independent question askable: does the winning raw
+    # product name the same commodity as the layer-B item? A match on numbers alone can be a
+    # coincidence; a match that also respects commodity identity is far harder to produce by chance,
+    # and 670 of 724 attributable rows have one. If that agreement collapsed, the matching would
+    # have decayed into noise while every count above still looked healthy.
+    attrib = [r for r in rows if r["status"] == "attributable"]
+    for r in attrib:
+        if not (r.get("raw_product") or "").strip():
+            problems.append(
+                f"D {r['layer_b_label']}/{r['item']} is attributable to {r['raw_label']!r} with no "
+                f"raw_product — the per-product index did not run, so the union-of-products error "
+                f"this column exists to detect is back and invisible")
+        if (r.get("product_agrees") or "") not in AGREE_VALUES:
+            problems.append(
+                f"D {r['layer_b_label']}/{r['item']}: product_agrees "
+                f"{r.get('product_agrees')!r} not in {sorted(AGREE_VALUES)}")
+    disagree = sorted(f"{r['layer_b_label']}/{r['item']}" for r in attrib
+                      if r.get("product_agrees") == "no")
+    print(f"attributable rows whose raw product names a different commodity: {len(disagree)} "
+          f"(ceiling {BASELINE_DISAGREE})")
+    if len(disagree) > BASELINE_DISAGREE:
+        problems.append(
+            f"D {len(disagree)} attributable series land on a raw product naming a DIFFERENT "
+            f"commodity, above the ceiling of {BASELINE_DISAGREE}. Each is either a vocabulary gap "
+            f"(`silk worm cocoons reelable` <- `sericulture`), a real finding (`flax fibre and tow` "
+            f"<- `linseed`) or a bad match — and a rise means more of the third")
+    elif len(disagree) < BASELINE_DISAGREE:
+        problems.append(
+            f"D only {len(disagree)} disagreeing series remain, below the pinned ceiling of "
+            f"{BASELINE_DISAGREE} — lower the baseline and say which vocabulary gap was closed")
 
     if problems:
         print(f"\nFAIL: {len(problems)} problem(s)\n")


### PR DESCRIPTION
A raw label is a **union of its products**. `french syria and lebanon` carries 18 of them, so a layer-B `grapes` series was being scored against values that may belong to `wine` or `olive: oil` — the same class of error as matching a trade tonnage to a production tonnage, which this method already had to correct for once in #315.

## The stricter index is uniformly more conservative

Which is how we know the looser one was *wrong* rather than merely coarser:

```
attributable    804 -> 779      25 attributions withdrawn
ambiguous        31 ->   6      25 resolved (only ambiguous because label unions overlapped)
unattributable   92 -> 142
mixed labels     11 ->  11      unchanged
```

75 series changed verdict or attribution. **The 11 item-level mixtures surviving untouched is the load-bearing result**: #372's finding is robust to the method, not an artefact of it.

## It corrects #372's own table

`syrian arab republic` carries Lebanon in **grapes (67%), oranges (69%) and tobacco (69%)** as well as cotton seed (63%) — not "cotton only". Four series need that decision, not one.

And `austria`'s `n` is specifically `austria-hungary` / **`fertilizers: calcium cyanamide`** — a further refinement of the `p`/`n`/`k` convention from #369.

## A second, independent signal falls out of it

Per-product matching makes a new question askable: does the winning raw product name the same **commodity** as the layer-B item? A match on numbers alone can be coincidence; a match that also respects commodity identity is much harder to produce by chance.

```
product_agrees:   yes 670    unknown 55    no 54     (of 779 attributable)
```

The raw vocabulary does not resemble the layer-B one — `grapes: table`, `citrus fruits: oranges, other`, `fertilizers: calcium cyanamide` — so agreement is judged on shared word stems and disagreement is **reported, never used to reject a match**. The 54 disagreements are informative rather than wrong:

- `silk worm cocoons reelable` ← `sericulture` — a vocabulary gap
- `flax fibre and tow` ← `linseed` — **independently reproduces #360's finding** from a different source and method

## Gating

Check D pins all of it: every attributable row must carry a `raw_product`, `product_agrees` must be in the vocabulary, and the 54 disagreements are a bidirectional ceiling.

The selftest case erases `raw_product` on every attributable row — **the exact state a regression to the label-level index would leave** — while series count, status counts, the 11 pinned mixtures and the distinctness filter all stay identical, so nothing but check D can see it.

**67 gates, 79 selftest cases, all pass.**

*PR opened by Claude.*