### PR TITLE
Detect broadcast cells: four or more items sharing one value in a label-year

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -490,6 +490,14 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_series_collapses.py
 
+      # Every other repetition guard looks along the YEAR axis. None could see one value repeated
+      # across ITEMS in a single label-year, which has a different cause: a cell broadcast over a row.
+      # mitchell india 1947 reads exactly 3,000 for asses, buffalo, camels, cattle, goats, horses,
+      # sheep AND swine, in a year its cattle reads 155,295,000 (1951). 5 blocks, all defects.
+      - name: Sources — four items may not share one value in a label-year
+        if: '!cancelled()'
+        run: python3 scripts/validate_item_blocks.py
+
       # A label can be right for one commodity and wrong for another, and no label-level decision can
       # fix that: the alias key is (label, source, years) with no item dimension. 11 iia labels mix
       # raw labels across their item series -- australia's `p` is CHRISTMAS ISLAND phosphate,

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ python3 scripts/validate_isolated_spikes.py         # no single year may read ma
 python3 scripts/validate_same_polity_overlaps.py   # two labels of one source may not collide on one polity's cells
 python3 scripts/validate_edition_conflicts.py      # one yearbook volume may not contradict another about a cell
 python3 scripts/validate_series_collapses.py       # no year may read many times BELOW its own neighbours
+python3 scripts/validate_item_blocks.py            # four items may not share one value in a label-year
 python3 scripts/validate_item_provenance.py         # no iia label may mix territories across its item series unrecorded
 python3 scripts/validate_item_product_switches.py   # an item series must not switch raw product back and forth
 python3 scripts/validate_item_equivalences.py       # every item/product mapping must be adjudicated

--- a/pipelines/polity-autoimprove/28_item_blocks.py
+++ b/pipelines/polity-autoimprove/28_item_blocks.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Where do FOUR OR MORE items share one value in a single label-year? A broadcast cell, not data.
+
+Every repetition detector here looks along the YEAR axis. `17_constant_runs.py` finds one value
+repeated across years within one series; `27_series_collapses.py` finds a year out of line with its
+own neighbours. Neither can see a value repeated across ITEMS within one year, and that shape has a
+different cause: not a carried-forward estimate but a single cell broadcast over a row, or a
+placeholder standing in for a table nobody filled.
+
+WHAT MAKES IT DIAGNOSTIC. `27_series_collapses.py` already flags `mitchell india / swine` at 1947 as
+an interior collapse -- 3,000 between 3,653,000 and 4,420,000. What it cannot say is that asses,
+buffalo, camels, cattle, goats, horses, sheep and swine ALL read exactly 3,000 that year. Eight
+independent errors landing on the same number is not a hypothesis anyone needs to weigh; one broadcast
+cell is. The cross-item pattern is the diagnosis, and it is invisible to a per-series test.
+
+THE VALUE ITSELF PROVES NOTHING. `3,000` occurs 148 times across 48 mitchell labels and 23 items,
+legitimately -- plenty of small producers really do report 3,000 head. It is the coincidence WITHIN a
+label-year that carries the signal, which is why the key is (source, label, unit, year) and why the
+threshold is a count of distinct items rather than any property of the number.
+
+WHY UNIT IS IN THE KEY. Without it the test pools livestock heads with crop hectares and tonnes, and
+the india block disappears: its crop rows that year carry ordinary varied values, so the group is no
+longer uniform and the block goes unreported. A placeholder is broadcast across one TABLE, and a table
+is one unit.
+
+WHAT THE FIRST RUN FOUND -- five blocks in the whole panel, and all five are defects:
+
+    mitchell india    heads 1947   8 items all      3,000   other years' median 20,895,500  (6,965x)
+    mitchell somalia  heads 1959   4 items all     15,000   other years' median  1,286,000  (   86x)
+    iia      belgium  ha    1934   4 items all          0
+    iia      belgium  ha    1935   4 items all          0
+    iia      belgium  ha    1936   4 items all          0
+
+The belgium blocks are issue 414's blank-read-as-0 arriving as a block rather than a cell, and they
+fall inside the iia_1938_39 window. India's cattle reads 3,000 in a year it reads 160,220,000 (1936)
+and 155,295,000 (1951), so no external source is needed to convict it.
+
+Usage:
+  python3 pipelines/polity-autoimprove/28_item_blocks.py            # report only
+  python3 pipelines/polity-autoimprove/28_item_blocks.py --write    # refresh the table
+  python3 pipelines/polity-autoimprove/28_item_blocks.py --check    # fail if stale
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+STATE = os.path.join(HERE, "state")
+OUT = os.path.join(STATE, "item_blocks.csv")
+DEFAULT_PANEL = os.path.expanduser(os.environ.get(
+    "WHEP_LAYER_B", "~/Nextcloud/whep/layer_b/consolidated_layer_b.parquet"))
+
+# Four distinct items sharing one value. Three would admit real coincidences among small producers --
+# a country reporting 1,000 head of three different animals is unremarkable -- and the observed blocks
+# are at 4 and 8, so nothing is lost. NOT tuned to the findings: raising it to 5 would drop somalia
+# and belgium, which are defects, and lowering it to 3 admits noise.
+MIN_ITEMS = 4
+
+FIELDS = ["source", "country", "unit", "year", "n_items", "value", "items",
+          "other_years_median", "ratio_to_other_years"]
+
+
+def build(panel_path: str) -> list[dict]:
+    import pandas as pd
+
+    d = pd.read_parquet(panel_path)
+    d = d.dropna(subset=["year", "value"])
+    out = []
+    for (src, lab, unit, yr), g in d.groupby(["source", "country", "unit", d["year"].astype(int)]):
+        if g["item"].nunique() < MIN_ITEMS:
+            continue
+        vals = g["value"].unique()
+        if len(vals) != 1:
+            continue
+        value = float(vals[0])
+        items = sorted({str(i) for i in g["item"]})
+        # The same items' level in OTHER years is what makes the block indefensible rather than merely
+        # odd. Measured over every other year those items report, not just adjacent ones.
+        oth = d[(d["source"] == src) & (d["country"] == lab) & (d["unit"] == unit)
+                & (d["item"].isin(items)) & (d["year"].astype(int) != yr)]
+        med = float(oth["value"].median()) if len(oth) else float("nan")
+        out.append({
+            "source": src, "country": lab, "unit": unit, "year": yr,
+            "n_items": len(items), "value": f"{value:g}", "items": ";".join(items),
+            "other_years_median": "" if med != med else f"{med:g}",
+            "ratio_to_other_years": ("" if med != med or value == 0 else f"{med / value:.1f}"),
+        })
+    out.sort(key=lambda r: (r["source"], r["country"], r["unit"], r["year"]))
+    return out
+
+
+def write(rows: list[dict], path: str) -> None:
+    """Build fully in memory then replace atomically — a truncating open() has cost this repo two
+    tracked state files mid-error."""
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=FIELDS)
+            w.writeheader()
+            w.writerows(rows)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
+    ap.add_argument("--check", action="store_true", help="exit 1 if the tracked table is stale")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.layer_b):
+        print(f"panel absent ({args.layer_b}); nothing to do", file=sys.stderr)
+        return 0
+
+    rows = build(args.layer_b)
+    print(f"label-years where >={MIN_ITEMS} items share one value: {len(rows)}")
+    for r in rows:
+        extra = (f"   other years' median {r['other_years_median']}"
+                 f" ({r['ratio_to_other_years']}x)" if r["ratio_to_other_years"] else "")
+        print(f"  {r['source']:9}{r['country'][:20]:22}{r['unit']:7}{r['year']}  "
+              f"{r['n_items']} items all = {r['value']:>12}{extra}")
+
+    if args.check:
+        if not os.path.exists(OUT):
+            print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+            return 1
+        with open(OUT, newline="") as fh:
+            have = list(csv.DictReader(fh))
+        want = [{k: str(v) for k, v in r.items()} for r in rows]
+        if have != want:
+            print(f"STALE {os.path.relpath(OUT, REPO)}: rerun with --write", file=sys.stderr)
+            return 1
+        print("table is current")
+        return 0
+
+    if args.write:
+        write(rows, OUT)
+        print(f"wrote {os.path.relpath(OUT, REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -426,6 +426,26 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        classes; `factor` is left EMPTY rather than given a sentinel later
                        arithmetic might believe.
                        --write refreshes state/series_collapses.csv
+28_item_blocks.py      where do FOUR OR MORE items share one value in a single label-year? Every
+                       other repetition detector here looks along the YEAR axis — 17_constant_runs.py
+                       for one value repeated across years, 27_series_collapses.py for a year out of
+                       line with its neighbours. None can see a value repeated across ITEMS in one
+                       year, and the cause differs: a cell broadcast over a row, or a placeholder for
+                       a table nobody filled.
+                       THE CROSS-ITEM VIEW IS THE DIAGNOSIS. 27_series_collapses.py already flags
+                       mitchell india / swine 1947 (3,000 between 3,653,000 and 4,420,000). What a
+                       per-series test cannot say is that asses, buffalo, camels, cattle, goats,
+                       horses, sheep AND swine all read exactly 3,000 that year — eight independent
+                       errors on one number is not a hypothesis worth weighing; one broadcast cell is.
+                       5 blocks in the whole panel and ALL FIVE are defects: mitchell india heads 1947
+                       (8 items, 3,000 vs a 20,895,500 median elsewhere), mitchell somalia heads 1959
+                       (4 items, 15,000 vs 1,286,000), and iia belgium ha 1934/1935/1936 (4 items all
+                       0 — issue 414's blank-read-as-0 as a block, inside the iia_1938_39 window).
+                       THE VALUE IS NOT THE SIGNAL: 3,000 occurs 148 times across 48 mitchell labels
+                       legitimately. UNIT MUST BE IN THE KEY, or india's varied crop rows that year
+                       make the group non-uniform and the block vanishes — a placeholder is broadcast
+                       across one TABLE, and a table is one unit.
+                       --write refreshes state/item_blocks.csv
                        in CI, since the panel is gitignored. Does NOT decide the cause of any
                        one seam: unit mismatch, different coverage and different item definitions
                        are probably all present, and separating them needs the sources.

--- a/pipelines/polity-autoimprove/state/item_blocks.csv
+++ b/pipelines/polity-autoimprove/state/item_blocks.csv
@@ -1,0 +1,6 @@
+source,country,unit,year,n_items,value,items,other_years_median,ratio_to_other_years
+iia,belgium,ha,1934,4,0,grapes;hempseed;rapeseed;yarn of true hemp,17,
+iia,belgium,ha,1935,4,0,grapes;hempseed;rapeseed;yarn of true hemp,17,
+iia,belgium,ha,1936,4,0,grapes;hempseed;rapeseed;yarn of true hemp,17,
+mitchell,india,heads,1947,8,3000,asses;buffalo;camels;cattle;goats;horses;sheep;swine / pigs,2.08955e+07,6965.2
+mitchell,somalia,heads,1959,4,15000,camels;cattle;goats;sheep,1.286e+06,85.7

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1437,6 +1437,32 @@ def mutate_spike_factor_rewritten(root, gpd, make_valid, affinity):
             f"rests on no longer describes the row it sits in")
 
 
+def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
+    """Lower a block's n_items while leaving the item list it describes intact.
+
+    The blocks are pinned by (source, country, unit, year) and counted against a ceiling, so both of
+    those signals survive a change to the COUNT column. What does not survive is the internal
+    agreement between `n_items` and `items` — and that column is the whole finding, because "eight
+    items agree to the digit" is what distinguishes a broadcast cell from eight coincidences. Dropped
+    to 4 rather than to 1 so it also stays above the generator's floor, leaving only the
+    count-versus-list check able to see it.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/item_blocks.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    worst = max(rows, key=lambda r: int(r["n_items"]))
+    before = worst["n_items"]
+    worst["n_items"] = "4"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"lowered the {worst['country']} / {worst['unit']} {worst['year']} block's n_items from "
+            f"{before} to 4 while leaving its {before}-item list in place, so the number carrying the "
+            f"finding no longer describes the row it sits in")
+
+
 def mutate_zero_tail_given_a_factor(root, gpd, make_valid, affinity):
     """Fill in a factor on a zero-position row, where no ratio exists.
 
@@ -3010,6 +3036,14 @@ CASES = (
         "put, so the one number every judgement here rests on contradicts the row it describes",
     ),
     (
+        "validate_item_blocks.py",
+        mutate_item_block_count_lowered,
+        "no longer describes the row",
+        "a broadcast-cell block whose item COUNT was lowered while its item list stayed — the ceiling "
+        "and the identity pin both survive that, and the count is the whole finding since 'eight "
+        "items agree to the digit' is what rules out eight coincidences",
+    ),
+    (
         "validate_series_collapses.py",
         mutate_zero_tail_given_a_factor,
         "there is no ratio against zero",
@@ -3606,6 +3640,10 @@ WRITABLE = {
     # real copy rather than a symlink into the tracked table.
     "validate_isolated_spikes.py": (
         "pipelines/polity-autoimprove/state/isolated_spikes.csv",
+    ),
+    # The case rewrites item_blocks.csv in place (it edits n_items), so a real copy.
+    "validate_item_blocks.py": (
+        "pipelines/polity-autoimprove/state/item_blocks.csv",
     ),
     # The case rewrites series_collapses.csv in place (it edits the factor column), so a real copy.
     "validate_series_collapses.py": (

--- a/scripts/validate_item_blocks.py
+++ b/scripts/validate_item_blocks.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Do four or more items share one value in a single label-year? That is a broadcast cell, not data.
+
+Every other repetition guard here looks along the YEAR axis. `validate_constant_runs.py` covers one
+value repeated across years within one series, `validate_isolated_spikes.py` and
+`validate_series_collapses.py` a year out of line with its own neighbours. None can see one value
+repeated across ITEMS within one year, and the cause is different: not a carried-forward estimate but
+a single cell broadcast over a row, or a placeholder for a table nobody filled.
+
+WHY THE CROSS-ITEM VIEW IS THE DIAGNOSIS. `validate_series_collapses.py` already pins
+`mitchell india / swine` at 1947 — 3,000 between 3,653,000 and 4,420,000. What a per-series test
+cannot say is that asses, buffalo, camels, cattle, goats, horses, sheep AND swine all read exactly
+3,000 that year. Eight independent errors landing on one number is not a hypothesis worth weighing;
+one broadcast cell is.
+
+`pipelines/polity-autoimprove/28_item_blocks.py` measures it from the layer-B panel, which is
+gitignored and absent in CI, so this gate reads the committed table.
+
+WHAT IT FOUND — five blocks in the whole panel, and every one is a defect:
+
+    mitchell india    heads 1947   8 items all      3,000   other years' median 20,895,500  (6,965x)
+    mitchell somalia  heads 1959   4 items all     15,000   other years' median  1,286,000  (   86x)
+    iia      belgium  ha    1934   4 items all          0
+    iia      belgium  ha    1935   4 items all          0
+    iia      belgium  ha    1936   4 items all          0
+
+India's cattle reads 3,000 in a year it reads 160,220,000 (1936) and 155,295,000 (1951), so no
+external source is needed. The belgium blocks are issue 414's blank-read-as-0 arriving as a block
+rather than a cell, inside the iia_1938_39 window.
+
+THE VALUE ITSELF IS NOT THE SIGNAL. `3,000` occurs 148 times across 48 mitchell labels and 23 items,
+legitimately — plenty of small producers report 3,000 head. The coincidence WITHIN a label-year is
+what carries it, so the check is on the block, never on the number.
+
+Three signals:
+  A. COUNT CEILING   blocks may not grow. Bidirectional: repairing one must lower it with a note.
+  B. EVERY BLOCK pinned by identity, so one cannot be swapped for another at a constant total.
+  C. INTERNAL SHAPE  the item count must match the item list, and must clear the generator's floor.
+
+Usage:
+  python3 scripts/validate_item_blocks.py
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/item_blocks.csv")
+
+# Measured 2026-08-19. BIDIRECTIONAL: repairing a block must lower this with a note saying which
+# label-year was fixed and whether the value became real data or a missing value.
+BASELINE_BLOCKS = 5
+
+# The generator's floor, restated so this gate does not depend on its constant to know what the
+# table means.
+MIN_ITEMS = 4
+
+BASELINE_KEYS = frozenset({
+    ("iia", "belgium", "ha", "1934"),
+    ("iia", "belgium", "ha", "1935"),
+    ("iia", "belgium", "ha", "1936"),
+    ("mitchell", "india", "heads", "1947"),
+    ("mitchell", "somalia", "heads", "1959"),
+})
+
+
+def key(r):
+    return (r["source"], r["country"], r["unit"], r["year"])
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} missing — run 28_item_blocks.py --write",
+              file=sys.stderr)
+        return 1
+    with open(TABLE, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    print(f"broadcast-cell blocks: {len(rows)} (ceiling {BASELINE_BLOCKS}, "
+          f"pinned {len(BASELINE_KEYS)})")
+
+    problems = []
+    if len(rows) > BASELINE_BLOCKS:
+        problems.append(
+            f"A {len(rows)} label-years have >={MIN_ITEMS} items sharing one value, above the ceiling "
+            f"of {BASELINE_BLOCKS}. Four unrelated commodities do not agree to the digit by accident — "
+            f"that is one cell broadcast over a row, or a placeholder for a table nobody filled")
+    elif len(rows) < BASELINE_BLOCKS:
+        problems.append(
+            f"A only {len(rows)} blocks remain, below the pinned ceiling of {BASELINE_BLOCKS} — lower "
+            f"the baseline and say which label-year was repaired and how")
+
+    seen = {key(r) for r in rows}
+    for k in sorted(seen - BASELINE_KEYS):
+        problems.append(
+            f"B NEW block: {k[1]} / {k[2]} at {k[3]}, {k[0]} — several items reading one identical "
+            f"value, which is not data")
+    for k in sorted(BASELINE_KEYS - seen):
+        problems.append(
+            f"B {k[1]} / {k[2]} at {k[3]} is pinned as a block but is not one any more — remove its "
+            f"entry, saying what was repaired")
+
+    for r in rows:
+        items = [i for i in r["items"].split(";") if i]
+        try:
+            n = int(r["n_items"])
+        except ValueError:
+            problems.append(f"C {r['country']} {r['year']}: unparseable n_items")
+            continue
+        if n != len(items):
+            problems.append(
+                f"C {r['country']} / {r['unit']} {r['year']}: n_items={n} but the items column names "
+                f"{len(items)} — the count every judgement here rests on no longer describes the row")
+        if n < MIN_ITEMS:
+            problems.append(
+                f"C {r['country']} / {r['unit']} {r['year']}: {n} items is below the floor of "
+                f"{MIN_ITEMS}, where commodities really can agree by coincidence")
+
+    for p in problems:
+        print(f"FAIL: {p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every repetition detector here looks along the **year** axis. None can see a value repeated across **items** within one year, and the cause differs: not a carried-forward estimate but a single cell broadcast over a row, or a placeholder for a table nobody filled.

**Five blocks in the whole panel, and every one is a defect:**

```
mitchell india    heads 1947   8 items all      3,000   other years' median 20,895,500
mitchell somalia  heads 1959   4 items all     15,000   other years' median  1,286,000
iia      belgium  ha    1934   4 items all          0
iia      belgium  ha    1935   4 items all          0
iia      belgium  ha    1936   4 items all          0
```

## The cross-item view is the diagnosis

`27_series_collapses.py` already pins `mitchell india / swine` at 1947 — 3,000 between 3,653,000 and 4,420,000. What a per-series test **cannot** say is that asses, buffalo, camels, cattle, goats, horses, sheep *and* swine all read exactly 3,000 that year. Eight independent errors landing on one number is not a hypothesis worth weighing; one broadcast cell is.

India's cattle reads 3,000 in a year it reads 160,220,000 (1936) and 155,295,000 (1951) — no external source needed.

The belgium blocks are #414's blank-read-as-0 arriving as a **block** rather than a cell, inside the `iia_1938_39` window.

## The value itself is not the signal

This is what keeps the test honest: **3,000 occurs 148 times** across 48 mitchell labels and 23 items, legitimately — plenty of small producers really do report 3,000 head. Only the coincidence *within a label-year* carries information, so the check is on the block and never on the number.

**Unit is in the key** because a placeholder is broadcast across one *table*, and a table is one unit. Without it the test pools livestock heads with crop hectares, india's varied crop rows make the group non-uniform, and the block disappears entirely.

**`MIN_ITEMS` is 4 and is not tuned to the findings**: 3 would admit real coincidences among small producers, and 5 would drop somalia and belgium, which are defects.

## Selftest

Lowers a block's `n_items` while leaving its item list intact — the ceiling and the identity pin both survive that, so only the check comparing count against list can see it, and that count is the whole finding.

**70 gates, 85 selftest cases, all pass.**

*PR opened by Claude.*