### PR TITLE
A series that drops to zero and stays there was invisible to every detector

### DIFF
--- a/pipelines/polity-autoimprove/27_series_collapses.py
+++ b/pipelines/polity-autoimprove/27_series_collapses.py
@@ -33,10 +33,31 @@ discriminate (Hungary's sugar collapse at 27x and Iran's castor at 26x sit below
 at 70x, which is not obviously war-related), so the table records the SHAPE and leaves the verdict to
 whoever can check the year. What it guarantees is that the shape can no longer appear silently.
 
+DROPS TO ZERO ARE A FOURTH AND FIFTH POSITION, added 2026-08-19. The first version of this tool
+excluded zeros entirely, deferring them to issue 414 -- and that deferral was wrong, because 414's
+tables cannot reach them: edition_conflicts.csv needs two volumes and only 1933 has them, and
+impossible_pairs.csv needs a paired area. A series that drops to zero and stays there was therefore
+invisible to EVERY detector here, including 17_constant_runs.py, which excludes zeros for the same
+reason. Measured: 81 zero tails and 42 isolated interior zeros.
+
+    zero_tail       a series ending in >=2 consecutive zeros after real output. `juan united
+                    kingdom / mules and hinnies` reads 0.0 for EVERY year 1921-1938 while the same
+                    source and label report asses (10,000 falling to 7,000) and horses (2,055,000
+                    to 1,100,000) throughout -- so the source is reporting draught animals and not
+                    reporting mules, and the zero means "not stated", not "none exist".
+    zero_interior   a single zero with real output on both sides.
+
+68 of the 81 tails begin in 1933-1936, which is the `iia_1938_39` window -- so most of this class is
+issue 414's blank-read-as-0 appearing as a RUN rather than a cell. The rest are not: the UK mules
+run starts in 1921, and `latvia` and `lithuania` sugar beet go to zero in 1940 when both states were
+annexed, where 0 most likely means reported inside Soviet statistics instead.
+
+NO RATIO IS RECORDED for these two positions, because there is none: `factor` is left empty rather
+than filled with a sentinel that later arithmetic might believe.
+
 UNORDERABLE SERIES ARE SKIPPED, not guessed at: 342 series carry two rows for one year with nothing
 in the panel to order them (issue 367), and a series with no defined neighbour has no collapse.
-Zero and negative values are excluded -- a ratio against zero is undefined, and a drop TO zero is the
-separate concern issue 414 measures.
+Negative values are excluded throughout.
 
 WHY A TRACKED TABLE. The panel is gitignored and absent in CI, so this writes
 `state/series_collapses.csv`, that file is committed, and the gate reads it -- the same arrangement as
@@ -80,7 +101,7 @@ def build(panel_path: str) -> list[dict]:
 
     d = pd.read_parquet(panel_path)
     d = d.dropna(subset=["year", "value"])
-    d = d[d["value"] > 0]
+    d = d[d["value"] >= 0]
     out = []
     for k, g in d.groupby(KEY, dropna=False):
         g = g.sort_values("year")
@@ -99,11 +120,36 @@ def build(panel_path: str) -> list[dict]:
                         "neighbour_value": f"{v[nb_i]:g}", "neighbour_year": y[nb_i],
                         "factor": f"{v[nb_i] / v[i]:.1f}", "series_n": len(v)})
 
-        if v[-2] / v[-1] >= COLLAPSE:
+        # --- zero positions, which carry no ratio ---
+        tail = 0
+        for x in reversed(v):
+            if x == 0:
+                tail += 1
+            else:
+                break
+        if tail >= 2 and any(x > 0 for x in v[:len(v) - tail]):
+            i = len(v) - tail
+            out.append({**base, "position": "zero_tail", "year": y[i],
+                        "value": "0", "neighbour_value": f"{v[i - 1]:g}",
+                        "neighbour_year": y[i - 1], "factor": "", "series_n": len(v)})
+        for i in range(1, len(v) - 1):
+            if v[i] == 0 and v[i - 1] > 0 and v[i + 1] > 0:
+                out.append({**base, "position": "zero_interior", "year": y[i],
+                            "value": "0", "neighbour_value": f"{min(v[i - 1], v[i + 1]):g}",
+                            "neighbour_year": y[i - 1], "factor": "", "series_n": len(v)})
+
+        # --- ratio positions ---
+        # Positivity is required PER CELL, not per series. Skipping any series that contains a zero
+        # anywhere would discard legitimate collapses elsewhere in it (8 of them), and the earlier
+        # `value > 0` filter was worse still: it DELETED the zero rows, making non-adjacent years
+        # look adjacent and inventing neighbours that are not neighbours.
+        if v[-1] > 0 and v[-2] > 0 and v[-2] / v[-1] >= COLLAPSE:
             emit("terminal_collapse", len(v) - 1, len(v) - 2)
-        if v[1] / v[0] >= COLLAPSE:
+        if v[0] > 0 and v[1] > 0 and v[1] / v[0] >= COLLAPSE:
             emit("leading_collapse", 0, 1)
         for i in range(1, len(v) - 1):
+            if v[i] <= 0 or v[i - 1] <= 0 or v[i + 1] <= 0:
+                continue
             if v[i - 1] / v[i] >= COLLAPSE and v[i + 1] / v[i] >= COLLAPSE:
                 # Report against the SMALLER neighbour, so `factor` is the weakest claim the row
                 # supports rather than the most impressive one.

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -393,6 +393,26 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        while mitchell china millet 6,524,000->4,000 ha (1952) is not. NO RATIO
                        SEPARATES THEM — hungary's sugar is 27x, below tanzania's cassava at 70x — so
                        inventing a threshold would fit it to the examples at hand (issue 406).
+                       TWO ZERO CLASSES ADDED 2026-08-19 because nothing could see them. This tool
+                       first excluded zeros, deferring them to issue 414 — wrongly:
+                       edition_conflicts.csv needs two volumes (only 1933 has them) and
+                       impossible_pairs.csv needs a paired area, and 17_constant_runs.py excludes
+                       zeros for the same divide-by-zero reason. A series dropping to zero and
+                       staying there was invisible to EVERY detector here. 81 zero_tail + 42
+                       zero_interior. `juan united kingdom / mules and hinnies` reads 0.0 for every
+                       year 1921-1938 while the SAME source and label report asses (10,000->7,000)
+                       and horses (2,055,000->1,100,000) throughout — the zero means "not stated".
+                       68 of the 81 tails start in 1933-1936, the iia_1938_39 window, so most of
+                       this class is issue 414's blank-read-as-0 appearing as a RUN.
+                       LEGITIMATE ZEROS ARE EXCLUDED BY CONSTRUCTION: a series that OPENS at zero is
+                       in neither class — `iia morocco / p` is zero for 1909-1918 because Moroccan
+                       phosphate mining had not begun.
+                       AND THE OLD FILTER FABRICATED A ROW, not just hid them: deleting zero rows
+                       promoted morocco's first POSITIVE value to the head of its series and
+                       reported a leading_collapse between two years that were not the start at all.
+                       leading_collapse 52 -> 51 on the fix. No ratio is recorded for the zero
+                       classes; `factor` is left EMPTY rather than given a sentinel later
+                       arithmetic might believe.
                        --write refreshes state/series_collapses.csv
                        in CI, since the panel is gitignored. Does NOT decide the cause of any
                        one seam: unit mismatch, different coverage and different item definitions

--- a/pipelines/polity-autoimprove/state/series_collapses.csv
+++ b/pipelines/polity-autoimprove/state/series_collapses.csv
@@ -3,17 +3,17 @@ iia,algeria,flax fibre and tow,tonnes,,interior_collapse,1919,0.1,100,1920,1000.
 iia,algeria,grapes,ha,,interior_collapse,1933,4360,173545,1921,39.8,24
 iia,algeria,linseed,tonnes,,interior_collapse,1920,1.4,120,1921,85.7,18
 iia,algeria,wine,ha,,interior_collapse,1933,373,351952,1932,943.6,20
-iia,australia,flax fibre and tow,ha,,interior_collapse,1923,2,53,1924,26.5,18
+iia,australia,flax fibre and tow,ha,,interior_collapse,1923,2,53,1924,26.5,24
 iia,australia,linseed,ha,,interior_collapse,1923,2,53,1924,26.5,6
 iia,canada,"eggs, hen, in shell",tonnes,,interior_collapse,1930,148.764,146659,1929,985.8,17
 iia,czech republic,rye,ha,,interior_collapse,1943,26000,861000,1942,33.1,24
 iia,egypt,"tangerines, mandarins, clementines, satsumas",tonnes,,interior_collapse,1939,2600,55100,1940,21.2,11
-iia,greece,grapes,tonnes,,interior_collapse,1937,3300,672500,1938,203.8,7
+iia,greece,grapes,tonnes,,interior_collapse,1937,3300,672500,1938,203.8,10
 iia,italy,sugar raw centrifugal,tonnes,,interior_collapse,1941,8000,372300,1942,46.5,33
 iia,japan,p,tonnes,,interior_collapse,1930,305,97340,1920,319.1,16
 iia,japan,p,tonnes,,interior_collapse,1932,23804,862401,1931,36.2,16
 iia,libya,wine,ha,,interior_collapse,1933,12,1000,1934,83.3,6
-iia,lithuania,sugar raw centrifugal,tonnes,,interior_collapse,1933,8.1,13700,1934,1691.4,9
+iia,lithuania,sugar raw centrifugal,tonnes,,interior_collapse,1933,8.1,13700,1934,1691.4,15
 iia,morocco,wine,ha,,interior_collapse,1933,113,8600,1932,76.1,12
 iia,panama,"cacao, beans",tonnes,,interior_collapse,1917,4.5,116.8,1918,26.0,23
 iia,russian federation,flax fibre and tow,ha,,interior_collapse,1918,20,730438,1920,36521.9,26
@@ -62,15 +62,14 @@ iia,czech republic,rye,ha,,leading_collapse,1910,3,732970,1919,244323.3,24
 iia,czech republic,yarn of true hemp,tonnes,,leading_collapse,1919,326.5,8489.1,1920,26.0,15
 iia,dr congo,cotton seed,ha,,leading_collapse,1922,5,7500,1923,1500.0,19
 iia,ivory coast,"cacao, beans",ha,,leading_collapse,1922,1000,50000,1930,50.0,14
-iia,morocco,p,tonnes,,leading_collapse,1921,8232,1.85e+06,1930,224.7,5
 iia,mozambique,cotton lint,ha,,leading_collapse,1922,53,11809,1923,222.8,11
 iia,mozambique,cotton seed,ha,,leading_collapse,1922,53,11809,1923,222.8,6
 iia,syrian arab republic,cotton lint,ha,,leading_collapse,1922,1320,28650,1924,21.7,19
 iia,syrian arab republic,cotton seed,ha,,leading_collapse,1922,1320,28650,1924,21.7,19
-iia,zambia,cotton lint,ha,,leading_collapse,1922,3,943,1923,314.3,6
-iia,zambia,cotton lint,tonnes,,leading_collapse,1922,0.1,86.1,1923,861.0,6
-iia,zambia,cotton seed,ha,,leading_collapse,1922,3,943,1923,314.3,6
-iia,zambia,cotton seed,tonnes,,leading_collapse,1922,0.2,201,1923,1005.0,6
+iia,zambia,cotton lint,ha,,leading_collapse,1922,3,943,1923,314.3,7
+iia,zambia,cotton lint,tonnes,,leading_collapse,1922,0.1,86.1,1923,861.0,7
+iia,zambia,cotton seed,ha,,leading_collapse,1922,3,943,1923,314.3,7
+iia,zambia,cotton seed,tonnes,,leading_collapse,1922,0.2,201,1923,1005.0,7
 iia,zambia,"tobacco, unmanufactured",ha,,leading_collapse,1922,29,1401,1923,48.3,11
 iia,zambia,"tobacco, unmanufactured",tonnes,,leading_collapse,1922,8.6,517,1923,60.1,17
 iia,zimbabwe,cotton lint,ha,,leading_collapse,1922,8,1597,1923,199.6,16
@@ -116,3 +115,126 @@ iia,norway,no3,tonnes,,terminal_collapse,1921,130,148000,1920,1138.5,13
 juan,hungary,castor beans seed,tonnes,,terminal_collapse,1945,200,6000,1943,30.0,4
 mitchell,"china, mainland",millet,ha,page_35_table_1,terminal_collapse,1952,4000,6.524e+06,1951,1631.0,6
 mitchell,tanzania,"cassava, fresh",ha,page_11_table_1,terminal_collapse,1960,7000,487000,1953,69.6,8
+iia,algeria,"beans, dry",ha,,zero_interior,1938,0,1000,1937,,11
+iia,algeria,cotton lint,tonnes,,zero_interior,1935,0,4.5,1933,,25
+iia,algeria,cotton lint,tonnes,,zero_interior,1938,0,100,1936,,25
+iia,algeria,cotton seed,tonnes,,zero_interior,1935,0,9,1933,,17
+iia,algeria,cotton seed,tonnes,,zero_interior,1938,0,100,1937,,17
+iia,antigua and barbuda,cotton lint,tonnes,,zero_interior,1934,0,1.2,1933,,23
+iia,antigua and barbuda,cotton lint,tonnes,,zero_interior,1936,0,100,1935,,23
+iia,bulgaria,sugar raw centrifugal,tonnes,,zero_interior,1925,0,40396.8,1924,,33
+iia,canada,p,tonnes,,zero_interior,1920,0,22,1919,,17
+iia,canada,p,tonnes,,zero_interior,1931,0,36,1930,,17
+iia,cyprus,flax fibre and tow,ha,,zero_interior,1938,0,1000,1937,,13
+iia,cyprus,flax fibre and tow,tonnes,,zero_interior,1938,0,800,1937,,15
+iia,cyprus,yarn of true hemp,tonnes,,zero_interior,1934,0,42.8,1933,,9
+iia,egypt,flax fibre and tow,ha,,zero_interior,1913,0,381,1912,,29
+iia,falkland islands (malvinas),"fertilizer, mixed",tonnes,,zero_interior,1918,0,606,1917,,6
+iia,germany,yarn of true hemp,ha,,zero_interior,1934,0,210,1933,,9
+iia,indonesia,p,tonnes,,zero_interior,1918,0,3582,1917,,12
+iia,kenya,"beans, dry",ha,,zero_interior,1938,0,1000,1936,,9
+iia,kenya,flax fibre and tow,ha,,zero_interior,1935,0,1000,1933,,7
+iia,kenya,"groundnuts, with shell",tonnes,,zero_interior,1934,0,300,1933,,17
+iia,libya,"oil, olive, virgin",tonnes,,zero_interior,1935,0,1600,1934,,18
+iia,malawi,cotton lint,ha,,zero_interior,1937,0,1000,1936,,30
+iia,malawi,cotton seed,ha,,zero_interior,1937,0,1000,1936,,19
+iia,montserrat,lemons and limes,ha,,zero_interior,1934,0,200,1933,,6
+iia,montserrat,sugar raw centrifugal,tonnes,,zero_interior,1937,0,100,1936,,14
+iia,morocco,cotton lint,tonnes,,zero_interior,1934,0,30,1933,,9
+iia,morocco,cotton lint,tonnes,,zero_interior,1940,0,100,1939,,9
+iia,morocco,cotton seed,tonnes,,zero_interior,1934,0,60,1933,,10
+iia,myanmar,sesame seed,ha,,zero_interior,1944,0,419000,1943,,12
+iia,new caledonia,p,tonnes,,zero_interior,1932,0,4361,1931,,4
+iia,palau,p,tonnes,,zero_interior,1913,0,60000,1912,,13
+iia,portugal,n,tonnes,,zero_interior,1920,0,5,1919,,8
+iia,saint lucia,lemons and limes,ha,,zero_interior,1933,0,1000,1932,,13
+iia,serbia,lemons and limes,tonnes,,zero_interior,1936,0,100,1935,,6
+iia,somalia,sesame seed,ha,,zero_interior,1935,0,5000,1934,,5
+iia,sri lanka,cotton seed,tonnes,,zero_interior,1933,0,100,1925,,11
+iia,switzerland,sugar raw centrifugal,tonnes,,zero_interior,1912,0,3477.4,1911,,33
+iia,vanuatu,cotton seed,tonnes,,zero_interior,1933,0,100,1932,,12
+iia,vanuatu,cotton seed,tonnes,,zero_interior,1936,0,100,1935,,12
+juan,czechoslovakia,asses,heads,,zero_interior,1935,0,1000,1934,,19
+juan,iceland,goats,heads,,zero_interior,1945,0,1000,1944,,103
+juan,iceland,goats,heads,,zero_interior,1948,0,1000,1947,,103
+fao1952,Germany Berlin,milk,1000 tonnes,livestock:production,zero_tail,1950,0,38,1949,,4
+fao1952,Germany Eastern,milk,1000 tonnes,livestock:production,zero_tail,1950,0,2358,1949,,4
+iia,algeria,"silk-worm cocoons, reelable",tonnes,,zero_tail,1933,0,0.22,1931,,14
+iia,australia,"coffee, green",ha,,zero_tail,1933,0,4,1932,,21
+iia,australia,"coffee, green",tonnes,,zero_tail,1933,0,1.9,1932,,21
+iia,australia,olives,ha,,zero_tail,1933,0,138,1932,,8
+iia,austria,soybeans,ha,,zero_tail,1934,0,96,1931,,5
+iia,austria,yarn of true hemp,ha,,zero_tail,1934,0,310,1933,,13
+iia,barbados,cotton lint,ha,,zero_tail,1934,0,25,1933,,24
+iia,barbados,cotton lint,tonnes,,zero_tail,1934,0,0.7,1933,,23
+iia,barbados,cotton seed,ha,,zero_tail,1934,0,25,1933,,12
+iia,belgium,hempseed,ha,,zero_tail,1934,0,17,1933,,10
+iia,belgium,rapeseed,ha,,zero_tail,1934,0,70,1933,,8
+iia,belgium,yarn of true hemp,ha,,zero_tail,1934,0,17,1933,,13
+iia,benin,"cacao, beans",ha,,zero_tail,1934,0,100,1933,,7
+iia,burundi,"tobacco, unmanufactured",ha,,zero_tail,1934,0,450,1933,,7
+iia,"china, taiwan province of",other berries and fruits of the genus vaccinium n.e.c.,ha,,zero_tail,1936,0,1000,1935,,8
+iia,"china, taiwan province of",rapeseed,ha,,zero_tail,1934,0,308,1933,,17
+iia,costa rica,lemons and limes,tonnes,,zero_tail,1931,0,1.1,1930,,7
+iia,cyprus,hempseed,ha,,zero_tail,1934,0,71,1933,,9
+iia,cyprus,hempseed,tonnes,,zero_tail,1934,0,13.4,1933,,9
+iia,cyprus,yarn of true hemp,ha,,zero_tail,1934,0,71,1933,,9
+iia,dominican republic,cotton seed,tonnes,,zero_tail,1933,0,22,1930,,5
+iia,ecuador,lemons and limes,tonnes,,zero_tail,1934,0,130,1930,,4
+iia,eritrea,"groundnuts, with shell",ha,,zero_tail,1936,0,1000,1935,,5
+iia,eritrea,"groundnuts, with shell",tonnes,,zero_tail,1936,0,200,1935,,5
+iia,eritrea,"tobacco, unmanufactured",ha,,zero_tail,1934,0,50,1933,,8
+iia,eswatini,"tobacco, unmanufactured",ha,,zero_tail,1933,0,223,1932,,8
+iia,fiji,cotton lint,ha,,zero_tail,1933,0,256,1932,,17
+iia,fiji,cotton lint,tonnes,,zero_tail,1933,0,16.4,1932,,8
+iia,fiji,cotton seed,ha,,zero_tail,1933,0,256,1932,,8
+iia,fiji,cotton seed,tonnes,,zero_tail,1933,0,49,1932,,8
+iia,french guiana,"cacao, beans",ha,,zero_tail,1933,0,383,1922,,5
+iia,french guiana,"cacao, beans",tonnes,,zero_tail,1933,0,5.9,1931,,11
+iia,french polynesia,"tobacco, unmanufactured",ha,,zero_tail,1934,0,30,1933,,8
+iia,greece,grapes,tonnes,,zero_tail,1941,0,619900,1939,,10
+iia,guadeloupe,cotton lint,ha,,zero_tail,1934,0,300,1933,,14
+iia,guadeloupe,cotton lint,tonnes,,zero_tail,1934,0,9,1933,,12
+iia,guadeloupe,cotton seed,ha,,zero_tail,1934,0,300,1933,,10
+iia,guatemala,cotton lint,tonnes,,zero_tail,1933,0,3,1932,,4
+iia,guatemala,"groundnuts, with shell",ha,,zero_tail,1934,0,28,1933,,6
+iia,guyana,lemons and limes,ha,,zero_tail,1934,0,352,1933,,6
+iia,india,cotton lint,ha,,zero_tail,1934,0,9.60688e+06,1933,,25
+iia,india,cotton seed,ha,,zero_tail,1936,0,5000,1935,,12
+iia,latvia,sugar raw centrifugal,tonnes,,zero_tail,1940,0,36000,1939,,16
+iia,libya,"tobacco, unmanufactured",ha,,zero_tail,1934,0,221,1933,,7
+iia,lithuania,sugar raw centrifugal,tonnes,,zero_tail,1940,0,21600,1939,,15
+iia,madagascar,cotton lint,ha,,zero_tail,1934,0,70,1933,,6
+iia,madagascar,cotton lint,tonnes,,zero_tail,1933,0,9,1931,,4
+iia,madagascar,cotton seed,ha,,zero_tail,1934,0,70,1933,,6
+iia,malawi,"coffee, green",tonnes,,zero_tail,1936,0,100,1935,,22
+iia,malta,cotton lint,ha,,zero_tail,1934,0,25,1933,,26
+iia,malta,cotton lint,tonnes,,zero_tail,1934,0,5.7,1933,,8
+iia,malta,cotton seed,ha,,zero_tail,1934,0,25,1933,,13
+iia,malta,cotton seed,tonnes,,zero_tail,1934,0,17,1933,,13
+iia,mauritius,"groundnuts, with shell",ha,,zero_tail,1934,0,40,1933,,11
+iia,mauritius,"tobacco, unmanufactured",ha,,zero_tail,1933,0,842,1932,,16
+iia,netherlands,"tobacco, unmanufactured",ha,,zero_tail,1934,0,21,1933,,8
+iia,new caledonia,cotton lint,ha,,zero_tail,1935,0,773,1933,,4
+iia,new caledonia,cotton lint,tonnes,,zero_tail,1935,0,10,1932,,6
+iia,new caledonia,cotton seed,ha,,zero_tail,1935,0,773,1933,,4
+iia,new caledonia,cotton seed,tonnes,,zero_tail,1934,0,30,1932,,7
+iia,new zealand,grapes,ha,,zero_tail,1933,0,75,1920,,16
+iia,new zealand,rye,ha,,zero_tail,1934,0,105,1933,,14
+iia,new zealand,wine,ha,,zero_tail,1933,0,132,1932,,10
+iia,nigeria,cotton lint,ha,,zero_tail,1939,0,236482,1924,,9
+iia,paraguay,lemons and limes,tonnes,,zero_tail,1933,0,1,1931,,6
+iia,portugal,lemons and limes,tonnes,,zero_tail,1933,0,4,1932,,8
+iia,saint vincent and the grenadines,"groundnuts, with shell",ha,,zero_tail,1934,0,60,1933,,7
+iia,south korea,sugar raw centrifugal,tonnes,,zero_tail,1932,0,1500.1,1931,,8
+iia,tunisia,"tobacco, unmanufactured",ha,,zero_tail,1935,0,1000,1934,,25
+iia,uruguay,rye,ha,,zero_tail,1935,0,58,1910,,4
+iia,vanuatu,cotton lint,ha,,zero_tail,1934,0,1821,1923,,5
+iia,vanuatu,cotton seed,ha,,zero_tail,1934,0,1821,1923,,5
+iia,zambia,"groundnuts, with shell",ha,,zero_tail,1933,0,382,1932,,10
+iia,zambia,oranges,ha,,zero_tail,1933,0,109,1932,,8
+juan,iceland,ducks,heads,,zero_tail,1948,0,1000,1947,,29
+juan,iceland,geese and guinea fowls,heads,,zero_tail,1948,0,1000,1947,,29
+juan,iceland,goats,heads,,zero_tail,1950,0,1000,1949,,103
+juan,switzerland,asses,heads,,zero_tail,1943,0,3000,1942,,14
+juan,united kingdom,mules and hinnies,heads,,zero_tail,1921,0,272000,1910,,28

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1437,6 +1437,38 @@ def mutate_spike_factor_rewritten(root, gpd, make_valid, affinity):
             f"rests on no longer describes the row it sits in")
 
 
+def mutate_zero_tail_given_a_factor(root, gpd, make_valid, affinity):
+    """Fill in a factor on a zero-position row, where no ratio exists.
+
+    The two zero classes deliberately leave `factor` EMPTY: there is no ratio against zero, and a
+    sentinel there is worse than a blank because later arithmetic might believe it. This mutation
+    writes a plausible-looking number into that column.
+
+    It dodges every other signal: the row count per position is unchanged so all five ceilings pass,
+    the identity tuple (source, country, item, unit, position, year) is untouched so all 239 pins
+    match, and the row still sits at value 0 so the zero-shape arm stays quiet. Only the arm that
+    forbids a ratio where none can exist can see it.
+
+    Picks the longest-running zero tail by series length rather than by name, since which one is
+    longest changes when the panel is rebuilt — the same reason the splice, spike and constant-run
+    mutators pick by measurement.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/series_collapses.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = max((r for r in rows if r["position"] == "zero_tail"),
+                 key=lambda r: int(r["series_n"]))
+    victim["factor"] = "999.0"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"gave the {victim['country']} / {victim['item']} {victim['year']} zero tail a factor of "
+            f"999.0, a ratio against zero that cannot exist, while its count, its identity pin and "
+            f"its zero value all stay as they were")
+
+
 def mutate_impossible_pair_area_filled(root, gpd, make_valid, affinity):
     """Give an impossible pair a nonzero area, the state the old divide-by-zero filter produced.
 
@@ -1486,7 +1518,8 @@ def mutate_collapse_factor_rewritten(root, gpd, make_valid, affinity):
     with open(path, newline="", encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
         fields = list(rows[0])
-    worst = max(rows, key=lambda r: float(r["factor"]))
+    # The zero positions carry no factor at all, so they cannot be the victim of a factor rewrite.
+    worst = max((r for r in rows if r["factor"]), key=lambda r: float(r["factor"]))
     before = worst["factor"]
     worst["factor"] = "21.0"
     with open(path, "w", newline="", encoding="utf-8") as fh:
@@ -2941,6 +2974,14 @@ CASES = (
         "does not match its own values",
         "a recorded spike's factor column rewritten to look ordinary while its three values stay "
         "put, so the one number every judgement here rests on contradicts the row it describes",
+    ),
+    (
+        "validate_series_collapses.py",
+        mutate_zero_tail_given_a_factor,
+        "there is no ratio against zero",
+        "a zero-position row given a fabricated ratio — all five ceilings, all 239 identity pins and "
+        "the zero value itself left intact, so only the arm forbidding a measurement where none can "
+        "exist can see it",
     ),
     (
         "validate_yield_corrections.py",

--- a/scripts/validate_series_collapses.py
+++ b/scripts/validate_series_collapses.py
@@ -14,14 +14,33 @@ detector could not see it twice over: wrong sign, and an endpoint. It was found 
 `pipelines/polity-autoimprove/27_series_collapses.py` measures the mirror shape from the layer-B
 panel. The panel is gitignored and absent in CI, so this gate reads the committed table.
 
-WHAT THE FIRST RUN MEASURED: 117 collapses at >=20x, in three positions and **zero overlap** with the
-21 rows of `isolated_spikes.csv` — a disjoint class, not a re-detection.
+WHAT IT MEASURES: 239 rows in five positions, with **zero overlap** with the 21 rows of
+`isolated_spikes.csv` — a disjoint class, not a re-detection.
 
     interior_collapse   55   a year >=20x below BOTH neighbours; the exact mirror of a spike
-    leading_collapse    52   the first value >=20x below its only neighbour
+    leading_collapse    51   the first value >=20x below its only neighbour
     terminal_collapse   10   the last value >=20x below its only neighbour
+    zero_tail           81   a series ending in >=2 zeros after real output
+    zero_interior       42   a single zero with real output on both sides
 
-    by source: iia 58, juan 37, mitchell 20, fao1952 2
+THE TWO ZERO CLASSES WERE ADDED BECAUSE NOTHING COULD SEE THEM. This tool first excluded zeros,
+deferring them to issue 414 — and that deferral was wrong: `edition_conflicts.csv` needs two volumes
+and only 1933 has them, and `impossible_pairs.csv` needs a paired area. `17_constant_runs.py`
+excludes zeros too, for the same divide-by-zero reason. So a series that dropped to zero and stayed
+there was invisible to EVERY detector in this repo.
+
+`juan united kingdom / mules and hinnies` reads 0.0 for every year 1921-1938 while the SAME source
+and label report asses (10,000 falling to 7,000) and horses (2,055,000 to 1,100,000) throughout. The
+source is reporting draught animals and not reporting mules; the zero means "not stated".
+
+68 of the 81 tails begin in 1933-1936 — the `iia_1938_39` window — so most of this class is issue
+414's blank-read-as-0 appearing as a RUN rather than a cell. The rest are not: the UK mules run
+starts in 1921, and `latvia` and `lithuania` sugar beet go to zero in 1940, when both were annexed
+and their output would be reported inside Soviet statistics instead.
+
+LEGITIMATE ZEROS ARE EXCLUDED BY CONSTRUCTION, not by judgement. A series that OPENS at zero is in
+neither class: `iia morocco / p` reads zero for 1909-1918 because Moroccan phosphate mining had not
+begun, and a leading run of zeros is exactly what that should look like.
 
 THE TABLE DOES NOT CLAIM ITS ROWS ARE DEFECTS, AND THAT IS A MEASURED POSITION. Of the ten terminal
 collapses, four are plausible war endings — `iia hungary / silk-worm cocoons` 236 -> 4 (1945),
@@ -51,9 +70,16 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/series_collapses.csv")
 
-# Measured 2026-08-19 on the first run. BIDIRECTIONAL: repairing a collapse must lower the matching
-# ceiling with a note saying which cell was fixed and how.
-BASELINE = {"interior_collapse": 55, "leading_collapse": 52, "terminal_collapse": 10}
+# Measured 2026-08-19. BIDIRECTIONAL: repairing a collapse must lower the matching ceiling with a
+# note saying which cell was fixed and how.
+#
+# `leading_collapse` fell from 52 to 51 when the generator stopped deleting zero rows before
+# comparing. `iia morocco / p` opens with TEN zeros (1909-1918, before Moroccan phosphate mining
+# began, so they are legitimate); the old `value > 0` filter removed them, promoted the first
+# POSITIVE value to the head of the series, and reported a leading collapse between two years that
+# were not the series start at all. That row was FABRICATED by the filter, not merely hidden by it.
+BASELINE = {"interior_collapse": 55, "leading_collapse": 51, "terminal_collapse": 10,
+            "zero_tail": 81, "zero_interior": 42}
 
 # The factor 27_series_collapses.py reports against, restated so the gate does not depend on the
 # generator\'s constant to know what the table means. Deliberately the same 20x
@@ -129,7 +155,6 @@ BASELINE_KEYS = frozenset({
     ('iia', 'czech republic', 'yarn of true hemp', 'tonnes', 'leading_collapse', '1919'),
     ('iia', 'dr congo', 'cotton seed', 'ha', 'leading_collapse', '1922'),
     ('iia', 'ivory coast', 'cacao, beans', 'ha', 'leading_collapse', '1922'),
-    ('iia', 'morocco', 'p', 'tonnes', 'leading_collapse', '1921'),
     ('iia', 'mozambique', 'cotton lint', 'ha', 'leading_collapse', '1922'),
     ('iia', 'mozambique', 'cotton seed', 'ha', 'leading_collapse', '1922'),
     ('iia', 'syrian arab republic', 'cotton lint', 'ha', 'leading_collapse', '1922'),
@@ -183,6 +208,129 @@ BASELINE_KEYS = frozenset({
     ('juan', 'hungary', 'castor beans seed', 'tonnes', 'terminal_collapse', '1945'),
     ('mitchell', 'china, mainland', 'millet', 'ha', 'terminal_collapse', '1952'),
     ('mitchell', 'tanzania', 'cassava, fresh', 'ha', 'terminal_collapse', '1960'),
+    ('iia', 'algeria', 'beans, dry', 'ha', 'zero_interior', '1938'),
+    ('iia', 'algeria', 'cotton lint', 'tonnes', 'zero_interior', '1935'),
+    ('iia', 'algeria', 'cotton lint', 'tonnes', 'zero_interior', '1938'),
+    ('iia', 'algeria', 'cotton seed', 'tonnes', 'zero_interior', '1935'),
+    ('iia', 'algeria', 'cotton seed', 'tonnes', 'zero_interior', '1938'),
+    ('iia', 'antigua and barbuda', 'cotton lint', 'tonnes', 'zero_interior', '1934'),
+    ('iia', 'antigua and barbuda', 'cotton lint', 'tonnes', 'zero_interior', '1936'),
+    ('iia', 'bulgaria', 'sugar raw centrifugal', 'tonnes', 'zero_interior', '1925'),
+    ('iia', 'canada', 'p', 'tonnes', 'zero_interior', '1920'),
+    ('iia', 'canada', 'p', 'tonnes', 'zero_interior', '1931'),
+    ('iia', 'cyprus', 'flax fibre and tow', 'ha', 'zero_interior', '1938'),
+    ('iia', 'cyprus', 'flax fibre and tow', 'tonnes', 'zero_interior', '1938'),
+    ('iia', 'cyprus', 'yarn of true hemp', 'tonnes', 'zero_interior', '1934'),
+    ('iia', 'egypt', 'flax fibre and tow', 'ha', 'zero_interior', '1913'),
+    ('iia', 'falkland islands (malvinas)', 'fertilizer, mixed', 'tonnes', 'zero_interior', '1918'),
+    ('iia', 'germany', 'yarn of true hemp', 'ha', 'zero_interior', '1934'),
+    ('iia', 'indonesia', 'p', 'tonnes', 'zero_interior', '1918'),
+    ('iia', 'kenya', 'beans, dry', 'ha', 'zero_interior', '1938'),
+    ('iia', 'kenya', 'flax fibre and tow', 'ha', 'zero_interior', '1935'),
+    ('iia', 'kenya', 'groundnuts, with shell', 'tonnes', 'zero_interior', '1934'),
+    ('iia', 'libya', 'oil, olive, virgin', 'tonnes', 'zero_interior', '1935'),
+    ('iia', 'malawi', 'cotton lint', 'ha', 'zero_interior', '1937'),
+    ('iia', 'malawi', 'cotton seed', 'ha', 'zero_interior', '1937'),
+    ('iia', 'montserrat', 'lemons and limes', 'ha', 'zero_interior', '1934'),
+    ('iia', 'montserrat', 'sugar raw centrifugal', 'tonnes', 'zero_interior', '1937'),
+    ('iia', 'morocco', 'cotton lint', 'tonnes', 'zero_interior', '1934'),
+    ('iia', 'morocco', 'cotton lint', 'tonnes', 'zero_interior', '1940'),
+    ('iia', 'morocco', 'cotton seed', 'tonnes', 'zero_interior', '1934'),
+    ('iia', 'myanmar', 'sesame seed', 'ha', 'zero_interior', '1944'),
+    ('iia', 'new caledonia', 'p', 'tonnes', 'zero_interior', '1932'),
+    ('iia', 'palau', 'p', 'tonnes', 'zero_interior', '1913'),
+    ('iia', 'portugal', 'n', 'tonnes', 'zero_interior', '1920'),
+    ('iia', 'saint lucia', 'lemons and limes', 'ha', 'zero_interior', '1933'),
+    ('iia', 'serbia', 'lemons and limes', 'tonnes', 'zero_interior', '1936'),
+    ('iia', 'somalia', 'sesame seed', 'ha', 'zero_interior', '1935'),
+    ('iia', 'sri lanka', 'cotton seed', 'tonnes', 'zero_interior', '1933'),
+    ('iia', 'switzerland', 'sugar raw centrifugal', 'tonnes', 'zero_interior', '1912'),
+    ('iia', 'vanuatu', 'cotton seed', 'tonnes', 'zero_interior', '1933'),
+    ('iia', 'vanuatu', 'cotton seed', 'tonnes', 'zero_interior', '1936'),
+    ('juan', 'czechoslovakia', 'asses', 'heads', 'zero_interior', '1935'),
+    ('juan', 'iceland', 'goats', 'heads', 'zero_interior', '1945'),
+    ('juan', 'iceland', 'goats', 'heads', 'zero_interior', '1948'),
+    ('fao1952', 'Germany Berlin', 'milk', '1000 tonnes', 'zero_tail', '1950'),
+    ('fao1952', 'Germany Eastern', 'milk', '1000 tonnes', 'zero_tail', '1950'),
+    ('iia', 'algeria', 'silk-worm cocoons, reelable', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'australia', 'coffee, green', 'ha', 'zero_tail', '1933'),
+    ('iia', 'australia', 'coffee, green', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'australia', 'olives', 'ha', 'zero_tail', '1933'),
+    ('iia', 'austria', 'soybeans', 'ha', 'zero_tail', '1934'),
+    ('iia', 'austria', 'yarn of true hemp', 'ha', 'zero_tail', '1934'),
+    ('iia', 'barbados', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'barbados', 'cotton lint', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'barbados', 'cotton seed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'belgium', 'hempseed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'belgium', 'rapeseed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'belgium', 'yarn of true hemp', 'ha', 'zero_tail', '1934'),
+    ('iia', 'benin', 'cacao, beans', 'ha', 'zero_tail', '1934'),
+    ('iia', 'burundi', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1934'),
+    ('iia', 'china, taiwan province of', 'other berries and fruits of the genus vaccinium n.e.c.', 'ha', 'zero_tail', '1936'),
+    ('iia', 'china, taiwan province of', 'rapeseed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'costa rica', 'lemons and limes', 'tonnes', 'zero_tail', '1931'),
+    ('iia', 'cyprus', 'hempseed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'cyprus', 'hempseed', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'cyprus', 'yarn of true hemp', 'ha', 'zero_tail', '1934'),
+    ('iia', 'dominican republic', 'cotton seed', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'ecuador', 'lemons and limes', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'eritrea', 'groundnuts, with shell', 'ha', 'zero_tail', '1936'),
+    ('iia', 'eritrea', 'groundnuts, with shell', 'tonnes', 'zero_tail', '1936'),
+    ('iia', 'eritrea', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1934'),
+    ('iia', 'eswatini', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1933'),
+    ('iia', 'fiji', 'cotton lint', 'ha', 'zero_tail', '1933'),
+    ('iia', 'fiji', 'cotton lint', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'fiji', 'cotton seed', 'ha', 'zero_tail', '1933'),
+    ('iia', 'fiji', 'cotton seed', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'french guiana', 'cacao, beans', 'ha', 'zero_tail', '1933'),
+    ('iia', 'french guiana', 'cacao, beans', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'french polynesia', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1934'),
+    ('iia', 'greece', 'grapes', 'tonnes', 'zero_tail', '1941'),
+    ('iia', 'guadeloupe', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'guadeloupe', 'cotton lint', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'guadeloupe', 'cotton seed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'guatemala', 'cotton lint', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'guatemala', 'groundnuts, with shell', 'ha', 'zero_tail', '1934'),
+    ('iia', 'guyana', 'lemons and limes', 'ha', 'zero_tail', '1934'),
+    ('iia', 'india', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'india', 'cotton seed', 'ha', 'zero_tail', '1936'),
+    ('iia', 'latvia', 'sugar raw centrifugal', 'tonnes', 'zero_tail', '1940'),
+    ('iia', 'libya', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1934'),
+    ('iia', 'lithuania', 'sugar raw centrifugal', 'tonnes', 'zero_tail', '1940'),
+    ('iia', 'madagascar', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'madagascar', 'cotton lint', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'madagascar', 'cotton seed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'malawi', 'coffee, green', 'tonnes', 'zero_tail', '1936'),
+    ('iia', 'malta', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'malta', 'cotton lint', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'malta', 'cotton seed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'malta', 'cotton seed', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'mauritius', 'groundnuts, with shell', 'ha', 'zero_tail', '1934'),
+    ('iia', 'mauritius', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1933'),
+    ('iia', 'netherlands', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1934'),
+    ('iia', 'new caledonia', 'cotton lint', 'ha', 'zero_tail', '1935'),
+    ('iia', 'new caledonia', 'cotton lint', 'tonnes', 'zero_tail', '1935'),
+    ('iia', 'new caledonia', 'cotton seed', 'ha', 'zero_tail', '1935'),
+    ('iia', 'new caledonia', 'cotton seed', 'tonnes', 'zero_tail', '1934'),
+    ('iia', 'new zealand', 'grapes', 'ha', 'zero_tail', '1933'),
+    ('iia', 'new zealand', 'rye', 'ha', 'zero_tail', '1934'),
+    ('iia', 'new zealand', 'wine', 'ha', 'zero_tail', '1933'),
+    ('iia', 'nigeria', 'cotton lint', 'ha', 'zero_tail', '1939'),
+    ('iia', 'paraguay', 'lemons and limes', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'portugal', 'lemons and limes', 'tonnes', 'zero_tail', '1933'),
+    ('iia', 'saint vincent and the grenadines', 'groundnuts, with shell', 'ha', 'zero_tail', '1934'),
+    ('iia', 'south korea', 'sugar raw centrifugal', 'tonnes', 'zero_tail', '1932'),
+    ('iia', 'tunisia', 'tobacco, unmanufactured', 'ha', 'zero_tail', '1935'),
+    ('iia', 'uruguay', 'rye', 'ha', 'zero_tail', '1935'),
+    ('iia', 'vanuatu', 'cotton lint', 'ha', 'zero_tail', '1934'),
+    ('iia', 'vanuatu', 'cotton seed', 'ha', 'zero_tail', '1934'),
+    ('iia', 'zambia', 'groundnuts, with shell', 'ha', 'zero_tail', '1933'),
+    ('iia', 'zambia', 'oranges', 'ha', 'zero_tail', '1933'),
+    ('juan', 'iceland', 'ducks', 'heads', 'zero_tail', '1948'),
+    ('juan', 'iceland', 'geese and guinea fowls', 'heads', 'zero_tail', '1948'),
+    ('juan', 'iceland', 'goats', 'heads', 'zero_tail', '1950'),
+    ('juan', 'switzerland', 'asses', 'heads', 'zero_tail', '1943'),
+    ('juan', 'united kingdom', 'mules and hinnies', 'heads', 'zero_tail', '1921'),
 })
 
 
@@ -232,6 +380,20 @@ def main() -> int:
     # A row whose recorded factor contradicts its own two values means the table and this gate
     # disagree about what the row says, and every judgement above rests on that column.
     for r in rows:
+        # The zero positions carry no ratio, deliberately: `factor` is left EMPTY rather than filled
+        # with a sentinel that later arithmetic might believe. Their shape check is that they really
+        # do sit at zero.
+        if r["position"].startswith("zero_"):
+            if r["factor"] != "":
+                problems.append(
+                    f"C {r['country']}/{r['item']} {r['year']}: a {r['position']} carries a factor "
+                    f"{r['factor']!r}, but there is no ratio against zero — an empty column has been "
+                    f"filled with something a consumer could take for a measurement")
+            if float(r["value"]) != 0:
+                problems.append(
+                    f"C {r['country']}/{r['item']} {r['year']} is classed {r['position']} but its "
+                    f"value is {r['value']}, not zero")
+            continue
         try:
             v, nb, f = float(r["value"]), float(r["neighbour_value"]), float(r["factor"])
         except ValueError:


### PR DESCRIPTION
Swept the pipeline for the pattern that produced #408, #412 and #420 — *a guard written to prevent an exception that also deletes the finding*. Six detectors filter `value > 0`, and the exclusion turns out to be load-bearing in a way none of them intended:

- `27_series_collapses.py` excluded zeros, deferring them to #414
- `17_constant_runs.py` excludes zeros, so a run of them is not a "constant run"
- **#414's own tables cannot reach them either**: `edition_conflicts.csv` needs *two* volumes and only 1933 has them; `impossible_pairs.csv` needs a paired area row

So the deferral pointed at nothing. Measured: **81 series ending in ≥2 zeros after real output, and 42 isolated interior zeros.**

## The clearest case

```
juan united kingdom / mules and hinnies    0.0 for EVERY year 1921-1938
```

while the **same source and same label** report asses (10,000 falling to 7,000) and horses (2,055,000 to 1,100,000) across those years. The source is reporting draught animals and not reporting mules. The zero means *not stated*, and nothing downstream can tell.

**68 of the 81 tails begin in 1933–1936** — the `iia_1938_39` window — so most of this class is #414's blank-read-as-0 appearing as a **run** rather than a cell. The rest are not: the UK mules run starts in 1921, and `latvia` and `lithuania` sugar beet go to zero in 1940 when both were annexed and their output would be reported inside Soviet statistics instead.

## Legitimate zeros are excluded by construction, not by judgement

A series that **opens** at zero is in neither class: `iia morocco / p` reads zero for 1909–1918 because Moroccan phosphate mining had not begun, and a leading run of zeros is exactly what that should look like.

## The old filter was not only hiding rows — it was fabricating one

Deleting zero rows made non-adjacent years look adjacent. Morocco's ten leading zeros were removed, its first **positive** value became the head of the series, and a `leading_collapse` was reported between two years that are not the series start at all.

`leading_collapse` falls **52 → 51** on the fix. Positivity is now required **per cell** rather than per series, which also recovers 8 legitimate collapses in series that happen to contain a zero somewhere else.

## Design

No ratio is recorded for the zero classes — `factor` is left **empty** rather than given a sentinel later arithmetic might believe — and the gate forbids one being filled in. The selftest case does exactly that, leaving all five ceilings, all 239 identity pins and the zero value itself intact so only that arm can see it.

**69 gates, 83 selftest cases, all pass.**

*PR opened by Claude.*