### PR TITLE
Gate that a queue row's span overlaps the polity it is routed to (#310)

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1543,6 +1543,56 @@ def mutate_outlier_ratio_rewritten(root, gpd, make_valid, affinity):
             f"ordering contract still holds")
 
 
+
+def mutate_triage_span_outside_candidate(root, gpd, make_valid, affinity):
+    """Reroute one queue row to a LIVE polity whose lifetime its own span misses entirely.
+
+    Arm G exists because two rules in the pipeline disagree: `matchlib.eff_year` dates a
+    period-average row to the period's END year, while `01_match_and_findings.py:110-130` picks that
+    row's polity by maximum COVERAGE of the period. Where a period straddles a boundary the row ends
+    up dated outside the lifetime of the polity it is routed to -- 7 assertions and 337 rows on a
+    freshly generated set (issue 310).
+
+    The target polity is chosen LIVE and by measurement, which is what keeps the other arms quiet: a
+    made-up code would trip arm F (orphaned candidate) and prove nothing about G. The row is also
+    chosen with a three-part key, so changing `candidate` cannot disturb arm A -- only a
+    disambiguated key carries the candidate in it. `key` and `inclusion_impossible` are untouched, so
+    arms B and E stay silent too.
+
+    Verified: this mutation produces exactly ONE failure, from G.
+    """
+    import csv as _csv
+    pol = os.path.join(root, "data/final/polities_database.csv")
+    with open(pol, newline="", encoding="utf-8") as fh:
+        spans = {r["polity_code"]: (r["start_year"], r["end_year"]) for r in _csv.DictReader(fh)}
+    spans = {k: (int(a), int(b)) for k, (a, b) in spans.items()
+             if str(a).isdigit() and str(b).isdigit()}
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/assertion_triage.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = target = None
+    for r in rows:
+        if r["key"].count("|") != 2:
+            continue
+        y0, y1 = (int(v) for v in r["years_observed"].split("-"))
+        for code, (s, e) in sorted(spans.items()):
+            if e < y0 or s > y1:
+                victim, target = r, code
+                break
+        if victim:
+            break
+    was = victim["candidate"]
+    victim["candidate"] = target
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"rerouted {victim['key']} from {was} to {target}, a LIVE polity whose lifetime "
+            f"{spans[target][0]}-{spans[target][1]} its own observed span "
+            f"{victim['years_observed']} misses entirely")
+
+
 def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
     """Lower a block's n_items while leaving the item list it describes intact.
 
@@ -3147,6 +3197,14 @@ CASES = (
         "does not match its own values",
         "a recorded spike's factor column rewritten to look ordinary while its three values stay "
         "put, so the one number every judgement here rests on contradicts the row it describes",
+    ),
+    (
+        "validate_assertion_triage.py",
+        mutate_triage_span_outside_candidate,
+        "lies entirely outside",
+        "a queue row rerouted to a LIVE polity whose lifetime its own observed span misses entirely -- "
+        "the shape issue 310's period-dating rule produces, where a row is dated by its period's END "
+        "year but routed by which polity covers MOST of that period",
     ),
     (
         "validate_assertion_triage.py",

--- a/scripts/validate_assertion_triage.py
+++ b/scripts/validate_assertion_triage.py
@@ -18,6 +18,7 @@ Almost nothing here is a pinned count. Five of the six arms recompute the column
     D  n_distinct_years in [1, span width] -- cannot observe more years than the span contains
     E  inclusion_impossible agrees with assertion_nesting_flags.csv   <-- CROSS-TABLE
     F  candidate resolves to a live polity_code
+    G  the observed span INTERSECTS the candidate's lifetime         <-- CROSS-TABLE
 
 E is the arm worth having. `inclusion_impossible` is a copy of a verdict computed in a DIFFERENT
 table, and a copied verdict is exactly the thing that goes stale when its source is regenerated and
@@ -27,16 +28,28 @@ the impossible pairs in assertion_nesting_flags.csv keyed on either side.
 Why no baseline row count: the queue drains on purpose. Pinning 796 would fail on the correct action
 of verifying an assertion, which is the failure mode validate_magnitude_outliers.py exists to avoid.
 
-WHAT THIS GATE DOES NOT CATCH — stated because the coverage is otherwise easy to over-read. Arm A is
-INTERNAL consistency: it proves each key rebuilds from its own three columns, and all 796 do. A row
-that is stale relative to `assertions.json` rebuilds perfectly and passes. Issue 434 is exactly that
-defect and this gate is green on it: 71 queue rows name a span no current assertion has, and 198
+ARM G, and why it is worth having before the resync. `matchlib.eff_year` dates a period-average row
+to the period's END year, but `01_match_and_findings.py:110-130` picks that row's polity by MAXIMUM
+COVERAGE of the period -- it documents rejecting the midpoint on measurement. Those two rules disagree
+wherever a period straddles a polity boundary, and the result is a row dated outside the lifetime of
+the very polity it is routed to. Measured on a freshly generated assertion set (issue 310): 7
+assertions, 337 rows, worst `india|fao1952|1938-1938 -> IND-1914-1937` where all 37 rows are the
+single period `1934-1938` and so date to 1938 against a polity ending 1937.
+
+The committed queue has ZERO violations, so this arm passes today and fires the moment a regeneration
+introduces one. That is the whole point of adding it now rather than after: the defect is currently
+latent in the generator, not in the table.
+
+WHAT THIS GATE STILL DOES NOT CATCH — stated because the coverage is otherwise easy to over-read. Arm
+A is INTERNAL consistency: it proves each key rebuilds from its own three columns, and all 796 do. A
+row that is stale relative to `assertions.json` rebuilds perfectly and passes. Issue 434 is exactly
+that defect and this gate is green on it: 71 queue rows name a span no current assertion has, and 198
 pending/reopened assertions (8.9% of pending panel rows) never reach the queue at all.
 
-The arm that would catch it is a seventh, checking the queue against `assertions.json`. It is absent
-because it would fail on main today, and the resync it demands is a decision about curated state
-(re-running the generator has previously re-banked verdicts over hand retractions). Order is: resync
-under 434, then add the arm. Arm E is the same class of check against a table that IS in sync.
+An arm comparing the queue against `assertions.json` is IMPOSSIBLE IN CI, not merely deferred: that
+file is gitignored and absent there (`validate_verdict_carryover.py` records the same constraint). So
+#434's resync has to be verified by hand at the point it is performed. Arms E and G are the same class
+of cross-table check restricted to tables CI actually has.
 
 Usage:
   python3 scripts/validate_assertion_triage.py
@@ -100,14 +113,21 @@ def main() -> int:
         print(f"FAIL: {os.path.relpath(TABLE, REPO)} has no rows", file=sys.stderr)
         return 1
 
-    live = None
+    live = spans = None
     if os.path.exists(POLITIES):
         with open(POLITIES, encoding="utf-8") as fh:
-            live = {r["polity_code"] for r in csv.DictReader(fh)}
+            pol = list(csv.DictReader(fh))
+        live = {r["polity_code"] for r in pol}
+        spans = {}
+        for r in pol:
+            try:
+                spans[r["polity_code"]] = (int(r["start_year"]), int(r["end_year"]))
+            except (KeyError, TypeError, ValueError):
+                pass
     imposs = impossible_keys()
 
     problems, orphans, seen, orders = [], set(), {}, []
-    rederived = flagged = 0
+    rederived = flagged = overlapped = 0
 
     for i, r in enumerate(rows, start=2):
         key = (r.get("key") or "").strip()
@@ -169,6 +189,22 @@ def main() -> int:
         if live is not None and cand and cand not in live:
             orphans.add(cand)
 
+        # --- G: a span must overlap the lifetime of the polity it is routed to ---
+        # Not "be contained in": a label legitimately reports across a boundary, and the assertion is
+        # then verified by deciding where to split it. What cannot be right is a span that misses the
+        # candidate's life ENTIRELY -- that is a routing claim contradicted by its own dates.
+        if spans is not None and m and cand in spans:
+            y0, y1 = int(m.group(1)), int(m.group(2))
+            s0, s1 = spans[cand]
+            if y1 < s0 or y0 > s1:
+                problems.append(
+                    f"G {where}: observed {span} lies entirely outside {cand}'s lifetime "
+                    f"{s0}-{s1}. The row is dated by the period's END year while 01 picks the polity "
+                    f"by maximum COVERAGE of that period, and the two rules disagree across a "
+                    f"boundary (issue 310)")
+            else:
+                overlapped += 1
+
         tier, status = (r.get("tier") or "").strip(), (r.get("status") or "").strip()
         if tier and tier not in TIERS:
             problems.append(f"{where}: unknown tier {tier!r} — generator and gate disagree about "
@@ -209,7 +245,8 @@ def main() -> int:
           f"inclusion_impossible {flagged}"
           + (f" agreeing with {len(imposs)} nesting keys" if imposs is not None
              else " (nesting table absent, arm E skipped)")
-          + f", orphaned candidates {len(orphans)}")
+          + f", orphaned candidates {len(orphans)}"
+          + f", spans overlapping their candidate {overlapped}")
 
     for p in problems:
         print(f"FAIL: {p}", file=sys.stderr)


### PR DESCRIPTION
Adds a seventh arm to `validate_assertion_triage.py`: **an assertion's observed span must intersect its
candidate's lifetime.**

### The defect it gates

Two rules in the pipeline disagree. `matchlib.eff_year` dates a period-average row to the period's
**END** year; `01_match_and_findings.py:110-130` picks that row's polity by **maximum coverage** of the
period, and documents rejecting the midpoint on measurement. Where a period straddles a polity boundary
they diverge, and the row is dated outside the lifetime of the polity it is routed to.

Measured on a freshly generated assertion set (#310) — 7 assertions, 337 rows:

```
span entirely outside candidate                          rows
  india|fao1952|1938-1938  -> IND-1914-1937 (1914-1937)    37
  brazil|iia|1913-1913     -> BRA-1903-1909 (1903-1909)     1
  cameroon|iia|1913-1913   -> GKM-1884-1912 (1884-1912)     1
  peru|iia|1913-1913       -> PER-1884-1909 (1884-1909)     1
```

`india/fao1952` is the clearest: all 37 rows are the single period `1934-1938`, so every one dates to
1938 against a polity ending 1937. Coverage picked the polity correctly; the end-year rule then pushed
the whole assertion past it.

### Intersection, not containment

Deliberate, and measured: **368 consecutive polity pairs share a boundary year**
(`AFG-1800-1893`/`AFG-1893-1919`, and so on) — that is the repo's own convention, so a containment
check would fail on correct data. A label also legitimately reports across a boundary, and the
assertion is verified by deciding where to split it. What cannot be right is a span that misses the
candidate's life *entirely*: a routing claim contradicted by its own dates.

### Why now rather than after #434's resync

The committed queue has **zero** violations, so this arm passes today and fires the moment a
regeneration introduces one. The defect is currently latent in the generator, not in the table — which
is exactly when a gate is cheapest to add.

### A constraint I had stated wrongly

I previously wrote that an arm comparing the queue against `assertions.json` was merely *deferred*
until the resync. It is **impossible in CI**: `assertions.json` is gitignored and absent there, as
`validate_verdict_carryover.py` already documents. The docstring now says that instead of implying a
future arm, and records that #434's resync has to be verified by hand at the point it is performed.

### Verification

Mutation-tested in isolation: the case reroutes a row to a **live** polity, chosen by measurement,
whose lifetime its span misses — a made-up code would trip arm F and prove nothing about G — and picks
a three-part-key row so changing `candidate` cannot disturb arm A. Produces **exactly one** failure,
from G.

All 71 gates pass. Selftest 88 → 89 cases, full suite green (two cases now cover this gate).
