### PR TITLE
Gate the two ungated assertion tables, re-deriving their verdicts (#432)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -506,6 +506,13 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_assertion_nesting_flags.py
 
+      # The triage queue decides WHAT GETS LOOKED AT, so a silent corruption produces work never done
+      # rather than a wrong number. Five of six arms re-derive a column from other columns; the sixth
+      # checks inclusion_impossible against assertion_nesting_flags.csv, the table it was copied from.
+      - name: Sources — the assertion triage queue must describe its own rows
+        if: '!cancelled()'
+        run: python3 scripts/validate_assertion_triage.py
+
       # A label can be right for one commodity and wrong for another, and no label-level decision can
       # fix that: the alias key is (label, source, years) with no item dimension. 11 iia labels mix
       # raw labels across their item series -- australia's `p` is CHRISTMAS ISLAND phosphate,

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -498,6 +498,14 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_item_blocks.py
 
+      # Issue 273's table: 234 nesting pairs, 20 where inclusion is arithmetically impossible and 13
+      # of those contradict an already-BANKED verdict. It was read by no gate until 2026-08-19. The
+      # `inclusion` verdict re-derives exactly from cells_outer_lt_inner / shared_cells using the
+      # generator's own thresholds — verified on all 84 rows that carry shared cells.
+      - name: Sources — the nesting-flag verdicts must follow from their own numbers
+        if: '!cancelled()'
+        run: python3 scripts/validate_assertion_nesting_flags.py
+
       # A label can be right for one commodity and wrong for another, and no label-level decision can
       # fix that: the alias key is (label, source, years) with no item dimension. 11 iia labels mix
       # raw labels across their item series -- australia's `p` is CHRISTMAS ISLAND phosphate,

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ python3 scripts/validate_edition_conflicts.py      # one yearbook volume may not
 python3 scripts/validate_series_collapses.py       # no year may read many times BELOW its own neighbours
 python3 scripts/validate_item_blocks.py            # four items may not share one value in a label-year
 python3 scripts/validate_assertion_nesting_flags.py # nesting-flag verdicts must follow from their own numbers
+python3 scripts/validate_assertion_triage.py        # the triage queue must describe its own rows
 python3 scripts/validate_item_provenance.py         # no iia label may mix territories across its item series unrecorded
 python3 scripts/validate_item_product_switches.py   # an item series must not switch raw product back and forth
 python3 scripts/validate_item_equivalences.py       # every item/product mapping must be adjudicated

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ python3 scripts/validate_same_polity_overlaps.py   # two labels of one source ma
 python3 scripts/validate_edition_conflicts.py      # one yearbook volume may not contradict another about a cell
 python3 scripts/validate_series_collapses.py       # no year may read many times BELOW its own neighbours
 python3 scripts/validate_item_blocks.py            # four items may not share one value in a label-year
+python3 scripts/validate_assertion_nesting_flags.py # nesting-flag verdicts must follow from their own numbers
 python3 scripts/validate_item_provenance.py         # no iia label may mix territories across its item series unrecorded
 python3 scripts/validate_item_product_switches.py   # an item series must not switch raw product back and forth
 python3 scripts/validate_item_equivalences.py       # every item/product mapping must be adjudicated

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1437,6 +1437,38 @@ def mutate_spike_factor_rewritten(root, gpd, make_valid, affinity):
             f"rests on no longer describes the row it sits in")
 
 
+def mutate_nesting_verdict_softened(root, gpd, make_valid, affinity):
+    """Downgrade the worst impossible-inclusion pair to `few_violations`, leaving its numbers alone.
+
+    `inclusion` is issue 273's whole finding, and it re-derives exactly from `cells_outer_lt_inner`
+    and `shared_cells` under the generator's thresholds (>=3 cells and >10%). Softening a verdict
+    without touching those numbers is what a hand edit or a partial merge looks like, and the shape
+    matters: 13 of the 20 impossible pairs contradict an already-BANKED verdict, so a verdict quietly
+    downgraded removes evidence AGAINST a recorded decision.
+
+    It trades the count back by promoting a `few_violations` row, so the bidirectional pin on 20 stays
+    satisfied and only the per-row re-derivation can see the swap. Same trick as the edition-conflict
+    and power-of-ten cases, for the same reason: a mutation that tripped the count would also pass
+    against a gate that only counted.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = max((r for r in rows if r["inclusion"] == "impossible_outer_excludes_inner"),
+                 key=lambda r: int(r["cells_outer_lt_inner"]))
+    donor = next(r for r in rows if r["inclusion"] == "few_violations")
+    victim["inclusion"] = "few_violations"
+    donor["inclusion"] = "impossible_outer_excludes_inner"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"downgraded {victim['outer_code']} <- {victim['inner_code']} "
+            f"({victim['cells_outer_lt_inner']} of {victim['shared_cells']} cells) from impossible to "
+            f"few_violations and promoted a lesser pair, so the pinned count of 20 still holds")
+
+
 def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
     """Lower a block's n_items while leaving the item list it describes intact.
 
@@ -3036,6 +3068,14 @@ CASES = (
         "put, so the one number every judgement here rests on contradicts the row it describes",
     ),
     (
+        "validate_assertion_nesting_flags.py",
+        mutate_nesting_verdict_softened,
+        "give 'impossible_outer_excludes_inner'",
+        "issue 273's worst impossible-inclusion verdict quietly downgraded, its cell counts untouched "
+        "and a lesser pair promoted so the pinned count of 20 still holds — 13 of those 20 are "
+        "evidence against an already-banked verdict, so only the re-derivation can see it",
+    ),
+    (
         "validate_item_blocks.py",
         mutate_item_block_count_lowered,
         "no longer describes the row",
@@ -3640,6 +3680,10 @@ WRITABLE = {
     # real copy rather than a symlink into the tracked table.
     "validate_isolated_spikes.py": (
         "pipelines/polity-autoimprove/state/isolated_spikes.csv",
+    ),
+    # The case swaps verdicts in assertion_nesting_flags.csv in place, so a real copy.
+    "validate_assertion_nesting_flags.py": (
+        "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv",
     ),
     # The case rewrites item_blocks.csv in place (it edits n_items), so a real copy.
     "validate_item_blocks.py": (

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1469,6 +1469,46 @@ def mutate_nesting_verdict_softened(root, gpd, make_valid, affinity):
             f"few_violations and promoted a lesser pair, so the pinned count of 20 still holds")
 
 
+
+def mutate_triage_inclusion_flag_desynced(root, gpd, make_valid, affinity):
+    """Desync `inclusion_impossible` from the table it was copied from, keeping the count.
+
+    `assertion_triage.csv` carries a copy of a verdict computed in `assertion_nesting_flags.csv`, and
+    a copied verdict is the thing that goes stale when its source is regenerated and its consumer is
+    not. This is what that looks like: the flag moves off the pair the arithmetic condemns and onto a
+    pair it does not.
+
+    It TRADES the flag rather than setting one, so the number of flagged rows is unchanged at 17 and
+    no count -- present or later added -- can see it. Only the per-row biconditional against the
+    nesting table can. Same trick as the nesting-flag and edition-conflict cases, for the same reason.
+
+    It also leaves `key`, `label`, `source` and `years_observed` untouched, so arm A still rebuilds
+    every key. An earlier version of this case edited the key instead and was caught by arm A while
+    arm E never spoke -- a mutation that trips a different arm proves nothing about the arm it aims at.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/assertion_triage.csv")
+    nesting = os.path.join(root, "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv")
+    imposs = set()
+    with open(nesting, newline="", encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            if r["inclusion"] == "impossible_outer_excludes_inner":
+                imposs.update(v for v in (r.get("outer_key"), r.get("inner_key")) if v)
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = next(r for r in rows if r["key"] in imposs)
+    donor = next(r for r in rows if r["key"] not in imposs)
+    victim["inclusion_impossible"] = "False"
+    donor["inclusion_impossible"] = "True"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"moved the inclusion_impossible flag off {victim['key']!r}, which "
+            f"assertion_nesting_flags.csv condemns, onto {donor['key']!r}, which it does not, "
+            f"leaving 17 rows flagged so no count changes")
+
+
 def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
     """Lower a block's n_items while leaving the item list it describes intact.
 
@@ -3068,6 +3108,14 @@ CASES = (
         "put, so the one number every judgement here rests on contradicts the row it describes",
     ),
     (
+        "validate_assertion_triage.py",
+        mutate_triage_inclusion_flag_desynced,
+        "COPY of that table's verdict",
+        "the inclusion_impossible flag traded off the pair assertion_nesting_flags.csv condemns onto "
+        "one it does not, leaving 17 rows flagged so no count moves -- the triage queue decides what "
+        "gets looked at, so a stale copy here means work never done rather than a wrong number",
+    ),
+    (
         "validate_assertion_nesting_flags.py",
         mutate_nesting_verdict_softened,
         "give 'impossible_outer_excludes_inner'",
@@ -3683,6 +3731,14 @@ WRITABLE = {
     ),
     # The case swaps verdicts in assertion_nesting_flags.csv in place, so a real copy.
     "validate_assertion_nesting_flags.py": (
+        "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv",
+    ),
+    # The case trades a flag in assertion_triage.csv in place, so a real copy. The nesting table is
+    # only READ by both gate and mutator, but stage() creates nothing it was not asked for, so it must
+    # be listed anyway or arm E SKIPS ITSELF ("nesting table absent") and the case passes having
+    # checked nothing -- the same trap validate_period_overlaps.py documents above.
+    "validate_assertion_triage.py": (
+        "pipelines/polity-autoimprove/state/assertion_triage.csv",
         "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv",
     ),
     # The case rewrites item_blocks.csv in place (it edits n_items), so a real copy.

--- a/scripts/validate_assertion_nesting_flags.py
+++ b/scripts/validate_assertion_nesting_flags.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Does the nesting-flag table still describe its own rows?
+
+`state/assertion_nesting_flags.csv` is issue 273's table: 234 same-source assertion pairs whose
+candidate polygons nest, with the panel's own extensive cells tested against inclusion. Its headline
+is that **in 20 of them inclusion is arithmetically impossible** — the source reports the outer
+territory EXCLUSIVE of the inner one, so the polity a label is routed to is larger than what the
+numbers describe. Metropolitan Japan against Korea and Formosa is the largest case; Juan's UK against
+Ireland the second.
+
+Until 2026-08-19 no gate read it (issue 432 found 11 such tracked tables). That matters more here than
+for most: 13 of the 20 impossible pairs contradict an already-BANKED verdict, so the table is evidence
+against recorded decisions, and nothing checked that it still said what it says.
+
+The `inclusion` verdict is FULLY RE-DERIVABLE from two of the row's own columns, using the generator's
+own thresholds (`--min-violations 3`, `--min-violation-frac 0.1`):
+
+    impossible_outer_excludes_inner   cells_outer_lt_inner >= 3  AND  / shared_cells > 0.10
+    consistent_with_inclusion         cells_outer_lt_inner == 0
+    few_violations                    otherwise
+
+Verified: that rule reproduces all 84 rows carrying shared cells, with zero mismatches. The other 150
+are `no_shared_cells` or `label_not_in_panel`, which the arithmetic cannot speak to and which this
+gate therefore requires to carry NO violating cells rather than re-deriving them.
+
+WHY THE 20 IS PINNED HERE, when validate_magnitude_outliers.py deliberately pins no count. The
+distinction is what the number is. 2,718 screening rows shift with any panel refresh, so pinning them
+would fail on a correct action and train the next person to edit baselines. **20 is a curated finding
+count that issue 273 is about.** If it moves, someone should have to say why — including whoever
+eventually fixes #273, whose remedy will move it on purpose. That is what a bidirectional pin is for.
+
+Usage:
+  python3 scripts/validate_assertion_nesting_flags.py
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv")
+POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
+
+# The generator's own defaults, restated so this gate does not depend on its constants to know what
+# the table means.
+MIN_VIOLATIONS = 3
+MIN_VIOLATION_FRAC = 0.1
+
+# Measured 2026-08-19. BIDIRECTIONAL: issue 273's remedy will change this deliberately, and whoever
+# changes it should have to say so.
+BASELINE_IMPOSSIBLE = 20
+
+VERDICTS = {"impossible_outer_excludes_inner", "consistent_with_inclusion", "few_violations",
+            "no_shared_cells", "label_not_in_panel"}
+# The two the arithmetic cannot speak to: no cells were comparable, so no verdict is derivable.
+NO_CELL_VERDICTS = {"no_shared_cells", "label_not_in_panel"}
+
+
+def num(x):
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return None
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} missing — run 12_triage_assertions.py",
+              file=sys.stderr)
+        return 1
+    with open(TABLE, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    live = None
+    if os.path.exists(POLITIES):
+        with open(POLITIES, encoding="utf-8") as fh:
+            live = {r["polity_code"] for r in csv.DictReader(fh)}
+
+    problems, orphans, derived, impossible = [], set(), 0, 0
+    for i, r in enumerate(rows, start=2):
+        where = f"line {i} {r.get('outer_code')} <- {r.get('inner_code')}"
+        verdict = r.get("inclusion", "")
+        if verdict not in VERDICTS:
+            problems.append(f"unknown inclusion {verdict!r} at {where} — generator and gate "
+                            f"disagree about the vocabulary")
+            continue
+        if verdict == "impossible_outer_excludes_inner":
+            impossible += 1
+
+        c, s = num(r.get("cells_outer_lt_inner")), num(r.get("shared_cells"))
+
+        # --- A: the verdict must follow from the row's own two numbers ---
+        if verdict in NO_CELL_VERDICTS:
+            if c:
+                problems.append(
+                    f"A {where}: verdict {verdict!r} means no cells were comparable, but the row "
+                    f"records {c:g} violating cells")
+        elif c is None or s is None or not s:
+            problems.append(f"A {where}: verdict {verdict!r} needs shared cells to be derivable, "
+                            f"but shared_cells={r.get('shared_cells')!r}")
+        else:
+            want = ("impossible_outer_excludes_inner"
+                    if (c >= MIN_VIOLATIONS and c / s > MIN_VIOLATION_FRAC)
+                    else "consistent_with_inclusion" if c == 0 else "few_violations")
+            derived += 1
+            if want != verdict:
+                problems.append(
+                    f"A {where}: table says {verdict!r} but its own numbers "
+                    f"({c:g} of {s:g} = {c / s:.1%}) give {want!r} under the generator's thresholds "
+                    f"(>={MIN_VIOLATIONS} cells and >{MIN_VIOLATION_FRAC:.0%})")
+            if c > s:
+                problems.append(f"A {where}: {c:g} violating cells exceeds {s:g} shared cells")
+
+        # --- B: both codes must still exist ---
+        if live is not None:
+            for k in ("outer_code", "inner_code"):
+                if r.get(k) and r[k] not in live:
+                    orphans.add(r[k])
+
+        # --- C: nesting means the inner polygon is inside the outer ---
+        oa, ia = num(r.get("outer_km2")), num(r.get("inner_km2"))
+        if oa is not None and ia is not None and ia > oa + 1:
+            problems.append(
+                f"C {where}: inner_km2 {ia:,.0f} exceeds outer_km2 {oa:,.0f} — this table is by "
+                f"definition pairs whose polygons NEST, so the pair does not belong in it")
+
+        # --- D: a covered share is a share ---
+        sh = num(r.get("inner_share_covered"))
+        if sh is not None and not (-1e-9 <= sh <= 1.0 + 1e-9):
+            problems.append(f"D {where}: inner_share_covered {sh:g} is outside [0, 1]")
+
+    for code in sorted(orphans):
+        problems.append(
+            f"B {code} is not a polity in data/final/polities_database.csv — the database moved "
+            f"under this table and rows on that code point at nothing. This is how six rows in "
+            f"magnitude_outliers.csv survived on re-spanned codes (issue 432)")
+
+    print(f"nesting flags: {len(rows)} pairs, {derived} verdicts re-derived from their own numbers, "
+          f"impossible {impossible}/{BASELINE_IMPOSSIBLE}, orphaned codes {len(orphans)}")
+
+    if impossible > BASELINE_IMPOSSIBLE:
+        problems.append(
+            f"{impossible} pairs are arithmetically impossible, above the pinned "
+            f"{BASELINE_IMPOSSIBLE}. A new one means a label is routed to a polity larger than the "
+            f"numbers describe — issue 273's class")
+    elif impossible < BASELINE_IMPOSSIBLE:
+        problems.append(
+            f"only {impossible} impossible pairs remain, below the pinned {BASELINE_IMPOSSIBLE} — "
+            f"lower the baseline and say which pair was resolved and how (issue 273)")
+
+    for p in problems:
+        print(f"FAIL: {p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_assertion_triage.py
+++ b/scripts/validate_assertion_triage.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Does the assertion triage queue still describe its own rows?
+
+`state/assertion_triage.csv` is the queue the verification workflow walks: 796 pending assertions,
+each a (label, source, year-span) claim routed to a candidate polity, ordered by `verify_order` and
+bucketed into a `tier` that decides how much scrutiny it gets. It is the table that decides WHAT GETS
+LOOKED AT, so a silent corruption here does not produce a wrong number — it produces work never done.
+
+Until 2026-08-19 no gate read it. It was the third of the three ungated tables issue 432 named, and
+the one I called least consequential; that was a judgement about blast radius, not about whether the
+table is checkable. It turned out to be the most re-derivable of the three.
+
+Almost nothing here is a pinned count. Five of the six arms recompute the column from other columns:
+
+    A  key            == norm(label)|source|years_observed   [+ |candidate when disambiguated]
+    B  keys unique    -- a key maps to one ledger row and one evidence bundle (00_intake.py:354)
+    C  verify_order   is a dense permutation of 1..N, so no assertion is unreachable or duplicated
+    D  n_distinct_years in [1, span width] -- cannot observe more years than the span contains
+    E  inclusion_impossible agrees with assertion_nesting_flags.csv   <-- CROSS-TABLE
+    F  candidate resolves to a live polity_code
+
+E is the arm worth having. `inclusion_impossible` is a copy of a verdict computed in a DIFFERENT
+table, and a copied verdict is exactly the thing that goes stale when its source is regenerated and
+its consumer is not. Verified 2026-08-19: the biconditional holds for all 796 rows (17 True), against
+the impossible pairs in assertion_nesting_flags.csv keyed on either side.
+
+Why no baseline row count: the queue drains on purpose. Pinning 796 would fail on the correct action
+of verifying an assertion, which is the failure mode validate_magnitude_outliers.py exists to avoid.
+
+WHAT THIS GATE DOES NOT CATCH — stated because the coverage is otherwise easy to over-read. Arm A is
+INTERNAL consistency: it proves each key rebuilds from its own three columns, and all 796 do. A row
+that is stale relative to `assertions.json` rebuilds perfectly and passes. Issue 434 is exactly that
+defect and this gate is green on it: 71 queue rows name a span no current assertion has, and 198
+pending/reopened assertions (8.9% of pending panel rows) never reach the queue at all.
+
+The arm that would catch it is a seventh, checking the queue against `assertions.json`. It is absent
+because it would fail on main today, and the resync it demands is a decision about curated state
+(re-running the generator has previously re-banked verdicts over hand retractions). Order is: resync
+under 434, then add the arm. Arm E is the same class of check against a table that IS in sync.
+
+Usage:
+  python3 scripts/validate_assertion_triage.py
+"""
+from __future__ import annotations
+
+import csv
+import os
+import re
+import sys
+import unicodedata
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/assertion_triage.csv")
+NESTING = os.path.join(REPO, "pipelines/polity-autoimprove/state/assertion_nesting_flags.csv")
+POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
+
+TIERS = {"territory_basis_wrong", "nested_reporting", "boundary_year", "weak_route", "precedent",
+         "thin", "bulk"}
+STATUSES = {"pending", "reopened", "confirmed", "rejected", "withdrawn"}
+TRUEISH = {"true", "yes", "1"}
+
+
+def norm(s) -> str:
+    """matchlib.norm, restated so the gate does not import the generator to know what a key means.
+
+    Cross-checked against the real one below when it is importable; CI has no numpy guarantee, so
+    this gate must not depend on that import to run its main arms.
+    """
+    if s is None:
+        return ""
+    s = str(s).strip().lower()
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode()
+    s = re.sub(r"\s*\(.*?\)\s*", " ", s)
+    s = re.sub(r"^the\s+", "", s)
+    s = re.sub(r"[^a-z0-9 ]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def impossible_keys() -> set[str] | None:
+    if not os.path.exists(NESTING):
+        return None
+    keys = set()
+    with open(NESTING, encoding="utf-8") as fh:
+        for r in csv.DictReader(fh):
+            if r.get("inclusion") == "impossible_outer_excludes_inner":
+                for k in ("outer_key", "inner_key"):
+                    if r.get(k):
+                        keys.add(r[k])
+    return keys
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} missing — run 12_triage_assertions.py",
+              file=sys.stderr)
+        return 1
+    with open(TABLE, encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    if not rows:
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} has no rows", file=sys.stderr)
+        return 1
+
+    live = None
+    if os.path.exists(POLITIES):
+        with open(POLITIES, encoding="utf-8") as fh:
+            live = {r["polity_code"] for r in csv.DictReader(fh)}
+    imposs = impossible_keys()
+
+    problems, orphans, seen, orders = [], set(), {}, []
+    rederived = flagged = 0
+
+    for i, r in enumerate(rows, start=2):
+        key = (r.get("key") or "").strip()
+        label, src = r.get("label") or "", (r.get("source") or "").strip()
+        span = (r.get("years_observed") or "").strip()
+        where = f"line {i} {key or '<no key>'}"
+
+        # --- A: the key must be rebuildable from the columns it claims to summarise ---
+        base = f"{norm(label)}|{src}|{span}"
+        cand = (r.get("candidate") or "").strip()
+        if key not in (base, f"{base}|{cand}"):
+            problems.append(
+                f"A {where}: key does not rebuild from its own columns — expected {base!r} "
+                f"(or that plus |{cand} when 00_intake disambiguates a shared key)")
+        else:
+            rederived += 1
+
+        # --- B: one key, one ledger row ---
+        if key in seen:
+            problems.append(
+                f"B {where}: key repeats line {seen[key]}. A key maps to one ledger row and one "
+                f"evidence bundle, so banking a verdict on it would write to both (00_intake.py)")
+        seen[key] = i
+
+        # --- C: the queue must be walkable ---
+        try:
+            orders.append(int(r["verify_order"]))
+        except (KeyError, TypeError, ValueError):
+            problems.append(f"C {where}: verify_order {r.get('verify_order')!r} is not an integer")
+
+        # --- D: you cannot observe more distinct years than the span holds ---
+        m = re.fullmatch(r"(-?\d+)-(-?\d+)", span)
+        n = r.get("n_distinct_years")
+        if m and n not in (None, ""):
+            try:
+                n_i, width = int(n), int(m.group(2)) - int(m.group(1)) + 1
+                if n_i < 1:
+                    problems.append(f"D {where}: n_distinct_years {n_i} is not positive")
+                elif n_i > width:
+                    problems.append(
+                        f"D {where}: n_distinct_years {n_i} exceeds the {width}-year span {span} — "
+                        f"the row observes more years than it covers")
+            except ValueError:
+                problems.append(f"D {where}: n_distinct_years {n!r} is not an integer")
+
+        # --- E: a verdict copied from another table must still match that table ---
+        flag = (r.get("inclusion_impossible") or "").strip().lower() in TRUEISH
+        flagged += flag
+        if imposs is not None:
+            want = key in imposs
+            if flag != want:
+                problems.append(
+                    f"E {where}: inclusion_impossible={flag} but assertion_nesting_flags.csv "
+                    f"{'does' if want else 'does not'} class this key impossible. This column is a "
+                    f"COPY of that table's verdict — a disagreement means one of the two was "
+                    f"regenerated without the other (issue 273's finding is in that table)")
+
+        # --- F: the routing target must still exist ---
+        if live is not None and cand and cand not in live:
+            orphans.add(cand)
+
+        tier, status = (r.get("tier") or "").strip(), (r.get("status") or "").strip()
+        if tier and tier not in TIERS:
+            problems.append(f"{where}: unknown tier {tier!r} — generator and gate disagree about "
+                            f"the vocabulary that decides how much scrutiny a row gets")
+        if status and status not in STATUSES:
+            problems.append(f"{where}: unknown status {status!r}")
+
+    if orders:
+        want = list(range(1, len(rows) + 1))
+        if sorted(orders) != want:
+            got = sorted(orders)
+            dup = {o for o in orders if orders.count(o) > 1}
+            problems.append(
+                f"C verify_order is not a dense 1..{len(rows)} ordering (min {got[0]}, max "
+                f"{got[-1]}, {len(set(orders))} distinct of {len(rows)}"
+                + (f", repeats {sorted(dup)[:5]}" if dup else "")
+                + ") — a gap or a repeat means an assertion is skipped or handled twice")
+
+    for code in sorted(orphans):
+        problems.append(
+            f"F {code} is not a polity in data/final/polities_database.csv — the assertion routes to "
+            f"a code the database no longer has, so verifying it can reach no polity")
+
+    # Drift check on the restated normaliser. Optional by design: it needs the generator's numpy.
+    try:
+        sys.path.insert(0, os.path.join(REPO, "pipelines/polity-autoimprove"))
+        from matchlib import norm as real_norm  # noqa: PLC0415
+    except Exception:
+        pass
+    else:
+        drift = [r["label"] for r in rows if norm(r.get("label")) != real_norm(r.get("label"))]
+        if drift:
+            problems.append(
+                f"this gate's restated norm() has drifted from matchlib.norm on {len(drift)} labels "
+                f"(e.g. {drift[:3]}) — arm A is then checking a rule the generator does not use")
+
+    print(f"assertion triage: {len(rows)} rows, {rederived} keys rebuilt from their own columns, "
+          f"inclusion_impossible {flagged}"
+          + (f" agreeing with {len(imposs)} nesting keys" if imposs is not None
+             else " (nesting table absent, arm E skipped)")
+          + f", orphaned candidates {len(orphans)}")
+
+    for p in problems:
+        print(f"FAIL: {p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two of the three tracked tables #432 found ungated. Both gates **re-derive** the table's own verdict
column rather than pinning a count, so neither can be satisfied by editing a baseline.

### `assertion_nesting_flags.csv` — #273's table

234 same-source assertion pairs whose candidate polygons nest, with the panel's extensive cells tested
against inclusion. Its headline is that in **20** of them inclusion is arithmetically impossible: the
source reports the outer territory *exclusive* of the inner, so the polity a label routes to is larger
than what the numbers describe.

The `inclusion` verdict re-derives exactly from `cells_outer_lt_inner / shared_cells` under the
generator's own thresholds (`--min-violations 3`, `--min-violation-frac 0.1`) — verified on all 84
rows carrying shared cells, zero mismatches. My first attempt used guessed thresholds (12 / 0.125) and
reproduced only 74 of 84; the real defaults reproduce all 84.

The count of 20 **is** pinned, bidirectionally, and the contrast with `validate_magnitude_outliers.py`
(which deliberately pins nothing) is the point: 2,718 screening rows shift with any panel refresh, so
pinning them would fail on a correct action. 20 is a curated finding count #273 is about — and 13 of
the 20 contradict an already-**banked** verdict, so the table is evidence against recorded decisions.

### `assertion_triage.csv` — the queue that decides what gets looked at

796 pending assertions ordered by `verify_order`, bucketed into a `tier` that sets scrutiny. A silent
corruption here produces *work never done* rather than a wrong number.

I had called this the least consequential of the three. That was a judgement about blast radius and it
was wrong about checkability — it is the most re-derivable of them. Five of six arms recompute a
column from other columns; no row count is pinned, because the queue drains on purpose.

Arm **E** is the one worth having: `inclusion_impossible` is a *copy* of a verdict computed in the
nesting table, and a copied verdict is what goes stale when its source is regenerated and its consumer
is not. The biconditional holds for all 796 rows against 29 condemned keys.

### On testing the arms

Every arm was mutation-tested individually, and one result is why that matters: arm **B** (key
uniqueness) initially "passed" via arm **A**, because copying a key also breaks its rebuild. The case
now copies the key *and* the columns it derives from, so only B can speak — verified as exactly one
FAIL, from B.

The new selftest case trades the `inclusion_impossible` flag off the condemned pair onto an
unaffected one, leaving 17 rows flagged so no count moves and only the per-row check can see it. Its
`WRITABLE` entry lists the nesting table too, read-only: `stage()` creates nothing it was not asked
for, so without that line arm E skips itself and the case passes having checked nothing — the trap
`validate_period_overlaps.py` already documents, hit again here.

### What these gates do not catch

Stated in the triage gate's docstring rather than left implied. Arm A is *internal* consistency, so a
row stale against `assertions.json` rebuilds fine and passes. That is **#434** — 71 dead queue rows
and 198 pending/reopened assertions (8.9% of pending panel rows) never queued, including 4 of #273's
impossible inclusions that are neither queued nor adjudicated. This gate is green on all of it. The
seventh arm that would catch it would fail on `main` today, so it has to follow the resync #434 asks
for, which is a decision about curated state and not one to make unilaterally.

---

Gates 68 → 70, selftest cases 85 → 87. Full suite green, all 87 cases pass, `ast.parse` and YAML
verified. Closes #432 (its third table is gated here; the resync it exposed is #434).
