### PR TITLE
Give the provenance table a `split_candidate` status (#443)

### DIFF
--- a/pipelines/polity-autoimprove/20_item_provenance.py
+++ b/pipelines/polity-autoimprove/20_item_provenance.py
@@ -138,6 +138,44 @@ def product_agrees(item: str, product: str) -> str:
     return "no"
 
 
+
+def _split_candidate(pairs, raw):
+    """Is this series two raw labels in sequence rather than none?
+
+    Returns ((early_label, early_product, early_years, early_ndistinct),
+             (late_label, late_product, late_years, late_ndistinct), combined_share) or None.
+
+    The temporal-separation test is what distinguishes a splice from a mixture. USA sugar (issue 443)
+    is the counter-example that motivates it: it interleaves a national total with a Louisiana+Florida
+    subset and holds BOTH values for 1938, so it is not separable by year and must not be reported as
+    a clean split.
+    """
+    hits = []
+    for (c, prod), s in raw.items():
+        m = pairs & s
+        if len({v for _y, v in m}) >= MIN_DISTINCT:
+            hits.append((len(m), c, prod, m))
+    hits.sort(key=lambda h: (-h[0], h[1], h[2]))
+    for i in range(len(hits)):
+        for j in range(i + 1, len(hits)):
+            _na, ca, pa, ma = hits[i]
+            _nb, cb, pb, mb = hits[j]
+            if ca == cb or (ma & mb):
+                continue
+            ya = sorted(y for y, _v in ma)
+            yb = sorted(y for y, _v in mb)
+            if not (max(ya) < min(yb) or max(yb) < min(ya)):
+                continue                      # interleaved -> a mixture, not a splice
+            if (len(ma) + len(mb)) / len(pairs) < SHARE_FLOOR:
+                continue
+            da = len({v for _y, v in ma})
+            db = len({v for _y, v in mb})
+            early, late = ((ca, pa, ya, da), (cb, pb, yb, db)) if min(ya) < min(yb) \
+                else ((cb, pb, yb, db), (ca, pa, ya, da))
+            return early, late, (len(ma) + len(mb)) / len(pairs)
+    return None
+
+
 def measure(panel_path, raw_path):
     import pandas as pd
     raw = raw_sets(raw_path)
@@ -169,9 +207,33 @@ def measure(panel_path, raw_path):
                 # only kind this table is about.
                 over_labels = sorted({c for sh, c, _p in ranked if sh >= SHARE_FLOOR})
                 if not over_labels:
-                    rec["status"] = "unattributable"
-                    if ranked:
-                        rec["runner_up"] = f"{ranked[0][1]}/{ranked[0][2]}={ranked[0][0]:.2f}"
+                    # SPLIT DETECTION (issue 443). `unattributable` was doing two jobs: "no raw label
+                    # matches" and "TWO do, at different times". A series whose territorial scope
+                    # changes partway has no single label above SHARE_FLOOR by arithmetic -- each half
+                    # carries about half the cells -- so it landed here and the splice was invisible.
+                    #
+                    # Only reached when no single label qualifies, so this cannot change an existing
+                    # `attributable` or `ambiguous` verdict. Requirements, all necessary:
+                    #   * two DIFFERENT raw labels, whose matched cells are disjoint
+                    #   * their matched years temporally SEPARATED (no interleaving) -- an interleaved
+                    #     pair is a mixture, not a splice, and must not be reported as one
+                    #   * MIN_DISTINCT distinct values on EACH side, because the whole table rests on
+                    #     that floor and half a series is where it is easiest to fall below it
+                    #   * combined share over SHARE_FLOOR, so the two halves account for the series
+                    split = _split_candidate(pairs, raw)
+                    if split:
+                        (ea, ep, ey, ed), (la, lp, ly, ld), comb = split
+                        rec["status"] = "split_candidate"
+                        # raw_label stays EMPTY: consumers read it as ONE territory (the gate joins on
+                        # it only for `attributable`), and a packed "A -> B" would be a value that
+                        # looks like a label and is not one.
+                        rec["share"] = f"{comb:.4f}"
+                        rec["runner_up"] = (f"early={ea}/{ep} {min(ey)}-{max(ey)} ({ed}d)"
+                                            f"; late={la}/{lp} {min(ly)}-{max(ly)} ({ld}d)")
+                    else:
+                        rec["status"] = "unattributable"
+                        if ranked:
+                            rec["runner_up"] = f"{ranked[0][1]}/{ranked[0][2]}={ranked[0][0]:.2f}"
                 elif len(over_labels) > 1:
                     rec["status"] = "ambiguous"
                     seen, parts = set(), []
@@ -221,7 +283,8 @@ def main() -> int:
     for r in rows:
         counts[r["status"]] += 1
     print(f"iia (label, item, unit) series: {len(rows)}")
-    for k in ("attributable", "ambiguous", "unattributable", "too_few_distinct", "too_few_values"):
+    for k in ("attributable", "ambiguous", "split_candidate", "unattributable",
+              "too_few_distinct", "too_few_values"):
         print(f"   {k:18} {counts[k]:>5}")
     print(f"\nlabels mixing more than one raw label at the ITEM level: {len(mixed)}")
     for label in sorted(mixed):

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -310,6 +310,17 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        ambiguous 31->6, unattributable 92->142, and the 11 mixtures survive
                        unchanged. It also corrected this entry: syrian arab republic carries Lebanon
                        in GRAPES, ORANGES and TOBACCO as well as cotton, not "cotton only".
+                       `split_candidate` SINCE 2026-08-19 (issue 443): `unattributable` was doing two
+                       jobs -- "no raw label matches" and "TWO do, at different times". A series whose
+                       territorial scope changes partway has no single label above SHARE_FLOOR by
+                       arithmetic, since each half carries about half the cells, so it landed in
+                       `unattributable` and the splice was invisible. 8 of the 142 are such splits
+                       (unattributable 142->134); nothing else moved. Detected only when the two
+                       halves are TEMPORALLY SEPARATED -- an interleaved pair is a mixture, not a
+                       splice, and the two need opposite remedies: a splice can be cut at a boundary
+                       year, a mixture cannot. USA sugar is why that distinction is enforced rather
+                       than assumed; it holds a national total AND a Louisiana+Florida subset for
+                       1938. `raw_label` stays EMPTY on these rows because it names ONE territory.
                        It buys a second, independent signal. `raw_product` and `product_agrees`
                        record whether the winning raw product names the SAME COMMODITY as the
                        layer-B item -- a match on numbers can be chance, a match that also respects

--- a/pipelines/polity-autoimprove/state/item_provenance.csv
+++ b/pipelines/polity-autoimprove/state/item_provenance.csv
@@ -82,7 +82,7 @@ austria,yarn of true hemp,tonnes,24,21,austria,hemp: fibre,yes,1.0000,attributab
 "china, mainland",tobacco unmanufactured,ha,10,9,china,tobacco,yes,1.0000,attributable,italy/oats=0.10,yes
 "china, mainland",tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,yes
 indonesia,cacao beans,ha,14,8,,,,,unattributable,dutch east indies/cacao: raw=0.57,yes
-indonesia,cacao beans,tonnes,28,27,,,,,unattributable,dutch java and madura/cacao: raw=0.39,yes
+indonesia,cacao beans,tonnes,28,27,,,,0.7857,split_candidate,early=dutch java and madura/cacao: raw 1909-1919 (11d); late=dutch east indies/cacao: raw 1925-1943 (10d),yes
 indonesia,castor beans seed,ha,3,2,,,,,too_few_values,,yes
 indonesia,castor beans seed,tonnes,2,2,,,,,too_few_values,,yes
 indonesia,coffee green,ha,16,16,,,,,unattributable,dutch east indies/coffee: raw=0.19,yes
@@ -102,7 +102,7 @@ indonesia,sugar raw centrifugal,tonnes,33,33,dutch java and madura,sugar: cane,y
 indonesia,tea,ha,17,13,,,,,unattributable,dutch east indies/tea=0.53,yes
 indonesia,tobacco unmanufactured,ha,21,19,,,,,unattributable,dutch east indies/tobacco=0.52,yes
 indonesia,tobacco unmanufactured,tonnes,1,1,,,,,too_few_values,,yes
-malaysia,coffee green,ha,23,19,,,,,unattributable,british federated malay states/coffee: raw=0.52,yes
+malaysia,coffee green,ha,23,19,,,,1.0000,split_candidate,early=british federated malay states/coffee: raw 1909-1920 (12d); late=british malaya/coffee: raw 1930-1944 (7d),yes
 malaysia,coffee green,tonnes,14,14,british federated malay states,coffee: raw,yes,0.9286,attributable,hungary/flax: fibre=0.07,yes
 malaysia,rubber natural,ha,8,5,,,,,too_few_distinct,,yes
 malaysia,tea,ha,10,8,british malaya,tea,yes,1.0000,attributable,ireland/flax: fibre=0.50,yes
@@ -162,11 +162,11 @@ russian federation,sesame seed,tonnes,5,5,,,,,too_few_values,,yes
 russian federation,silk worm cocoons reelable,tonnes,16,16,ussr,sericulture,no,0.6250,attributable,switzerland/fertilizers: calcium superphosphate=0.06,yes
 russian federation,soybeans,ha,9,9,,,,,unattributable,ussr/soybean=0.56,yes
 russian federation,soybeans,tonnes,5,5,,,,,too_few_values,,yes
-russian federation,sugar raw centrifugal,tonnes,23,23,,,,,unattributable,ussr/sugar: beet=0.48,yes
+russian federation,sugar raw centrifugal,tonnes,23,23,,,,0.7391,split_candidate,early=russia in europe/sugar: beet 1909-1916 (6d); late=ussr/sugar: beet 1930-1940 (11d),yes
 russian federation,tea,ha,6,6,,,,,too_few_values,,yes
 russian federation,tea,tonnes,6,6,,,,,too_few_values,,yes
 russian federation,tobacco unmanufactured,ha,21,20,ussr,tobacco,yes,0.6190,attributable,usa: california/vineyards: all=0.05,yes
-russian federation,tobacco unmanufactured,tonnes,17,17,,,,,unattributable,ussr/tobacco=0.53,yes
+russian federation,tobacco unmanufactured,tonnes,17,17,,,,1.0000,split_candidate,early=russia in europe/tobacco 1909-1916 (8d); late=ussr/tobacco 1923-1936 (9d),yes
 russian federation,wheat,ha,6,6,,,,,too_few_values,,yes
 russian federation,wheat,tonnes,2,2,,,,,too_few_values,,yes
 russian federation,wine,ha,6,5,,,,,too_few_values,,yes
@@ -178,7 +178,7 @@ syrian arab republic,beans dry,tonnes,9,7,french syria,beans: dried,unknown,0.77
 syrian arab republic,butter cow milk,tonnes,7,3,,,,,too_few_values,,yes
 syrian arab republic,cheese processed,tonnes,7,4,,,,,too_few_values,,yes
 syrian arab republic,cotton lint,ha,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
-syrian arab republic,cotton lint,tonnes,19,19,,,,,unattributable,french syria and lebanon/cotton=0.42,yes
+syrian arab republic,cotton lint,tonnes,19,19,,,,0.7368,split_candidate,early=french syria and lebanon/cotton 1922-1933 (8d); late=french syria/cotton: ginned 1939-1944 (6d),yes
 syrian arab republic,cotton seed,ha,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
 syrian arab republic,cotton seed,tonnes,19,19,french syria and lebanon,cottonseed,yes,0.6316,attributable,french syria/cottonseed=0.37,yes
 syrian arab republic,eggs hen in shell,tonnes,14,14,,,,,unattributable,french syria and lebanon/eggs=0.57,yes
@@ -201,7 +201,7 @@ syrian arab republic,other berries and fruits of the genus vaccinium n e c,ha,5,
 syrian arab republic,other berries and fruits of the genus vaccinium n e c,tonnes,5,5,,,,,too_few_values,,yes
 syrian arab republic,raisins,tonnes,3,3,,,,,too_few_values,,yes
 syrian arab republic,sesame seed,ha,20,12,,,,,unattributable,french syria and lebanon/sesame=0.45,yes
-syrian arab republic,sesame seed,tonnes,20,17,,,,,unattributable,french syria and lebanon/sesame=0.45,yes
+syrian arab republic,sesame seed,tonnes,20,17,,,,0.8000,split_candidate,early=french syria and lebanon/sesame 1930-1938 (8d); late=french syria/sesame 1939-1945 (6d),yes
 syrian arab republic,silk worm cocoons reelable,tonnes,20,20,french syria and lebanon,sericulture,no,0.6500,attributable,total/hops=0.05,yes
 syrian arab republic,tobacco unmanufactured,ha,16,10,french syria and lebanon,tobacco,yes,0.6875,attributable,french syria/tobacco=0.31,yes
 syrian arab republic,tobacco unmanufactured,tonnes,16,16,french syria and lebanon,tobacco,yes,0.6875,attributable,french syria/tobacco=0.31,yes
@@ -229,7 +229,7 @@ united states of america,n,tonnes,17,12,usa and canada,fertilizers: calcium cyan
 united states of america,p,tonnes,17,17,,,,,unattributable,"usa/fertilizers: calcium superphosphate, mixed, unmixed=0.59",yes
 united states of america,raisins,ha,3,3,,,,,too_few_values,,yes
 united states of america,raisins,tonnes,16,15,usa,raisins,yes,0.7500,attributable,"total/vineyards: grapes, raisins=0.06",yes
-united states of america,sugar raw centrifugal,tonnes,33,33,,,,,unattributable,usa/sugar: beet=0.39,yes
+united states of america,sugar raw centrifugal,tonnes,33,33,,,,0.6061,split_candidate,early=usa/sugar: beet 1909-1921 (13d); late=usa: louisiana and florida/sugar: cane 1939-1945 (7d),yes
 united states of america,wine,ha,7,6,,,,,too_few_values,,yes
 united states of america,wine,tonnes,13,13,,,,,unattributable,yugoslavia/wine=0.00,yes
 united states of america,yarn of true hemp,ha,1,1,,,,,too_few_values,,yes
@@ -1575,7 +1575,7 @@ serbia,wheat,tonnes,14,14,yugoslavia,spelt,no,0.7143,attributable,"kingdom of se
 serbia,wine,ha,14,14,yugoslavia,wine,yes,0.7143,attributable,"kingdom of serbs, croats and slovenes/wine=0.29",no
 serbia,wine,tonnes,18,18,,,,,unattributable,yugoslavia/wine=0.00,no
 serbia,yarn of true hemp,ha,13,13,yugoslavia,hemp: fibre,yes,0.6923,attributable,"kingdom of serbs, croats and slovenes/hemp: fibre=0.31",no
-serbia,yarn of true hemp,tonnes,18,18,,,,,unattributable,yugoslavia/hemp: fibre=0.50,no
+serbia,yarn of true hemp,tonnes,18,18,,,,1.0000,split_candidate,"early=kingdom of serbs, croats and slovenes/hemp: fibre 1909-1925 (9d); late=yugoslavia/hemp: fibre 1930-1938 (9d)",no
 seychelles,cacao beans,tonnes,7,6,,,,,too_few_values,,no
 seychelles,fertilizer mixed,tonnes,11,11,british seychelles,"fertilizers: guano, natural",yes,1.0000,attributable,yugoslavia/wine=0.00,no
 sierra leone,cacao beans,ha,9,8,british sierra leone,cacao: raw,yes,1.0000,attributable,total/cottonseed=0.11,no

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1626,6 +1626,40 @@ def mutate_landuse_dropped_digit_residual(root, gpd, make_valid, affinity):
             f"ten the diagnosis claims, while every other field stays valid")
 
 
+
+def mutate_provenance_split_interleaved(root, gpd, make_valid, affinity):
+    """Stretch a split_candidate's early half so the two halves overlap in time.
+
+    `split_candidate` (issue 443) claims a series is two raw labels IN SEQUENCE. The temporal
+    separation is the entire claim: two labels matching the same series over OVERLAPPING years is a
+    mixture, not a splice, and the two cases need opposite remedies -- a splice can be cut at a
+    boundary year, a mixture cannot. USA sugar is the counter-example that proves the distinction
+    matters, holding a national total AND a two-state subset for 1938.
+
+    The mutation only rewrites the early half's END year to the late half's end, so the row keeps its
+    status, both raw labels, both distinct-value counts and its share -- every other arm stays quiet
+    and only the ordering check can see that the claim has stopped being true.
+    """
+    import re as _re
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/item_provenance.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    victim = next(r for r in rows if r["status"] == "split_candidate")
+    before = victim["runner_up"]
+    m = _re.match(r"(early=.+? )(-?\d+)-(-?\d+)( \(\d+d\); late=.+? )(-?\d+)-(-?\d+)( \(\d+d\))$",
+                  before)
+    g = m.groups()
+    victim["runner_up"] = f"{g[0]}{g[1]}-{g[5]}{g[3]}{g[4]}-{g[5]}{g[6]}"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"stretched {victim['layer_b_label']}/{victim['item']}'s early half to end at "
+            f"{g[5]}, so it now overlaps the late half instead of preceding it, while the status, "
+            f"both labels, both distinct counts and the share all stay as they were")
+
+
 def mutate_item_block_count_lowered(root, gpd, make_valid, affinity):
     """Lower a block's n_items while leaving the item list it describes intact.
 
@@ -3362,6 +3396,14 @@ CASES = (
         "as likely to be a value collision",
         "a switching series whose second product is left supplying a single cell, which is the shape "
         "a value collision takes and is exactly what MIN_PER_PRODUCT exists to reject",
+    ),
+    (
+        "validate_item_provenance.py",
+        mutate_provenance_split_interleaved,
+        "MIXTURE, not a splice",
+        "a split_candidate's two halves made to overlap in time, with its status, labels, distinct "
+        "counts and share untouched -- a splice can be cut at a boundary year and a mixture cannot, "
+        "so reporting one as the other sends the remedy the wrong way (issue 443)",
     ),
     (
         "validate_item_provenance.py",

--- a/scripts/validate_item_provenance.py
+++ b/scripts/validate_item_provenance.py
@@ -36,6 +36,7 @@ Usage:
 from __future__ import annotations
 
 import csv
+import re
 import os
 import sys
 from collections import defaultdict
@@ -49,7 +50,8 @@ MIN_VALUES = 8
 MIN_DISTINCT = 6
 SHARE_FLOOR = 0.60
 
-STATUSES = {"attributable", "ambiguous", "unattributable", "too_few_distinct", "too_few_values"}
+STATUSES = {"attributable", "ambiguous", "split_candidate", "unattributable",
+            "too_few_distinct", "too_few_values"}
 
 # Measured 2026-08-18. BIDIRECTIONAL: repairing a mixture must remove its entry with a note.
 BASELINE_MIXED = frozenset({
@@ -109,6 +111,50 @@ def main() -> int:
     for r in rows:
         if r["status"] not in STATUSES:
             problems.append(f"C {r['layer_b_label']}/{r['item']}: unknown status {r['status']!r}")
+
+        # --- E: a split_candidate must carry the split it claims (issue 443) --------------------
+        # `split_candidate` says the series is TWO raw labels in sequence. Freshness is not checkable
+        # here -- CI has neither the panel nor the raw extract -- so this checks the claim is
+        # INTERNALLY complete and self-consistent, the same standard arm A of
+        # validate_assertion_triage.py holds. What it catches is a hand edit or a partial merge that
+        # leaves the status behind without the evidence, which is how a status becomes decorative.
+        if r["status"] == "split_candidate":
+            where = f"E {r['layer_b_label']}/{r['item']}/{r['unit']}"
+            if r["raw_label"]:
+                problems.append(
+                    f"{where}: split_candidate must leave raw_label EMPTY -- it names ONE territory "
+                    f"and this row has two, so a consumer joining on it would read {r['raw_label']!r} "
+                    f"as the whole series' provenance")
+            m = re.match(r"early=(.+?) (-?\d+)-(-?\d+) \((\d+)d\); late=(.+?) (-?\d+)-(-?\d+) \((\d+)d\)$",
+                         r["runner_up"] or "")
+            if not m:
+                problems.append(
+                    f"{where}: split_candidate without a parseable split in runner_up "
+                    f"({r['runner_up']!r}). The status is then a claim with no evidence attached")
+            else:
+                e_lab, e0, e1, e_d, l_lab, l0, l1, l_d = m.groups()
+                if e_lab.split("/")[0] == l_lab.split("/")[0]:
+                    problems.append(f"{where}: both halves name the same raw label "
+                                    f"{e_lab.split('/')[0]!r} -- that is not a split")
+                if int(e1) >= int(l0):
+                    problems.append(
+                        f"{where}: the halves overlap in time ({e0}-{e1} then {l0}-{l1}). An "
+                        f"interleaved pair is a MIXTURE, not a splice, and must not be reported as "
+                        f"one -- USA sugar holds two scopes for the same year (issue 443)")
+                for half, d in (("early", e_d), ("late", l_d)):
+                    if int(d) < MIN_DISTINCT:
+                        problems.append(
+                            f"{where}: the {half} half rests on {d} distinct values, below "
+                            f"MIN_DISTINCT={MIN_DISTINCT}. Half a series is exactly where this floor "
+                            f"is easiest to fall below, and below it a fingerprint matches anything")
+                sh = r["share"]
+                try:
+                    if float(sh) < SHARE_FLOOR:
+                        problems.append(f"{where}: combined share {sh} is below SHARE_FLOOR="
+                                        f"{SHARE_FLOOR}, so the two halves do not account for the "
+                                        f"series")
+                except (TypeError, ValueError):
+                    problems.append(f"{where}: split_candidate with unparseable share {sh!r}")
             continue
         if r["status"] != "attributable":
             continue


### PR DESCRIPTION
Implements the handling suggested on #443.

`unattributable` was doing two jobs: **"no raw label matches this series"** and **"two do, at different
times."** The second is a source splice, and it was invisible by arithmetic — a series whose territorial
scope changes partway has no single raw label above `SHARE_FLOOR = 0.60`, because each half carries
about half the cells, so it fell into the status that reads *we could not tell*.

### The regeneration is contained

```
rows 1918 -> 1918
status changes: 8, ALL `unattributable -> split_candidate`
attributable 779 (unchanged)   ambiguous 6 (unchanged)   unattributable 142 -> 134
too_few_distinct 69 (unchanged)   too_few_values 922 (unchanged)
```

The detection sits **inside** the `unattributable` branch, so it structurally cannot alter an
`attributable` or `ambiguous` verdict — and the diff confirms that rather than relying on it.

```
indonesia             cacao beans       t   java+madura 1909-1919 -> dutch east indies 1925-1943
malaysia              coffee green      ha  br fed malay states 1909-1920 -> british malaya 1930-1944
russian federation    sugar raw centr.  t   russia in europe 1909-1916 -> ussr 1930-1940
russian federation    tobacco unmanuf.  t   russia in europe 1909-1916 -> ussr 1923-1936
serbia                yarn of true hemp t   kingdom of serbs... 1909-1925 -> yugoslavia 1930-1938
syrian arab republic  cotton lint       t   french syria and lebanon 1922-1933 -> french syria 1939-1944
syrian arab republic  sesame seed       t   french syria and lebanon 1930-1938 -> french syria 1939-1945
united states         sugar raw centr.  t   usa/sugar: beet 1909-1921 -> usa: louisiana and florida/
                                            sugar: cane 1939-1945
```

Most are genuine territorial successions (`russia in europe -> ussr`,
`kingdom of serbs, croats and slovenes -> yugoslavia`). Their values are not wrong for their own years —
what was missing is any record that the series' territorial basis changes partway, which is #372's defect
occurring *within* an item rather than across items.

### Temporal separation is required, and that is the point

Two labels matching one series over **overlapping** years is a *mixture*, not a splice, and the two need
opposite remedies: a splice can be cut at a boundary year, a mixture cannot. USA sugar is the case that
proves it — it holds a national total and a Louisiana+Florida subset for the **same 1938** (2,153,800 t
and 361,500 t).

That case also shows why these are labelled *candidates*: per-product, its pairing changes **commodity as
well as territory** (`sugar: beet -> sugar: cane`), so it may belong with `21_item_product_switches.py`
rather than here. Recorded on the issue rather than quietly resolved.

### Gate arm E

Re-derives the claim from the row: `raw_label` empty, `runner_up` parseable, two *different* labels,
halves temporally ordered, `MIN_DISTINCT` on **each** half, combined share over `SHARE_FLOOR`.

`raw_label` is deliberately left **empty** on a split row — it names ONE territory, the gate joins on it
only for `attributable`, and packing `"A -> B"` there would put a value that looks like a label and is
not one. The split lives in `runner_up` in a parseable form.

Freshness is not checkable in CI (it has neither the panel nor the raw extract), so arm E holds the same
internal-consistency standard as `validate_assertion_triage.py` arm A: it catches the hand edit or
partial merge that leaves a status behind without its evidence.

All six sub-checks were mutation-tested individually and each names its own defect. The selftest case
stretches a split's early half to overlap the late one, leaving status, both labels, both distinct counts
and the share untouched, so only the ordering check can see it.

### Scope

Selftest 90 → 91 cases. All 71 gates pass, full suite green on an idle tree.

The remaining 134 `unattributable` series are measured and mostly genuine: **108** have fewer than two
raw labels clearing the distinctness floor, **23** have candidates but no qualifying disjoint pair, and
only **3** are interleaved mixtures (`australia cotton seed` ×2, `indonesia tobacco`) — a bounded class
with no status of its own, left for #443.
