### PR TITLE
Carry `period` into matched_rows.parquet so intake can date period-average rows (#434)

### DIFF
--- a/pipelines/polity-autoimprove/00_intake.py
+++ b/pipelines/polity-autoimprove/00_intake.py
@@ -73,6 +73,26 @@ df = pd.read_parquet(A.input) if A.input.endswith(".parquet") else pd.read_csv(A
 n_raw = len(df)
 if A.aggregate_col:
     df = df[~df[A.aggregate_col].astype(bool)]
+
+# REFUSE a period column that is present and unused (issue 434). matchlib.eff_year exists to read
+# "the END year of a period-average label like 1934-1938", and 5.12% of layer B carries its year ONLY
+# there. Without --period-col those rows arrive as year=NA, so any label/candidate group whose only
+# rows are period rows gets years_observed "None-None" -- and 12_triage_assertions.py:149 raises
+# ValueError on that, which froze the triage queue entirely. The failure was silent for exactly the
+# reason a warning would not have helped: the run still printed a healthy routing percentage.
+#
+# Measured on the production input: passing --period-col changes NO row count (189,849 either way) and
+# no assertion count (1,074), but takes null spans 14 -> 0 and reconciles 65 of the 71 triage keys the
+# period-blind run cannot express. So there is no tradeoff to weigh -- an unused period column is
+# always a mistake, which is why this refuses rather than warns.
+if not A.period_col and "period" in getattr(df, "columns", ()):
+    raise SystemExit(
+        "00_intake: the input carries a `period` column but --period-col was not passed, so every "
+        "row whose year lives only in a period label (e.g. '1909-1913') arrives undatable and its "
+        "assertion gets a 'None-None' span that 12_triage_assertions.py cannot parse (issue 434).\n"
+        "  fix: add `--period-col period` to the invocation\n"
+        "  if the column genuinely is not a period-average label, rename it in the input first.")
+
 w = pd.DataFrame({
     "label": df[A.label_col],
     "year":  pd.to_numeric(df[A.year_col], errors="coerce"),

--- a/pipelines/polity-autoimprove/01_match_and_findings.py
+++ b/pipelines/polity-autoimprove/01_match_and_findings.py
@@ -323,7 +323,18 @@ json.dump({"summary": {
           },
           "findings": findings},
           open(f"{OUT}/findings.json","w"), indent=1)
-work[["source","country","iso3c","year","item","value","unit","whep_code","match_method"]] \
+# `period` is carried even though nothing in THIS stage needs it downstream: 5.12% of layer B
+# (9,865 rows -- fao1952 3,702, iia 6,163) has a null `year` and carries its year only in a
+# period-average label like `1909-1913`. This stage already recovers those itself (eff_year(),
+# period_span(), and the coverage-scoring at line 131), but it used to DROP the column here, so
+# 00_intake.py could not be given `--period-col` -- the option exists and matchlib.eff_year was
+# written for exactly this -- and every period row reached it as an undatable year=NA row.
+# The consequence was not misrouting (measured: 9,210 of 9,210 routed period rows land in a polity
+# whose life overlaps their period label, and routing is 98.7% vs 99.7% for dated rows). It was that
+# a label/candidate group whose ONLY overlapping rows are period rows got years_observed
+# "None-None", and 12_triage_assertions.py:149 raises ValueError on that -- so the triage queue
+# could not be regenerated AT ALL, which is why it drifted (issue 434).
+work[["source","country","iso3c","year","period","item","value","unit","whep_code","match_method"]] \
     .to_parquet(f"{OUT}/matched_rows.parquet", index=False)
 
 # coverage by source after

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -575,9 +575,17 @@ python3 pipelines/polity-autoimprove/01_match_and_findings.py     # rebuild matc
 python3 pipelines/polity-autoimprove/00_intake.py \
   --input pipelines/polity-autoimprove/state/matched_rows.parquet \
   --label-col country --year-col year --iso-col iso3c \
-  --value-col value --item-col item --unit-col unit \
+  --value-col value --item-col item --unit-col unit --period-col period \
   --source-col source --prior-code-col whep_code
 ```
+
+`--period-col` is not optional on this input and 00_intake refuses without it (issue 434). 5.12% of
+layer B (9,865 rows: `iia` 6,163, `fao1952` 3,702) has a null `year` and carries its year only in a
+period-average label like `1909-1913`. Omitting the flag changes no row or assertion count -- 189,849
+and 1,074 either way -- but leaves 14 assertions with a `None-None` span, and
+`12_triage_assertions.py:149` raises `ValueError` on those, so the triage queue cannot be regenerated
+at all. It is also what stage 01 had to start carrying: `matched_rows.parquet` did not include the
+column, so the flag could not be passed even deliberately.
 
 `--iso-col` and `--prior-code-col` are what separate the production run from a label-only
 one (88.9% routed against 67.7% for a source that cannot supply them). Run it to `--out` a


### PR DESCRIPTION
Fixes the root cause of #434. The triage queue was not stale because a step was skipped — the step
**could not run**:

```
File "pipelines/polity-autoimprove/12_triage_assertions.py", line 149, in span
    return int(y0), int(y1)
ValueError: invalid literal for int() with base 10: 'None'
```

### Why a span was ever `None`

5.12% of layer B — 9,865 rows, `iia` 6,163 and `fao1952` 3,702 — has a null `year` and carries its year
only in a period-average label like `1909-1913`. `matchlib.eff_year` exists to read exactly that ("the
END year of a period-average label"), and `00_intake.py` already advertised `--period-col` in its own
usage docstring.

Neither could be used: `01_match_and_findings.py` uses the column internally (its own `eff_year`,
`period_span`, the coverage-scoring at line 131) but **dropped it from the explicit column list on
write**. `matched_rows.parquet` had no `period` at all, so the documented invocation could not pass the
flag even deliberately. A label/candidate group whose only overlapping rows are period rows then gets
`years_observed = "None-None"`, and `span()` dies on it.

Poland is the clearest case: `iia` rows run 1913–1945, candidate `POL-1815-1918`, and the sole
overlapping year is 1913 — carried by 13 rows whose `year` is `<NA>` and whose `period` is `1909-1913`.

### What it did *not* cause

I expected misrouting and measured two clean negatives instead:

- routing is **98.7%** for period rows vs **99.7%** for dated rows — one point, not a cliff;
- **9,210 of 9,210** routed period rows land in a polity whose life overlaps their period label. Zero
  land outside it.

So iso-routing 4,159 period rows with a NaN year was not silently picking the wrong era. Worth stating,
because it bounds the fix: this is not a data-correction PR.

### Controlled A/B

Same rebuilt parquet; the only difference is the flag:

| | assertions | rows covered | null spans | dup keys |
|---|---|---|---|---|
| no `--period-col` | 1,074 | 189,849 | 14 | 0 |
| with `--period-col` | 1,074 | 189,849 | **0** | 0 |

Identical assertion count and identical rows covered — the flag *dates rows that were already there*
rather than adding or dropping any. There is no tradeoff to weigh, which is what justifies change 3
below being a refusal rather than a warning.

It also reconciles **65 of the 71** triage keys #434 called dead, against **0 of 71** for the
period-blind run. That reverses the direction I first reported on #434: `assertions.json` is the file
that lost information, and the queue's keys were mostly right. `albania|iia|1929-1941` is the queue's
key, and only the period-aware run can reproduce it.

### Changes

1. `01_match_and_findings.py` adds `period` to the parquet's column list, with the reasoning recorded at
   the write site.
2. The README's production invocation gains `--period-col period`, plus a note on why it is not
   optional on this input.
3. `00_intake.py` **refuses** an input carrying an unused `period` column. A warning would not have
   helped — the broken run prints `deterministic pass: 189,849/190,529 routed (99.6%)` and looks
   healthy. Verified the guard fires on the old invocation and writes no output file.

### Verification

- `12_triage_assertions.py` now **runs to completion** on a freshly generated assertion set (temp
  `--out-triage`/`--out-nesting`; nothing tracked written) — it could not before.
- Null spans 14 → 0; the 9 recoverable groups get real spans (`poland|iia|1913-1913` etc.); the other 4
  reroute to era-correct polities once dated (`turkey` `TUR-1913-1914` → `TUR-1920-2025` + `TUR-1800-1913`).
- All 70 gates pass. No tracked table is touched: `matched_rows.parquet` and `findings.json` are
  gitignored.

### Deliberately not here

Overwriting `state/assertions.json` or `state/assertion_triage.csv`. Regenerating the assertion set also
moves `banked` 155 → 369 and `reopened` 145 → 129 — the ledger catching up, unrelated to periods. That
is a large change to curated state and belongs in its own step with the diff reviewed. This PR makes the
regeneration possible and correct; it does not perform it. #434 stays open for that.
