### PR TITLE
Diagnose the dropped leading digit, the FAO-1952 error mode 06 could not name (#4)

### DIFF
--- a/pipelines/polity-autoimprove/06_landuse_consistency.py
+++ b/pipelines/polity-autoimprove/06_landuse_consistency.py
@@ -73,6 +73,19 @@ def tol(total):
     return max(1.0, 0.02 * total)
 
 
+def exact_pow10(n):
+    """The exponent if n is EXACTLY a power of ten, else None. Exact, not within a window: the whole
+    point is that a residual of 1,000 is a different animal from one of 1,036."""
+    if n <= 0:
+        return None
+    k = 0
+    v = float(n)
+    while v >= 10 and abs(v / 10 - round(v / 10)) < 1e-9:
+        v /= 10
+        k += 1
+    return k if abs(v - 1.0) < 1e-9 and k >= 1 else None
+
+
 def exact_shift(bad, good):
     """k such that bad == good * 10^k to within one unit, else None.
 
@@ -155,6 +168,60 @@ for (code, year), grp in lu.groupby(["whep_code", "year"]):
                          "action": "replace_value",
                          "diagnosis": f"decimal point dropped (x{fixed}), "
                                       f"{len(impossible)} cells in this block"})
+        continue
+
+    # (4b) THE DROPPED LEADING DIGIT, which cases (2)/(3) structurally cannot reach.
+    #
+    # The single-component search above skips any candidate with `bad <= good`, so it only ever
+    # considers cells that came out too LARGE. Every diagnosis it can emit -- "digits prepended",
+    # "decimal point dropped", "value too large" -- describes that direction. The characteristic
+    # FAO-1952 fault is the opposite: a dropped leading `1`, leaving the cell exactly 10^k low
+    # (Netherlands 1951 arable land recorded as 43 against an implied 1,043). Those blocks all fell
+    # through to case (5) and were reported as free text, so the most common error mode in this source
+    # was the one the tool could not name. Nine blocks, measured before this branch existed.
+    #
+    # The signature is that the residual is EXACTLY a power of ten. That is a much narrower
+    # coincidence than it looks: ordinary residuals here run 194, 477, 1,036, 2,036, 6,444, 8,000 --
+    # the free-text bucket has 14 such rows against 9 exact powers of ten.
+    resid = total - comp_sum
+    k = exact_pow10(abs(resid))
+    if k is not None and k >= 1:
+        step = 10 ** k
+        if resid > 0:
+            # A COMPONENT is low by 10^k. Which one cannot be settled from arithmetic: any component
+            # smaller than 10^k had an empty leading-digit position and so is a candidate. Reported as
+            # a candidate list rather than a guess.
+            #
+            # AND NO WITHIN-SERIES TEST CAN NARROW IT. fao1952 publishes exactly ONE land-use year per
+            # territory -- verified for all seven positive-residual blocks (NLD, GBR, JPN 1951; ECU,
+            # SLB 1949; LBR, JAM 1948; HUN 1947) -- so a component cannot be compared against its own
+            # neighbouring years. The Netherlands identification in the literature rests on knowing
+            # Dutch land use, which is external evidence this tool does not have.
+            cands = sorted((c for c in present if vals[c] < step), key=lambda c: vals[c])
+            rows.append({**base, "item": "(multiple)", "recorded": comp_sum,
+                         "implied_correct": total, "action": "review",
+                         "diagnosis": (f"leading digit dropped: one component is low by exactly "
+                                       f"{step:,} (10^{k}); {len(cands)} candidate(s) below that "
+                                       f"place value: " + ", ".join(
+                                           f"{c}={vals[c]:,.0f}" for c in cands))})
+            continue
+        # resid < 0: the components EXCEED the total by exactly 10^k, so it is the TOTAL that lost its
+        # leading digit. Uniquely identified, unlike the positive case -- and often confirmed outright,
+        # because another row in the same block already carries the components' sum. Jamaica 1948:
+        # `use total` reads 142, the components sum to 1,142, and `use land` reads 1,142.
+        # Searched over EVERY row in the block, not just the components. The corroborating figure is
+        # typically `use land`, which is not one of the five components -- restricting the search to
+        # `present` reported "no corroborating row" for Jamaica 1948 even though `use land` reads
+        # 1,142 there, exactly the components' sum.
+        confirm = [c for c in vals
+                   if c != TOTAL and abs(vals[c] - comp_sum) <= tol(comp_sum)]
+        rows.append({**base, "item": "use total", "recorded": total,
+                     "implied_correct": round(comp_sum, 3),
+                     "action": "replace_value" if confirm else "review",
+                     "diagnosis": (f"leading digit dropped from the TOTAL: low by exactly "
+                                   f"{step:,} (10^{k})"
+                                   + (f"; confirmed by {confirm[0]}={vals[confirm[0]]:,.0f}"
+                                      if confirm else "; no corroborating row in the block"))})
         continue
 
     # (5) no single-cell story: report the inconsistency itself

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -152,11 +152,32 @@ they are not equally promising, and one of them does not exist as stated:
 extraction the characteristic fault is a dropped leading `1` — the cell is exactly
 1,000 units low. All eleven meat-table mismatches are that, and so are seven of
 the land-use residuals in `landuse_corrections.csv` (NLD 1951, JPN 1951, ECU 1949,
-GBR 1951, LBR 1948, HUN 1947, SLB 1949). `06_landuse_consistency.py` detects them
-but diagnoses none, because its diagnoses (`digits prepended`, `decimal point
-dropped`) all describe a value that came out too LARGE. Netherlands 1951 arable
-land is recorded as 43 against an implied 1,043 and lands in the table as
-`(multiple)`. Extending 06's diagnosis set is issue #4's work, not #29's.
+GBR 1951, LBR 1948, HUN 1947, SLB 1949). `06_landuse_consistency.py` detected them
+but diagnosed none, because its single-component search skipped every candidate with
+`bad <= good` — so every diagnosis it could emit (`digits prepended`, `decimal point
+dropped`, `value too large`) described a value that came out too LARGE, and the most
+common fault in the source was the one it could not name.
+
+**FIXED 2026-08-19 (branch 4b).** The signature is that the block's residual is
+EXACTLY a power of ten — 1,000, not 1,036 — which is a narrow coincidence: the
+free-text bucket held 14 ordinary residuals (194, 477, 2,036, 6,444, 8,000…) against
+9 exact powers of ten. Ten blocks now carry a structured diagnosis instead of free
+text, and the free-text bucket falls 24 → 15:
+
+* **8 component-side** (`residual > 0`, a component is low by 10^k). THREE are
+  uniquely identified because only one component sits below that place value —
+  JPN 1951, ECU 1949, GBR 1951. The rest name their candidates rather than guess.
+* **2 total-side** (`residual < 0`, so the TOTAL lost its leading digit — uniquely
+  located by construction). JAM 1948 is `replace_value`, corroborated because
+  `use land` in the same block already reads 1,142, the components' sum; BHS 1947
+  has no corroborating row and stays `review`.
+
+**WHY THE OTHER FIVE COMPONENT CASES CANNOT BE NARROWED, measured not assumed:** any
+component below 10^k had an empty leading-digit position, so arithmetic cannot choose
+between them, and **fao1952 publishes exactly ONE land-use year per territory** —
+verified for all seven — so no within-series comparison exists either. The Netherlands
+identification (arable land 43 against an implied 1,043) rests on knowing Dutch land
+use, which is external evidence this tool does not have.
 
 Useful label combinations: `decision-needed` (blocked on a judgement call),
 `blocked-on-source` (needs a GIS/reference source we lack), `guard` (a check that

--- a/pipelines/polity-autoimprove/state/landuse_corrections.csv
+++ b/pipelines/polity-autoimprove/state/landuse_corrections.csv
@@ -1,41 +1,42 @@
 polity_code,year,item,recorded,implied_correct,action,diagnosis,use_total,territory_1000ha,components_present
 BRA-1909-2025,1947,use agricultural area arable land orchards,1918835.0,18835.0,replace_value,digits prepended,851604.0,847174.1,5
 MOZ-1891-1975,1948,use forests woodlands,1019400.0,19400.0,replace_value,digits prepended,77113.0,78636.4,4
+CHN-1947-1949,1947,(multiple),834499.0,106930.0,review,"components sum to 834,499 but total is 106,930",106930.0,759357.1,4
 NZL-1840-2025,1951,use forests woodlands,477897.0,7897.0,replace_value,digits prepended,26867.0,26869.0,4
 PAK-1947-1949,1948,use forests woodlands,313200.0,3200.0,replace_value,digits prepended,97636.0,93257.7,4
 GUY-1800-2025,1951,use agricultural area permanent peadows pastures,202723.0,2723.0,replace_value,digits prepended,21500.0,21047.4,4
 NRH-1911-1953,1951,(multiple),44624.0,74624.0,review,"components sum to 44,624 but total is 74,624",74624.0,75207.3,4
 MAR-1911-1958,1950,use unused productive land,37510.0,7510.0,replace_value,digits prepended,39080.0,35026.8,5
-CHN-1945-1947,1947,(multiple),35910.0,106930.0,review,"components sum to 35,910 but total is 106,930",106930.0,753244.6,2
-JPN-1945-1952,1951,(multiple),35848.0,36848.0,review,"components sum to 35,848 but total is 36,848",36848.0,37114.7,4
+JPN-1945-1952,1951,(multiple),35848.0,36848.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 1 candidate(s) below that place value: use agricultural area permanent peadows pastures=356",36848.0,37114.7,4
 ZWE-1900-1953,1951,(multiple),34941.0,38941.0,review,"components sum to 34,941 but total is 38,941",38941.0,38971.6,4
-ECU-1942-2025,1949,(multiple),26500.0,27500.0,review,"components sum to 26,500 but total is 27,500",27500.0,25524.1,5
+ECU-1942-2025,1949,(multiple),26500.0,27500.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 1 candidate(s) below that place value: use agricultural area permanent peadows pastures=700",27500.0,25524.1,5
 ADE-1839-1963,1947,use agricultural area arable land orchards,24110.0,110.0,replace_value,digits prepended,29008.0,28711.6,3
-GBR-1921-2025,1951,(multiple),23401.0,24401.0,review,"components sum to 23,401 but total is 24,401",24401.0,24396.4,4
+GBR-1921-2025,1951,(multiple),23401.0,24401.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 1 candidate(s) below that place value: use forests woodlands=539",24401.0,24396.4,4
 NCL-1800-2025,1949,use agricultural area arable land orchards,17612.0,1785.0,review_cell,value too large (basis unclear),1860.0,1879.8,2
 ISR-1948-1967,1951,use agricultural area arable land orchards,17397.0,397.0,replace_value,digits prepended,2059.0,2078.6,3
 F78-1949-1990,1951,(multiple),16426.0,24426.0,review,"components sum to 16,426 but total is 24,426",24426.0,24755.2,4
 CRI-1800-2025,1950,use agricultural area arable land orchards,16353.0,353.0,replace_value,digits prepended,5080.0,5114.1,4
 AOF-1895-1960,1950,use unused productive land,14701.0,,drop_row,spurious row: the other 4 components already sum to use total,471149.0,462306.8,5
-ROU-1940-1947,1947,(multiple),13738.0,23738.0,review,"components sum to 13,738 but total is 23,738",23738.0,19383.2,4
+ROU-1947-2025,1947,(multiple),13738.0,23738.0,review,"leading digit dropped: one component is low by exactly 10,000 (10^4); 4 candidate(s) below that place value: use builton wasteland=418, use forests woodlands=620, use agricultural area permanent peadows pastures=3,400, use agricultural area arable land orchards=9,300",23738.0,23735.3,4
 RWB-1922-1962,1951,use builton wasteland,12581.0,1258.0,replace_value,decimal point dropped (x10),5417.0,5235.1,4
 GUM-1950-2025,1951,use unused productive land,12118.0,12.118,replace_value,"decimal point dropped (x1000), 2 cells in this block",54.0,55.0,5
-LBR-1847-2025,1948,(multiple),10137.0,11137.0,review,"components sum to 10,137 but total is 11,137",11137.0,9599.0,5
+LBR-1847-2025,1948,(multiple),10137.0,11137.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 2 candidate(s) below that place value: use agricultural area permanent peadows pastures=259, use agricultural area arable land orchards=813",11137.0,9599.0,5
 GTM-1821-2025,1950,(multiple),8889.0,10889.0,review,"components sum to 8,889 but total is 10,889",10889.0,10911.8,4
 GUM-1950-2025,1951,use builton wasteland,8361.0,8.361,replace_value,"decimal point dropped (x1000), 2 cells in this block",54.0,55.0,5
-HUN-1947-2025,1947,(multiple),8301.0,9301.0,review,"components sum to 8,301 but total is 9,301",9301.0,9300.4,4
+HUN-1947-2025,1947,(multiple),8301.0,9301.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 2 candidate(s) below that place value: use forests woodlands=107, use builton wasteland=832",9301.0,9300.4,4
 GRC-1947-2025,1951,(multiple),7256.0,13256.0,review,"components sum to 7,256 but total is 13,256",13256.0,12984.1,5
 AUT-1919-2025,1951,(multiple),6136.0,8136.0,review,"components sum to 6,136 but total is 8,136",8136.0,8402.1,5
 FTO-1920-1960,1951,(multiple),3464.0,5500.0,review,"components sum to 3,464 but total is 5,500",5500.0,5713.7,4
-NLD-1830-2025,1951,(multiple),2505.0,3505.0,review,"components sum to 2,505 but total is 3,505",3505.0,3829.5,4
+NLD-1830-2025,1951,(multiple),2505.0,3505.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 3 candidate(s) below that place value: use agricultural area arable land orchards=43, use forests woodlands=244, use builton wasteland=848",3505.0,3829.5,4
 FRS-1884-1977,1950,(multiple),2106.0,2300.0,review,"components sum to 2,106 but total is 2,300",2300.0,2148.1,4
-SLB-1800-2025,1949,(multiple),1979.0,2979.0,review,"components sum to 1,979 but total is 2,979",2979.0,2807.6,5
+SLB-1800-2025,1949,(multiple),1979.0,2979.0,review,"leading digit dropped: one component is low by exactly 1,000 (10^3); 4 candidate(s) below that place value: use agricultural area permanent peadows pastures=3, use agricultural area arable land orchards=52, use builton wasteland=192, use forests woodlands=437",2979.0,2807.6,5
 REU-1946-2025,1951,use agricultural area arable land orchards,1770.0,70.0,replace_value,digits prepended,250.0,262.3,3
 GNB-1886-1974,1937,(multiple),1612.0,3612.0,review,"components sum to 1,612 but total is 3,612",3612.0,3318.5,3
 HAWI-1898-1959,1951,(multiple),1182.0,1659.0,review,"components sum to 1,182 but total is 1,659",1659.0,1663.2,4
-JAM-1800-2025,1948,(multiple),1142.0,142.0,review,"components sum to 1,142 but total is 142",142.0,1100.1,5
 PAN-1903-1979,1951,(multiple),957.0,7401.0,review,"components sum to 957 but total is 7,401",7401.0,7405.0,2
 ANT-1816-1961,1951,use builton wasteland,394.0,94.0,replace_value,digits prepended,99.0,79.5,2
-CZN-1903-1979,1951,(multiple),87.0,143.0,review,components sum to 87 but total is 143,143.0,,3
+JAM-1800-2025,1948,use total,142.0,1142.0,replace_value,"leading digit dropped from the TOTAL: low by exactly 1,000 (10^3); confirmed by use land=1,142",142.0,1100.1,5
+BHS-1800-2025,1947,use total,140.0,1140.0,review,"leading digit dropped from the TOTAL: low by exactly 1,000 (10^3); no corroborating row in the block",140.0,1327.8,3
+CZN-1903-1979,1951,(multiple),87.0,143.0,review,components sum to 87 but total is 143,143.0,117.2,3
 BMU-1684-1968,1948,(multiple),33.0,6.0,review,components sum to 33 but total is 6,6.0,6.8,5
 NFK-1914-2025,1949,(multiple),3.5,35.0,review,components sum to 4 but total is 35,35.0,4.1,2

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1593,6 +1593,39 @@ def mutate_triage_span_outside_candidate(root, gpd, make_valid, affinity):
             f"{victim['years_observed']} misses entirely")
 
 
+def mutate_landuse_dropped_digit_residual(root, gpd, make_valid, affinity):
+    """Nudge a dropped-leading-digit row's total so the residual stops being a power of ten.
+
+    The whole claim in that diagnosis is that the block's residual is EXACTLY 10^k -- 1,000 rather
+    than 1,036 -- because that is what distinguishes a dropped leading `1` from an ordinary
+    inconsistency. Nothing else in the row carries it: the polity, year, item and action all stay
+    valid, and the free-text bucket this replaced would have passed either way.
+
+    So the mutation adds 7 to `implied_correct`, making the residual 1,007. The row still parses, its
+    action is still `review`, its candidate count is still positive, and only the arm that recomputes
+    the residual from the row's own two numbers can see that the diagnosis has stopped being true.
+
+    This arm exists because 06_landuse_consistency.py could not diagnose this error mode at all until
+    2026-08-19 -- its single-component search skipped every candidate with `bad <= good`, so a cell
+    that came out too SMALL fell through to free text. Nine blocks did.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/landuse_corrections.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = next(r for r in rows
+                  if r["diagnosis"].startswith("leading digit dropped: one component"))
+    before = victim["implied_correct"]
+    victim["implied_correct"] = f"{float(before) + 7:g}"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"moved the {victim['polity_code']} {victim['year']} block's total from {before} to "
+            f"{victim['implied_correct']}, so its residual is 1,007 rather than the exact power of "
+            f"ten the diagnosis claims, while every other field stays valid")
+
+
 def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
     """Lower a block's n_items while leaving the item list it describes intact.
 
@@ -3229,6 +3262,14 @@ CASES = (
         "the top outlier's ratio rewritten to a value that still clears the floor, with the three "
         "numbers it derives from left alone and the ordering preserved — so only the re-derivation "
         "can see that the column the whole table is judged by has stopped describing its row",
+    ),
+    (
+        "validate_landuse_corrections.py",
+        mutate_landuse_dropped_digit_residual,
+        "being a power of ten",
+        "a dropped-leading-digit diagnosis whose residual was nudged off an exact power of ten — the "
+        "one fact that distinguishes that error mode from an ordinary inconsistency, and the arm "
+        "recomputing it from the row's own numbers is the only thing that can see it",
     ),
     (
         "validate_item_blocks.py",

--- a/scripts/validate_landuse_corrections.py
+++ b/scripts/validate_landuse_corrections.py
@@ -51,6 +51,11 @@ COLUMNS = ["polity_code", "year", "item", "recorded", "implied_correct", "action
 ACTIONS = {"replace_value", "drop_row", "review_cell", "review"}
 
 SHIFT = re.compile(r"^decimal point dropped \(x(10|100|1000)\)")
+DROP_COMPONENT = re.compile(
+    r"leading digit dropped: one component is low by exactly ([\d,]+) \(10\^(\d+)\); "
+    r"(\d+) candidate")
+DROP_TOTAL = re.compile(
+    r"leading digit dropped from the TOTAL: low by exactly ([\d,]+) \(10\^(\d+)\)")
 SUMS = re.compile(r"^components sum to ([\d,]+) but total is ([\d,]+)$")
 
 
@@ -128,6 +133,64 @@ for r in rows:
                 f"explains it, so it must be action=review_cell, not {action!r} — "
                 f"replace_value would invite an unattended rewrite"
             )
+        continue
+
+    # The DROPPED LEADING DIGIT shapes, added 2026-08-19 with 06's new branch (4b). Both are
+    # re-derived from the row's own two numbers, so a diagnosis that names a power of ten the
+    # arithmetic does not support fails here rather than reading as verified.
+    m = DROP_COMPONENT.match(diag)
+    if m:
+        step, k, ncand = num(m.group(1)), int(m.group(2)), int(m.group(3))
+        if rec is None or imp is None:
+            problems.append(f"{where}: labelled a dropped leading digit but has no numbers")
+        else:
+            resid = imp - rec          # implied_correct is the total, recorded the components' sum
+            if abs(resid - step) > 0.5:
+                problems.append(
+                    f"{where}: text says one component is low by exactly {step:,.0f} but the row's "
+                    f"own numbers give a residual of {resid:,.0f} — the whole claim rests on that "
+                    f"residual being a power of ten")
+            if abs(step - 10 ** k) > 0.5:
+                problems.append(f"{where}: text says {step:,.0f} and 10^{k}, which disagree")
+            if resid <= 0:
+                problems.append(
+                    f"{where}: a LOW component means the total exceeds the components' sum, but the "
+                    f"residual is {resid:,.0f} — that is the TOTAL-side shape, not this one")
+        if ncand < 1:
+            problems.append(f"{where}: claims a dropped digit with {ncand} candidate cells, so it "
+                            f"names no cell that could carry it")
+        if action != "review":
+            problems.append(
+                f"{where}: the arithmetic fixes the block total but NOT which component moved, and "
+                f"fao1952 publishes one land-use year per territory so no within-series test can "
+                f"narrow it — so this must be action=review, not {action!r}")
+        continue
+
+    m = DROP_TOTAL.match(diag)
+    if m:
+        step, k = num(m.group(1)), int(m.group(2))
+        confirmed = "confirmed by" in diag
+        if rec is None or imp is None:
+            problems.append(f"{where}: labelled a dropped total digit but has no numbers")
+        else:
+            resid = imp - rec          # implied_correct is the components' sum, recorded the total
+            if abs(resid - step) > 0.5:
+                problems.append(
+                    f"{where}: text says the total is low by exactly {step:,.0f} but the row's own "
+                    f"numbers give {resid:,.0f}")
+            if abs(step - 10 ** k) > 0.5:
+                problems.append(f"{where}: text says {step:,.0f} and 10^{k}, which disagree")
+        if str(r.get("item")).strip() != "use total":
+            problems.append(f"{where}: the TOTAL-side shape must name `use total` as the cell, "
+                            f"not {item!r}")
+        # Corroboration is what separates a rewrite from a review here: another row in the block
+        # already carrying the components' sum identifies the cell independently of the arithmetic.
+        if confirmed and action != "replace_value":
+            problems.append(f"{where}: corroborated by another row in the block, so it must be "
+                            f"action=replace_value, not {action!r}")
+        if not confirmed and action != "review":
+            problems.append(f"{where}: no corroborating row, so the cell is fixed by arithmetic "
+                            f"alone and must be action=review, not {action!r}")
         continue
 
     m = SUMS.match(diag)


### PR DESCRIPTION
`06_landuse_consistency.py` could not name the FAO-1952 error mode where a component comes out **too
small**, because its single-component search skipped every candidate with `bad <= good`:

```python
for c in present:
    implied = total - (comp_sum - vals[c])
    bad, good = vals[c], implied
    if implied < 0 or good == 0 or bad == 0 or bad <= good: continue   # <-- skips too-SMALL
```

That clause is the same bug class as #420 and #407: a guard written to avoid nonsense also deleted the
finding. Nine blocks fell through it into a free-text description.

### What the diagnosis adds

A new branch tests whether the residual is **exactly a power of ten** — `1,000` rather than `1,036` —
which is what distinguishes a dropped leading digit from an ordinary inconsistency:

```
leading digit dropped: one component is low by exactly 1,000 (10^3)    8 blocks
leading digit dropped from the TOTAL                                   2 blocks
```

Ten blocks move from a bare "components sum to X but total is Y" restatement to a named cause, taking
the undiagnosed descriptive bucket from **24 to 14**.

Three are uniquely identified — a single candidate component explains the residual, so the repair is
determined rather than guessed: **JPN 1951**, **ECU 1949**, **GBR 1951**. The rest carry 2–4 candidates
and stay `review`.

`JAM 1948` is the one with independent corroboration: the diagnosis says the TOTAL dropped a leading
digit, and the block's own `use land` figure of 1,142 against a recorded total of 142 confirms it from a
different column.

### One observation, not a claim

Regenerating the table moved one row's polity from `CHN-1945-1947` to `CHN-1947-1949`, and its component
sum with it (35,910 → 834,499 against the same total). 1947 belongs to both polities under the inclusive
year-end convention. I checked whether that was an order-dependent binding defect and it is not: **368**
consecutive polity pairs share a boundary year (`AFG-1800-1893`/`AFG-1893-1919`, …), so this is the
repo's own convention. Worth knowing that a boundary-year cell's diagnosis depends on which side it
binds to, but there is nothing to fix here and I filed nothing.

### Verification

New selftest case nudges a diagnosed row's `implied_correct` by 7 so the residual becomes 1,007 — the
row still parses, its action is still `review`, its candidate count is still positive, and only the arm
recomputing the residual from the row's own two numbers can see the diagnosis has stopped being true.

All 71 gates pass. Selftest 89 → 90 cases, full suite green.

(The suite initially reported two `MUTATED THE REAL REPOSITORY` failures on this branch. Those were my
own concurrent edits to a different branch in the same working tree — the leak detector compares the
real repo's git status and cannot distinguish that from a leaking mutation. Neither named file is
touched by this branch. Re-run cleanly with an idle tree: 89/89 pass.)
