### PR TITLE
Detect series COLLAPSES: the mirror shape isolated_spikes.py cannot see

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -483,6 +483,13 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_edition_conflicts.py
 
+      # validate_isolated_spikes.py is one-directional and skips endpoints, and both choices left a
+      # hole with a confirmed defect in it: iia nauru/p ends on 97 after 424,896 — a transposition
+      # with Australia's 1933 phosphate. 117 collapses at >=20x, ZERO overlapping the spike table.
+      - name: Sources — no year may read many times BELOW its own neighbours
+        if: '!cancelled()'
+        run: python3 scripts/validate_series_collapses.py
+
       # A label can be right for one commodity and wrong for another, and no label-level decision can
       # fix that: the alias key is (label, source, years) with no item dimension. 11 iia labels mix
       # raw labels across their item series -- australia's `p` is CHRISTMAS ISLAND phosphate,

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ python3 scripts/validate_constant_runs.py           # a value repeated for years
 python3 scripts/validate_isolated_spikes.py         # no single year may read many times its own neighbours
 python3 scripts/validate_same_polity_overlaps.py   # two labels of one source may not collide on one polity's cells
 python3 scripts/validate_edition_conflicts.py      # one yearbook volume may not contradict another about a cell
+python3 scripts/validate_series_collapses.py       # no year may read many times BELOW its own neighbours
 python3 scripts/validate_item_provenance.py         # no iia label may mix territories across its item series unrecorded
 python3 scripts/validate_item_product_switches.py   # an item series must not switch raw product back and forth
 python3 scripts/validate_item_equivalences.py       # every item/product mapping must be adjudicated

--- a/pipelines/polity-autoimprove/27_series_collapses.py
+++ b/pipelines/polity-autoimprove/27_series_collapses.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Where does a series COLLAPSE — one year many times below its neighbours, or below its own start/end?
+
+`18_isolated_spikes.py` is one-directional by construction: it flags a year reading >=20x ABOVE both
+its neighbours, and it explicitly skips endpoints because they have only one neighbour. Both choices
+were right for what it was built to catch and both leave a hole, and the hole has a confirmed defect
+sitting in it.
+
+WHAT FELL THROUGH IT. `iia nauru / p` runs 275,720 / 245,040 / 424,896 for 1930-1932 and then ends on
+**97** in 1933 -- a 4,380x collapse in the series' final year. It is a transposition: the iia_1933_34
+volume swapped Nauru's and Australia's 1933 phosphate, and iia_1938_39 has them the right way round
+(369,500 and 100). Confirmed in state/data_errors.csv, found only because 26_edition_conflicts.py
+compares yearbook volumes. The spike detector could not see it twice over: wrong sign, and an endpoint.
+
+THREE POSITIONS, because the evidence available differs at each:
+
+    interior_collapse   a year >=20x below BOTH neighbours. The exact mirror of an isolated spike,
+                        and the strongest shape -- a real collapse and recovery in adjacent years is
+                        rare. 55 found.
+    terminal_collapse   the last value >=20x below its only neighbour. 10 found.
+    leading_collapse    the first value >=20x below its only neighbour. 52 found.
+
+THIS TABLE DOES NOT CLAIM ITS ROWS ARE DEFECTS, and the measurement is why. Among the ten terminal
+collapses, `iia hungary / silk-worm cocoons` 236 -> 4 in **1945**, `juan hungary / castor beans`
+6,000 -> 200 in **1945**, `iia hungary / sugar raw centrifugal` 176,400 -> 6,500 in **1945** and
+`iia iran / castor beans` 2,600 -> 100 in **1944** are all plausible: a war ends a series on a
+genuinely collapsed harvest. Meanwhile `mitchell china, mainland / millet` 6,524,000 -> 4,000 ha in
+1952 and `iia norway / no3` 148,000 -> 130 t in 1921 are not plausible at all.
+
+NO THRESHOLD SEPARATES THOSE TWO GROUPS, and inventing one that happened to would be fitting it to
+the examples in front of me -- the error issue 406 already caught me making. The ratio does not
+discriminate (Hungary's sugar collapse at 27x and Iran's castor at 26x sit below Tanzania's cassava
+at 70x, which is not obviously war-related), so the table records the SHAPE and leaves the verdict to
+whoever can check the year. What it guarantees is that the shape can no longer appear silently.
+
+UNORDERABLE SERIES ARE SKIPPED, not guessed at: 342 series carry two rows for one year with nothing
+in the panel to order them (issue 367), and a series with no defined neighbour has no collapse.
+Zero and negative values are excluded -- a ratio against zero is undefined, and a drop TO zero is the
+separate concern issue 414 measures.
+
+WHY A TRACKED TABLE. The panel is gitignored and absent in CI, so this writes
+`state/series_collapses.csv`, that file is committed, and the gate reads it -- the same arrangement as
+16_source_splices.py, 17_constant_runs.py, 18_isolated_spikes.py and 26_edition_conflicts.py.
+
+Usage:
+  python3 pipelines/polity-autoimprove/27_series_collapses.py            # report only
+  python3 pipelines/polity-autoimprove/27_series_collapses.py --write    # refresh the table
+  python3 pipelines/polity-autoimprove/27_series_collapses.py --check    # fail if stale
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+STATE = os.path.join(HERE, "state")
+OUT = os.path.join(STATE, "series_collapses.csv")
+DEFAULT_PANEL = os.path.expanduser(os.environ.get(
+    "WHEP_LAYER_B", "~/Nextcloud/whep/layer_b/consolidated_layer_b.parquet"))
+
+# The same factor 18_isolated_spikes.py uses, deliberately: this is its mirror, and two detectors for
+# one phenomenon that disagreed about what counts as extreme would be worse than either alone.
+COLLAPSE = 20.0
+
+# `indicator` MUST be in the series key. Without it fao1952 packs several indicators under one item
+# code and the detector compares indicators rather than years -- the trap that gave 18_isolated_spikes
+# 110 hits instead of 21.
+KEY = ["source", "country", "item", "unit", "indicator"]
+
+FIELDS = ["source", "country", "item", "unit", "indicator", "position", "year",
+          "value", "neighbour_value", "neighbour_year", "factor", "series_n"]
+
+
+def build(panel_path: str) -> list[dict]:
+    import pandas as pd
+
+    d = pd.read_parquet(panel_path)
+    d = d.dropna(subset=["year", "value"])
+    d = d[d["value"] > 0]
+    out = []
+    for k, g in d.groupby(KEY, dropna=False):
+        g = g.sort_values("year")
+        # A series with two rows for one year has no defined neighbour (issue 367). Skipped, not
+        # guessed at.
+        if g["year"].nunique() < len(g):
+            continue
+        v = [float(x) for x in g["value"]]
+        y = [int(x) for x in g["year"]]
+        if len(v) < 4:
+            continue
+        base = dict(zip(KEY, [("" if x != x else x) if not isinstance(x, str) else x for x in k]))
+
+        def emit(position, i, nb_i):
+            out.append({**base, "position": position, "year": y[i], "value": f"{v[i]:g}",
+                        "neighbour_value": f"{v[nb_i]:g}", "neighbour_year": y[nb_i],
+                        "factor": f"{v[nb_i] / v[i]:.1f}", "series_n": len(v)})
+
+        if v[-2] / v[-1] >= COLLAPSE:
+            emit("terminal_collapse", len(v) - 1, len(v) - 2)
+        if v[1] / v[0] >= COLLAPSE:
+            emit("leading_collapse", 0, 1)
+        for i in range(1, len(v) - 1):
+            if v[i - 1] / v[i] >= COLLAPSE and v[i + 1] / v[i] >= COLLAPSE:
+                # Report against the SMALLER neighbour, so `factor` is the weakest claim the row
+                # supports rather than the most impressive one.
+                nb = i - 1 if v[i - 1] <= v[i + 1] else i + 1
+                emit("interior_collapse", i, nb)
+    out.sort(key=lambda r: (r["position"], r["source"], str(r["country"]), str(r["item"]),
+                            str(r["unit"]), r["year"]))
+    return out
+
+
+def write(rows: list[dict], path: str) -> None:
+    """Build fully in memory then replace atomically — a truncating open() has cost this repo two
+    tracked state files mid-error."""
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=FIELDS)
+            w.writeheader()
+            w.writerows(rows)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
+    ap.add_argument("--check", action="store_true", help="exit 1 if the tracked table is stale")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.layer_b):
+        print(f"panel absent ({args.layer_b}); nothing to do", file=sys.stderr)
+        return 0
+
+    rows = build(args.layer_b)
+    by = {}
+    for r in rows:
+        by[r["position"]] = by.get(r["position"], 0) + 1
+    print(f"series collapses >={COLLAPSE:.0f}x: {len(rows)}")
+    for p in sorted(by):
+        print(f"  {p:20} {by[p]}")
+
+    if args.check:
+        if not os.path.exists(OUT):
+            print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+            return 1
+        with open(OUT, newline="") as fh:
+            have = list(csv.DictReader(fh))
+        want = [{k: str(v) for k, v in r.items()} for r in rows]
+        if have != want:
+            print(f"STALE {os.path.relpath(OUT, REPO)}: rerun with --write", file=sys.stderr)
+            return 1
+        print("table is current")
+        return 0
+
+    if args.write:
+        write(rows, OUT)
+        print(f"wrote {os.path.relpath(OUT, REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -379,6 +379,21 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        layer B. Where a second opinion exists the pipeline prefers it (1933: 179
                        raw zeros -> 61 in layer B); where none exists they pass through (1935:
                        148 -> 120). Issue 414. --write refreshes state/edition_conflicts.csv
+27_series_collapses.py where does a series COLLAPSE — a year many times BELOW its neighbours, or
+                       below its own start/end? 18_isolated_spikes.py is one-directional and skips
+                       endpoints, and both left a hole: `iia nauru / p` runs 275,720/245,040/424,896
+                       for 1930-32 and ends on **97** in 1933 — the iia_1933_34 volume swapped
+                       Nauru's and Australia's phosphate (iia_1938_39 has 369,500 and 100). Wrong
+                       sign AND an endpoint, so the spike detector missed it twice over.
+                       117 collapses at >=20x — interior 55, leading 52, terminal 10 — with ZERO
+                       overlap with isolated_spikes.csv, so a disjoint class not a re-detection.
+                       IT DOES NOT CLAIM ITS ROWS ARE DEFECTS, and that is measured: of the 10
+                       terminal collapses, four are plausible war endings (hungary silk cocoons
+                       236->4 and sugar 176,400->6,500 in 1945, iran castor 2,600->100 in 1944)
+                       while mitchell china millet 6,524,000->4,000 ha (1952) is not. NO RATIO
+                       SEPARATES THEM — hungary's sugar is 27x, below tanzania's cassava at 70x — so
+                       inventing a threshold would fit it to the examples at hand (issue 406).
+                       --write refreshes state/series_collapses.csv
                        in CI, since the panel is gitignored. Does NOT decide the cause of any
                        one seam: unit mismatch, different coverage and different item definitions
                        are probably all present, and separating them needs the sources.

--- a/pipelines/polity-autoimprove/state/series_collapses.csv
+++ b/pipelines/polity-autoimprove/state/series_collapses.csv
@@ -1,0 +1,118 @@
+source,country,item,unit,indicator,position,year,value,neighbour_value,neighbour_year,factor,series_n
+iia,algeria,flax fibre and tow,tonnes,,interior_collapse,1919,0.1,100,1920,1000.0,5
+iia,algeria,grapes,ha,,interior_collapse,1933,4360,173545,1921,39.8,24
+iia,algeria,linseed,tonnes,,interior_collapse,1920,1.4,120,1921,85.7,18
+iia,algeria,wine,ha,,interior_collapse,1933,373,351952,1932,943.6,20
+iia,australia,flax fibre and tow,ha,,interior_collapse,1923,2,53,1924,26.5,18
+iia,australia,linseed,ha,,interior_collapse,1923,2,53,1924,26.5,6
+iia,canada,"eggs, hen, in shell",tonnes,,interior_collapse,1930,148.764,146659,1929,985.8,17
+iia,czech republic,rye,ha,,interior_collapse,1943,26000,861000,1942,33.1,24
+iia,egypt,"tangerines, mandarins, clementines, satsumas",tonnes,,interior_collapse,1939,2600,55100,1940,21.2,11
+iia,greece,grapes,tonnes,,interior_collapse,1937,3300,672500,1938,203.8,7
+iia,italy,sugar raw centrifugal,tonnes,,interior_collapse,1941,8000,372300,1942,46.5,33
+iia,japan,p,tonnes,,interior_collapse,1930,305,97340,1920,319.1,16
+iia,japan,p,tonnes,,interior_collapse,1932,23804,862401,1931,36.2,16
+iia,libya,wine,ha,,interior_collapse,1933,12,1000,1934,83.3,6
+iia,lithuania,sugar raw centrifugal,tonnes,,interior_collapse,1933,8.1,13700,1934,1691.4,9
+iia,morocco,wine,ha,,interior_collapse,1933,113,8600,1932,76.1,12
+iia,panama,"cacao, beans",tonnes,,interior_collapse,1917,4.5,116.8,1918,26.0,23
+iia,russian federation,flax fibre and tow,ha,,interior_collapse,1918,20,730438,1920,36521.9,26
+iia,russian federation,flax fibre and tow,tonnes,,interior_collapse,1918,10.6,319250,1922,30117.9,20
+iia,russian federation,hemp tow waste,ha,,interior_collapse,1918,5,536848,1917,107369.6,12
+iia,russian federation,rapeseed,ha,,interior_collapse,1914,48,34910,1915,727.3,12
+iia,russian federation,rapeseed,tonnes,,interior_collapse,1914,52.3,41229.5,1915,788.3,9
+iia,russian federation,rye,ha,,interior_collapse,1918,7,9.99363e+06,1917,1427660.9,31
+iia,russian federation,rye,tonnes,,interior_collapse,1918,12.6,1.61999e+07,1917,1285709.9,28
+iia,russian federation,rye,tonnes,,interior_collapse,1931,21990,2.202e+07,1932,1001.4,28
+iia,serbia,rye,ha,,interior_collapse,1943,26000,861000,1942,33.1,22
+iia,syrian arab republic,olives,tonnes,,interior_collapse,1941,1700,35000,1940,20.6,18
+iia,tunisia,wine,ha,,interior_collapse,1933,440,44000,1932,100.0,20
+iia,united states of america,"coffee, green",ha,,interior_collapse,1924,2428,64904,1923,26.7,28
+iia,united states of america,"coffee, green",tonnes,,interior_collapse,1933,50.8,4966,1932,97.8,29
+juan,argentina,grapes,tonnes,,interior_collapse,1932,15875,1.196e+06,1929,75.3,44
+juan,brazil,figs,tonnes,,interior_collapse,1959,0.5,10000,1958,20000.0,9
+juan,bulgaria,flax fibre and tow,ha,,interior_collapse,1899,48.9662,1500,1903,30.6,47
+juan,bulgaria,linseed,ha,,interior_collapse,1899,48.9662,1500,1903,30.6,47
+juan,bulgaria,linseed,tonnes,,interior_collapse,1899,14.2248,871.774,1898,61.3,47
+juan,bulgaria,rapeseed,ha,,interior_collapse,1915,300,6200,1914,20.7,42
+juan,denmark,rapeseed,tonnes,,interior_collapse,1921,7.11238,829.1,1920,116.6,16
+juan,mexico,sugar cane,ha,,interior_collapse,1899,681,24574,1898,36.1,53
+juan,mexico,sugar cane,tonnes,,interior_collapse,1899,27583.6,1.24813e+06,1900,45.2,53
+juan,panama,swine / pigs,heads,,interior_collapse,1921,1095,30000,1916,27.4,18
+juan,spain,canary seed,tonnes,,interior_collapse,1901,2.033,684.266,1902,336.6,98
+juan,spain,"grain, mixed",tonnes,,interior_collapse,1907,766.9,29285,1905,38.2,54
+juan,spain,linseed,tonnes,,interior_collapse,1924,43,1140,1925,26.5,98
+juan,switzerland,plums and sloes,tonnes,,interior_collapse,1887,160,7438,1886,46.5,111
+juan,switzerland,"walnuts, with shell",tonnes,,interior_collapse,1887,98,2221,1886,22.7,111
+mitchell,cameroon,"coffee, green",tonnes,page_11_table_1,interior_collapse,1941,100,4200,1940,42.0,27
+mitchell,"china, mainland","groundnuts, with shell",tonnes,page_7_table_1,interior_collapse,1930,2000,621000,1924,310.5,10
+mitchell,"china, mainland",oats,ha,page_35_table_1,interior_collapse,1952,4000,959000,1951,239.8,13
+mitchell,india,asses,heads,page_36_table_1,interior_collapse,1908,3000,1.231e+06,1905,410.3,30
+mitchell,india,swine / pigs,heads,page_43_table_1,interior_collapse,1947,3000,3.653e+06,1948,1217.7,8
+mitchell,india,"tobacco, unmanufactured",tonnes,page_10_table_1,interior_collapse,1946,4000,246000,1947,61.5,20
+mitchell,korea,barley,ha,page_41_table_1,interior_collapse,1944,18000,712000,1945,39.6,17
+mitchell,nigeria,cattle,heads,page_8_table_1,interior_collapse,1950,13000,3.216e+06,1956,247.4,24
+mitchell,nigeria,goats,heads,page_8_table_1,interior_collapse,1950,13000,6.22e+06,1949,478.5,24
+mitchell,nigeria,sheep,heads,page_8_table_1,interior_collapse,1950,13000,2.43e+06,1948,186.9,23
+fao1952,Canada,horses mules asses,1000 heads,livestock:livestock,leading_collapse,1931,6,2776,1939,462.7,5
+fao1952,United Kingdom,horses mules asses,1000 heads,livestock:livestock,leading_collapse,1938,7,1084,1939,154.9,5
+iia,chile,flax fibre and tow,tonnes,,leading_collapse,1910,2.4,57.5,1911,24.0,5
+iia,czech republic,hemp tow waste,ha,,leading_collapse,1919,477,9934,1920,20.8,10
+iia,czech republic,rye,ha,,leading_collapse,1910,3,732970,1919,244323.3,24
+iia,czech republic,yarn of true hemp,tonnes,,leading_collapse,1919,326.5,8489.1,1920,26.0,15
+iia,dr congo,cotton seed,ha,,leading_collapse,1922,5,7500,1923,1500.0,19
+iia,ivory coast,"cacao, beans",ha,,leading_collapse,1922,1000,50000,1930,50.0,14
+iia,morocco,p,tonnes,,leading_collapse,1921,8232,1.85e+06,1930,224.7,5
+iia,mozambique,cotton lint,ha,,leading_collapse,1922,53,11809,1923,222.8,11
+iia,mozambique,cotton seed,ha,,leading_collapse,1922,53,11809,1923,222.8,6
+iia,syrian arab republic,cotton lint,ha,,leading_collapse,1922,1320,28650,1924,21.7,19
+iia,syrian arab republic,cotton seed,ha,,leading_collapse,1922,1320,28650,1924,21.7,19
+iia,zambia,cotton lint,ha,,leading_collapse,1922,3,943,1923,314.3,6
+iia,zambia,cotton lint,tonnes,,leading_collapse,1922,0.1,86.1,1923,861.0,6
+iia,zambia,cotton seed,ha,,leading_collapse,1922,3,943,1923,314.3,6
+iia,zambia,cotton seed,tonnes,,leading_collapse,1922,0.2,201,1923,1005.0,6
+iia,zambia,"tobacco, unmanufactured",ha,,leading_collapse,1922,29,1401,1923,48.3,11
+iia,zambia,"tobacco, unmanufactured",tonnes,,leading_collapse,1922,8.6,517,1923,60.1,17
+iia,zimbabwe,cotton lint,ha,,leading_collapse,1922,8,1597,1923,199.6,16
+iia,zimbabwe,cotton lint,tonnes,,leading_collapse,1922,0.4,230,1923,575.0,14
+iia,zimbabwe,cotton seed,ha,,leading_collapse,1922,8,1597,1923,199.6,16
+iia,zimbabwe,cotton seed,tonnes,,leading_collapse,1922,1,537,1923,537.0,16
+juan,argentina,artichokes,tonnes,,leading_collapse,1937,58,18360,1945,316.6,8
+juan,argentina,barley,ha,,leading_collapse,1872,1713.08,49000,1900,28.6,62
+juan,argentina,fibre crops nes,tonnes,,leading_collapse,1937,2832,200000,1944,70.6,9
+juan,argentina,garlic,tonnes,,leading_collapse,1937,224.43,7800,1942,34.8,11
+juan,argentina,soybeans,ha,,leading_collapse,1937,2,1315,1942,657.5,19
+juan,argentina,sugar cane,ha,,leading_collapse,1872,2452,50000,1901,20.4,60
+juan,argentina,tea,ha,,leading_collapse,1937,1.3,631,1946,485.4,12
+juan,bulgaria,linseed,tonnes,,leading_collapse,1897,19.305,871.774,1898,45.2,47
+juan,canada,goats,heads,,leading_collapse,1918,367,9364,1924,25.5,9
+juan,colombia,"coffee, green",ha,,leading_collapse,1916,4620.5,200000,1925,43.3,16
+juan,czechoslovakia,hemp tow waste,tonnes,,leading_collapse,1919,320,8480,1920,26.5,33
+juan,czechoslovakia,maize,tonnes,,leading_collapse,1919,11380,245062,1920,21.5,42
+juan,czechoslovakia,sunflower seed,ha,,leading_collapse,1919,651.13,26000,1934,39.9,10
+juan,el salvador,asses,heads,,leading_collapse,1930,2196,114200,1939,52.0,14
+juan,germany,mules and hinnies,heads,,leading_collapse,1912,1000,27000,1921,27.0,14
+juan,haiti,maize,ha,,leading_collapse,1930,2630,120000,1948,45.6,4
+juan,mexico,"oil, cottonseed",tonnes,,leading_collapse,1907,101.378,86000,1925,848.3,36
+juan,peru,chick peas,tonnes,,leading_collapse,1948,1000,21000,1951,21.0,9
+juan,switzerland,apples,tonnes,,leading_collapse,1850,1363,30201,1851,22.2,111
+juan,switzerland,rapeseed,tonnes,,leading_collapse,1909,10,1400,1942,140.0,18
+juan,united states of america,soybeans,ha,,leading_collapse,1909,1000,62320.7,1917,62.3,43
+mitchell,india,asses,heads,page_43_table_1,leading_collapse,1947,3000,1.13e+06,1948,376.7,7
+mitchell,india,buffalo,heads,page_43_table_1,leading_collapse,1947,3000,3.9553e+07,1948,13184.3,7
+mitchell,india,camels,heads,page_43_table_1,leading_collapse,1947,3000,643000,1948,214.3,6
+mitchell,india,cattle,heads,page_43_table_1,leading_collapse,1947,3000,1.33544e+08,1948,44514.7,7
+mitchell,india,goats,heads,page_43_table_1,leading_collapse,1947,3000,4.4271e+07,1948,14757.0,7
+mitchell,india,horses,heads,page_43_table_1,leading_collapse,1947,3000,1.397e+06,1948,465.7,7
+mitchell,india,sheep,heads,page_43_table_1,leading_collapse,1947,3000,3.5816e+07,1948,11938.7,7
+mitchell,natal,"tobacco, unmanufactured",tonnes,copia de page_5_table_2,leading_collapse,1861,0.3,6.2,1862,20.7,37
+iia,hungary,"silk-worm cocoons, reelable",tonnes,,terminal_collapse,1945,4,236,1944,59.0,21
+iia,hungary,sugar raw centrifugal,tonnes,,terminal_collapse,1945,6500,176400,1944,27.1,29
+iia,iran,castor beans seed,tonnes,,terminal_collapse,1944,100,2600,1941,26.0,4
+iia,israel,oranges,tonnes,,terminal_collapse,1939,1300,317000,1937,243.8,9
+iia,mauritius,"coffee, green",tonnes,,terminal_collapse,1915,0.1,3.6,1914,36.0,6
+iia,nauru,p,tonnes,,terminal_collapse,1933,97,424896,1932,4380.4,15
+iia,norway,no3,tonnes,,terminal_collapse,1921,130,148000,1920,1138.5,13
+juan,hungary,castor beans seed,tonnes,,terminal_collapse,1945,200,6000,1943,30.0,4
+mitchell,"china, mainland",millet,ha,page_35_table_1,terminal_collapse,1952,4000,6.524e+06,1951,1631.0,6
+mitchell,tanzania,"cassava, fresh",ha,page_11_table_1,terminal_collapse,1960,7000,487000,1953,69.6,8

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1437,6 +1437,38 @@ def mutate_spike_factor_rewritten(root, gpd, make_valid, affinity):
             f"rests on no longer describes the row it sits in")
 
 
+def mutate_collapse_factor_rewritten(root, gpd, make_valid, affinity):
+    """Rewrite the deepest collapse's factor to look ordinary while its two values stay put.
+
+    The mutation dodges both of the gate's headline signals on purpose. The row count per position is
+    untouched, so the bidirectional ceilings stay quiet; the source, label, item, unit, position and
+    year are untouched, so all 117 identity pins still match. What changes is the one column every
+    judgement rests on -- and the row keeps the value and neighbour_value that contradict it.
+
+    That combination is what a partially-regenerated table looks like: the shape survives, the
+    measurement rots, and nothing about the row LOOKS wrong on its own. Only check C, which
+    recomputes the ratio from the two numbers sitting beside it, can see it.
+
+    It picks the deepest collapse by factor rather than by name, since which one is deepest changes
+    when the panel is rebuilt -- the same reason the splice, spike and constant-run mutators pick by
+    measurement.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/series_collapses.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    worst = max(rows, key=lambda r: float(r["factor"]))
+    before = worst["factor"]
+    worst["factor"] = "21.0"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"rewrote the {worst['country']} / {worst['item']} {worst['year']} collapse's factor from "
+            f"{before} to 21.0 while leaving its two values alone, so the column every judgement "
+            f"rests on no longer describes the row it sits in")
+
+
 def mutate_edition_zero_reclassed(root, gpd, make_valid, affinity):
     """Move a contradicted zero into the `revised` class, where the ceiling treats it as normal.
 
@@ -2882,6 +2914,14 @@ CASES = (
         "put, so the one number every judgement here rests on contradicts the row it describes",
     ),
     (
+        "validate_series_collapses.py",
+        mutate_collapse_factor_rewritten,
+        "does not match its own values",
+        "the deepest collapse's factor rewritten to look ordinary while its two values stay put — "
+        "row counts and all 117 identity pins unchanged, so only the check that recomputes the "
+        "ratio from the numbers beside it can see the table has rotted",
+    ),
+    (
         "validate_edition_conflicts.py",
         mutate_edition_zero_reclassed,
         "is classed revised but carries a zero",
@@ -3446,6 +3486,10 @@ WRITABLE = {
     # real copy rather than a symlink into the tracked table.
     "validate_isolated_spikes.py": (
         "pipelines/polity-autoimprove/state/isolated_spikes.csv",
+    ),
+    # The case rewrites series_collapses.csv in place (it edits the factor column), so a real copy.
+    "validate_series_collapses.py": (
+        "pipelines/polity-autoimprove/state/series_collapses.csv",
     ),
     # The case rewrites edition_conflicts.csv in place (it reclassifies rows), so a real copy.
     "validate_edition_conflicts.py": (

--- a/scripts/validate_series_collapses.py
+++ b/scripts/validate_series_collapses.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Does a series COLLAPSE — one year many times below its neighbours, or below its own start/end?
+
+`validate_isolated_spikes.py` guards the opposite shape and is one-directional by construction: it
+flags a year reading >=20x ABOVE both neighbours and explicitly skips endpoints. Both choices were
+right for what it was built to catch, and together they left a hole with a CONFIRMED defect in it.
+
+`iia nauru / p` runs 275,720 / 245,040 / 424,896 for 1930-1932 and ends on **97** in 1933 — a 4,380x
+collapse in the series\' final year. It is a transposition: the iia_1933_34 volume swapped Nauru\'s and
+Australia\'s 1933 phosphate, and iia_1938_39 has them the right way round (369,500 and 100). The spike
+detector could not see it twice over: wrong sign, and an endpoint. It was found only because
+26_edition_conflicts.py compares yearbook volumes, and it is banked in state/data_errors.csv.
+
+`pipelines/polity-autoimprove/27_series_collapses.py` measures the mirror shape from the layer-B
+panel. The panel is gitignored and absent in CI, so this gate reads the committed table.
+
+WHAT THE FIRST RUN MEASURED: 117 collapses at >=20x, in three positions and **zero overlap** with the
+21 rows of `isolated_spikes.csv` — a disjoint class, not a re-detection.
+
+    interior_collapse   55   a year >=20x below BOTH neighbours; the exact mirror of a spike
+    leading_collapse    52   the first value >=20x below its only neighbour
+    terminal_collapse   10   the last value >=20x below its only neighbour
+
+    by source: iia 58, juan 37, mitchell 20, fao1952 2
+
+THE TABLE DOES NOT CLAIM ITS ROWS ARE DEFECTS, AND THAT IS A MEASURED POSITION. Of the ten terminal
+collapses, four are plausible war endings — `iia hungary / silk-worm cocoons` 236 -> 4 (1945),
+`juan hungary / castor beans` 6,000 -> 200 (1945), `iia hungary / sugar raw centrifugal`
+176,400 -> 6,500 (1945), `iia iran / castor beans` 2,600 -> 100 (1944) — while
+`mitchell china, mainland / millet` 6,524,000 -> 4,000 ha (1952) and `iia norway / no3`
+148,000 -> 130 t (1921) are not plausible at all. NO RATIO SEPARATES THEM: Hungary\'s sugar sits at
+27x and Iran\'s castor at 26x, below Tanzania\'s cassava at 70x. A threshold that happened to split
+them would be fitted to the examples in front of me, which is the error issue 406 caught. So the gate
+guards the SHAPE and leaves each verdict to whoever can check the year.
+
+Two signals:
+  A. COUNT CEILINGS  per position. Bidirectional: repairing collapses must lower them with a note,
+     so the table cannot quietly refill.
+  B. EVERY COLLAPSE  all 117 pinned by identity, so one cannot be swapped for another under a
+     constant total — the failure a count-only ceiling cannot see.
+
+Usage:
+  python3 scripts/validate_series_collapses.py
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/series_collapses.csv")
+
+# Measured 2026-08-19 on the first run. BIDIRECTIONAL: repairing a collapse must lower the matching
+# ceiling with a note saying which cell was fixed and how.
+BASELINE = {"interior_collapse": 55, "leading_collapse": 52, "terminal_collapse": 10}
+
+# The factor 27_series_collapses.py reports against, restated so the gate does not depend on the
+# generator\'s constant to know what the table means. Deliberately the same 20x
+# validate_isolated_spikes.py uses: two detectors for one phenomenon that disagreed about what
+# counts as extreme would be worse than either alone.
+COLLAPSE = 20.0
+
+POSITIONS = frozenset(BASELINE)
+
+# Every collapse on the first run. GENERATED FROM THE TABLE, never hand-typed — transcribing a
+# baseline from a truncated printout once missed 18 of 30 entries.
+BASELINE_KEYS = frozenset({
+    ('iia', 'algeria', 'flax fibre and tow', 'tonnes', 'interior_collapse', '1919'),
+    ('iia', 'algeria', 'grapes', 'ha', 'interior_collapse', '1933'),
+    ('iia', 'algeria', 'linseed', 'tonnes', 'interior_collapse', '1920'),
+    ('iia', 'algeria', 'wine', 'ha', 'interior_collapse', '1933'),
+    ('iia', 'australia', 'flax fibre and tow', 'ha', 'interior_collapse', '1923'),
+    ('iia', 'australia', 'linseed', 'ha', 'interior_collapse', '1923'),
+    ('iia', 'canada', 'eggs, hen, in shell', 'tonnes', 'interior_collapse', '1930'),
+    ('iia', 'czech republic', 'rye', 'ha', 'interior_collapse', '1943'),
+    ('iia', 'egypt', 'tangerines, mandarins, clementines, satsumas', 'tonnes', 'interior_collapse', '1939'),
+    ('iia', 'greece', 'grapes', 'tonnes', 'interior_collapse', '1937'),
+    ('iia', 'italy', 'sugar raw centrifugal', 'tonnes', 'interior_collapse', '1941'),
+    ('iia', 'japan', 'p', 'tonnes', 'interior_collapse', '1930'),
+    ('iia', 'japan', 'p', 'tonnes', 'interior_collapse', '1932'),
+    ('iia', 'libya', 'wine', 'ha', 'interior_collapse', '1933'),
+    ('iia', 'lithuania', 'sugar raw centrifugal', 'tonnes', 'interior_collapse', '1933'),
+    ('iia', 'morocco', 'wine', 'ha', 'interior_collapse', '1933'),
+    ('iia', 'panama', 'cacao, beans', 'tonnes', 'interior_collapse', '1917'),
+    ('iia', 'russian federation', 'flax fibre and tow', 'ha', 'interior_collapse', '1918'),
+    ('iia', 'russian federation', 'flax fibre and tow', 'tonnes', 'interior_collapse', '1918'),
+    ('iia', 'russian federation', 'hemp tow waste', 'ha', 'interior_collapse', '1918'),
+    ('iia', 'russian federation', 'rapeseed', 'ha', 'interior_collapse', '1914'),
+    ('iia', 'russian federation', 'rapeseed', 'tonnes', 'interior_collapse', '1914'),
+    ('iia', 'russian federation', 'rye', 'ha', 'interior_collapse', '1918'),
+    ('iia', 'russian federation', 'rye', 'tonnes', 'interior_collapse', '1918'),
+    ('iia', 'russian federation', 'rye', 'tonnes', 'interior_collapse', '1931'),
+    ('iia', 'serbia', 'rye', 'ha', 'interior_collapse', '1943'),
+    ('iia', 'syrian arab republic', 'olives', 'tonnes', 'interior_collapse', '1941'),
+    ('iia', 'tunisia', 'wine', 'ha', 'interior_collapse', '1933'),
+    ('iia', 'united states of america', 'coffee, green', 'ha', 'interior_collapse', '1924'),
+    ('iia', 'united states of america', 'coffee, green', 'tonnes', 'interior_collapse', '1933'),
+    ('juan', 'argentina', 'grapes', 'tonnes', 'interior_collapse', '1932'),
+    ('juan', 'brazil', 'figs', 'tonnes', 'interior_collapse', '1959'),
+    ('juan', 'bulgaria', 'flax fibre and tow', 'ha', 'interior_collapse', '1899'),
+    ('juan', 'bulgaria', 'linseed', 'ha', 'interior_collapse', '1899'),
+    ('juan', 'bulgaria', 'linseed', 'tonnes', 'interior_collapse', '1899'),
+    ('juan', 'bulgaria', 'rapeseed', 'ha', 'interior_collapse', '1915'),
+    ('juan', 'denmark', 'rapeseed', 'tonnes', 'interior_collapse', '1921'),
+    ('juan', 'mexico', 'sugar cane', 'ha', 'interior_collapse', '1899'),
+    ('juan', 'mexico', 'sugar cane', 'tonnes', 'interior_collapse', '1899'),
+    ('juan', 'panama', 'swine / pigs', 'heads', 'interior_collapse', '1921'),
+    ('juan', 'spain', 'canary seed', 'tonnes', 'interior_collapse', '1901'),
+    ('juan', 'spain', 'grain, mixed', 'tonnes', 'interior_collapse', '1907'),
+    ('juan', 'spain', 'linseed', 'tonnes', 'interior_collapse', '1924'),
+    ('juan', 'switzerland', 'plums and sloes', 'tonnes', 'interior_collapse', '1887'),
+    ('juan', 'switzerland', 'walnuts, with shell', 'tonnes', 'interior_collapse', '1887'),
+    ('mitchell', 'cameroon', 'coffee, green', 'tonnes', 'interior_collapse', '1941'),
+    ('mitchell', 'china, mainland', 'groundnuts, with shell', 'tonnes', 'interior_collapse', '1930'),
+    ('mitchell', 'china, mainland', 'oats', 'ha', 'interior_collapse', '1952'),
+    ('mitchell', 'india', 'asses', 'heads', 'interior_collapse', '1908'),
+    ('mitchell', 'india', 'swine / pigs', 'heads', 'interior_collapse', '1947'),
+    ('mitchell', 'india', 'tobacco, unmanufactured', 'tonnes', 'interior_collapse', '1946'),
+    ('mitchell', 'korea', 'barley', 'ha', 'interior_collapse', '1944'),
+    ('mitchell', 'nigeria', 'cattle', 'heads', 'interior_collapse', '1950'),
+    ('mitchell', 'nigeria', 'goats', 'heads', 'interior_collapse', '1950'),
+    ('mitchell', 'nigeria', 'sheep', 'heads', 'interior_collapse', '1950'),
+    ('fao1952', 'Canada', 'horses mules asses', '1000 heads', 'leading_collapse', '1931'),
+    ('fao1952', 'United Kingdom', 'horses mules asses', '1000 heads', 'leading_collapse', '1938'),
+    ('iia', 'chile', 'flax fibre and tow', 'tonnes', 'leading_collapse', '1910'),
+    ('iia', 'czech republic', 'hemp tow waste', 'ha', 'leading_collapse', '1919'),
+    ('iia', 'czech republic', 'rye', 'ha', 'leading_collapse', '1910'),
+    ('iia', 'czech republic', 'yarn of true hemp', 'tonnes', 'leading_collapse', '1919'),
+    ('iia', 'dr congo', 'cotton seed', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'ivory coast', 'cacao, beans', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'morocco', 'p', 'tonnes', 'leading_collapse', '1921'),
+    ('iia', 'mozambique', 'cotton lint', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'mozambique', 'cotton seed', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'syrian arab republic', 'cotton lint', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'syrian arab republic', 'cotton seed', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'cotton lint', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'cotton lint', 'tonnes', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'cotton seed', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'cotton seed', 'tonnes', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'tobacco, unmanufactured', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zambia', 'tobacco, unmanufactured', 'tonnes', 'leading_collapse', '1922'),
+    ('iia', 'zimbabwe', 'cotton lint', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zimbabwe', 'cotton lint', 'tonnes', 'leading_collapse', '1922'),
+    ('iia', 'zimbabwe', 'cotton seed', 'ha', 'leading_collapse', '1922'),
+    ('iia', 'zimbabwe', 'cotton seed', 'tonnes', 'leading_collapse', '1922'),
+    ('juan', 'argentina', 'artichokes', 'tonnes', 'leading_collapse', '1937'),
+    ('juan', 'argentina', 'barley', 'ha', 'leading_collapse', '1872'),
+    ('juan', 'argentina', 'fibre crops nes', 'tonnes', 'leading_collapse', '1937'),
+    ('juan', 'argentina', 'garlic', 'tonnes', 'leading_collapse', '1937'),
+    ('juan', 'argentina', 'soybeans', 'ha', 'leading_collapse', '1937'),
+    ('juan', 'argentina', 'sugar cane', 'ha', 'leading_collapse', '1872'),
+    ('juan', 'argentina', 'tea', 'ha', 'leading_collapse', '1937'),
+    ('juan', 'bulgaria', 'linseed', 'tonnes', 'leading_collapse', '1897'),
+    ('juan', 'canada', 'goats', 'heads', 'leading_collapse', '1918'),
+    ('juan', 'colombia', 'coffee, green', 'ha', 'leading_collapse', '1916'),
+    ('juan', 'czechoslovakia', 'hemp tow waste', 'tonnes', 'leading_collapse', '1919'),
+    ('juan', 'czechoslovakia', 'maize', 'tonnes', 'leading_collapse', '1919'),
+    ('juan', 'czechoslovakia', 'sunflower seed', 'ha', 'leading_collapse', '1919'),
+    ('juan', 'el salvador', 'asses', 'heads', 'leading_collapse', '1930'),
+    ('juan', 'germany', 'mules and hinnies', 'heads', 'leading_collapse', '1912'),
+    ('juan', 'haiti', 'maize', 'ha', 'leading_collapse', '1930'),
+    ('juan', 'mexico', 'oil, cottonseed', 'tonnes', 'leading_collapse', '1907'),
+    ('juan', 'peru', 'chick peas', 'tonnes', 'leading_collapse', '1948'),
+    ('juan', 'switzerland', 'apples', 'tonnes', 'leading_collapse', '1850'),
+    ('juan', 'switzerland', 'rapeseed', 'tonnes', 'leading_collapse', '1909'),
+    ('juan', 'united states of america', 'soybeans', 'ha', 'leading_collapse', '1909'),
+    ('mitchell', 'india', 'asses', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'buffalo', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'camels', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'cattle', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'goats', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'horses', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'india', 'sheep', 'heads', 'leading_collapse', '1947'),
+    ('mitchell', 'natal', 'tobacco, unmanufactured', 'tonnes', 'leading_collapse', '1861'),
+    ('iia', 'hungary', 'silk-worm cocoons, reelable', 'tonnes', 'terminal_collapse', '1945'),
+    ('iia', 'hungary', 'sugar raw centrifugal', 'tonnes', 'terminal_collapse', '1945'),
+    ('iia', 'iran', 'castor beans seed', 'tonnes', 'terminal_collapse', '1944'),
+    ('iia', 'israel', 'oranges', 'tonnes', 'terminal_collapse', '1939'),
+    ('iia', 'mauritius', 'coffee, green', 'tonnes', 'terminal_collapse', '1915'),
+    ('iia', 'nauru', 'p', 'tonnes', 'terminal_collapse', '1933'),
+    ('iia', 'norway', 'no3', 'tonnes', 'terminal_collapse', '1921'),
+    ('juan', 'hungary', 'castor beans seed', 'tonnes', 'terminal_collapse', '1945'),
+    ('mitchell', 'china, mainland', 'millet', 'ha', 'terminal_collapse', '1952'),
+    ('mitchell', 'tanzania', 'cassava, fresh', 'ha', 'terminal_collapse', '1960'),
+})
+
+
+def key(r):
+    return (r["source"], r["country"], r["item"], r["unit"], r["position"], r["year"])
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} missing — run 27_series_collapses.py --write",
+              file=sys.stderr)
+        return 1
+    with open(TABLE, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    counts = {}
+    for r in rows:
+        counts[r["position"]] = counts.get(r["position"], 0) + 1
+    print(f"series collapses: {len(rows)} (pinned {len(BASELINE_KEYS)})  "
+          + "  ".join(f"{p}={counts.get(p, 0)}/{BASELINE[p]}" for p in sorted(BASELINE)))
+
+    problems = []
+    for pos in sorted(BASELINE):
+        n = counts.get(pos, 0)
+        if n > BASELINE[pos]:
+            problems.append(
+                f"A {n} {pos} rows, above the ceiling of {BASELINE[pos]}. A year reading "
+                f">={COLLAPSE:.0f}x below its neighbours is a dropped digit, a misaligned column or a "
+                f"transposed pair until someone shows it is a real collapse")
+        elif n < BASELINE[pos]:
+            problems.append(
+                f"A only {n} {pos} rows remain, below the pinned ceiling of {BASELINE[pos]} — lower "
+                f"the baseline and say which cells were repaired and on what evidence")
+    for pos in sorted(set(counts) - POSITIONS):
+        problems.append(f"A unknown position {pos!r} — generator and gate disagree about the vocabulary")
+
+    seen = {key(r) for r in rows}
+    for k in sorted(seen - BASELINE_KEYS):
+        problems.append(
+            f"B NEW {k[4]}: {k[1]} / {k[2]} ({k[3]}) at {k[5]}, {k[0]} — reads >={COLLAPSE:.0f}x below "
+            f"its neighbour(s) and is not pinned")
+    for k in sorted(BASELINE_KEYS - seen):
+        problems.append(
+            f"B {k[1]} / {k[2]} at {k[5]} is pinned as a {k[4]} but is not one any more — remove its "
+            f"entry, saying what was repaired")
+
+    # A row whose recorded factor contradicts its own two values means the table and this gate
+    # disagree about what the row says, and every judgement above rests on that column.
+    for r in rows:
+        try:
+            v, nb, f = float(r["value"]), float(r["neighbour_value"]), float(r["factor"])
+        except ValueError:
+            problems.append(f"C {r['country']}/{r['item']} {r['year']}: unparseable numbers")
+            continue
+        if v <= 0:
+            problems.append(f"C {r['country']}/{r['item']} {r['year']}: value {v:g} is not positive, "
+                            f"so the ratio is undefined and the row should not exist")
+            continue
+        if abs(nb / v - f) > max(0.05, f * 1e-3):
+            problems.append(
+                f"C {r['country']}/{r['item']} {r['year']}: recorded factor {f:g} does not match its "
+                f"own values ({nb:g} / {v:g} = {nb / v:.1f}) — the column every judgement rests on no "
+                f"longer describes the row it sits in")
+        if f < COLLAPSE:
+            problems.append(
+                f"C {r['country']}/{r['item']} {r['year']}: factor {f:g} is below the {COLLAPSE:.0f}x "
+                f"threshold the table is defined by")
+
+    for p in problems:
+        print(f"FAIL: {p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`18_isolated_spikes.py` is one-directional by construction — it flags a year reading **≥20× above** both neighbours — and it explicitly skips endpoints because they have only one. Both choices were right for what it was built to catch. Together they left a hole **with a confirmed defect sitting in it**.

`iia nauru / p` runs 275,720 / 245,040 / 424,896 for 1930–1932 and ends on **97** in 1933: the `iia_1933_34` volume swapped Nauru's and Australia's phosphate, and `iia_1938_39` has them the right way round (369,500 and 100). **Wrong sign *and* an endpoint**, so the spike detector missed it twice over. It was found only because `26_edition_conflicts.py` compares yearbook volumes (#418).

```
series collapses >=20x          117
  interior_collapse              55    a year >=20x below BOTH neighbours
  leading_collapse               52    first value below its only neighbour
  terminal_collapse              10    last value below its only neighbour
  by source: iia 58, juan 37, mitchell 20, fao1952 2
```

**Zero of the 117 appear in `isolated_spikes.csv`** — a disjoint class, not a re-detection.

## The table does not claim its rows are defects, and that is measured rather than cautious

Of the ten terminal collapses, **four are plausible war endings**:

| series | | year |
|---|---|---|
| hungary / silk-worm cocoons | 236 → 4 | 1945 |
| hungary / castor beans | 6,000 → 200 | 1945 |
| hungary / sugar raw centrifugal | 176,400 → 6,500 | 1945 |
| iran / castor beans | 2,600 → 100 | 1944 |

Meanwhile `mitchell china / millet` 6,524,000 → 4,000 ha (1952) and `iia norway / no3` 148,000 → 130 t (1921) are not plausible at all.

**No ratio separates those groups.** Hungary's sugar sits at 27× and Iran's castor at 26×, *below* Tanzania's cassava at 70× which is not obviously war-related. A threshold that happened to split them would be fitted to the examples in front of me — the error #406 caught me making. So the gate guards the **shape** and leaves each verdict to whoever can check the year. What it guarantees is that the shape can no longer appear silently.

## Design notes

- **Deliberately the same 20× factor** as the spike detector: two detectors for one phenomenon that disagreed about what counts as extreme would be worse than either alone.
- `indicator` is in the series key — without it fao1952 packs several indicators under one item code and the comparison is between indicators rather than years.
- Unorderable series (#367) are skipped, not guessed at; zero/negative values excluded, since a drop **to** zero is #414's separate concern.

## Selftest

Rewrites the deepest collapse's factor to `21.0` while leaving its two values in place: row counts and all 117 identity pins stay valid, so **only** check C — which recomputes the ratio from the numbers beside it — can see the table has rotted.

**69 gates, 81 selftest cases, all pass.**

*PR opened by Claude.*