### PR TITLE
Key fao1952 on `indicator` in the same-polity overlap census (#451)

### DIFF
--- a/pipelines/polity-autoimprove/01_match_and_findings.py
+++ b/pipelines/polity-autoimprove/01_match_and_findings.py
@@ -336,7 +336,13 @@ json.dump({"summary": {
 # a label/candidate group whose ONLY overlapping rows are period rows got years_observed
 # "None-None", and 12_triage_assertions.py:149 raises ValueError on that -- so the triage queue
 # could not be regenerated AT ALL, which is why it drifted (issue 434).
-work[["source","country","iso3c","year","period","item","value","unit","whep_code","match_method"]] \
+# `indicator` carried for the same reason as `period`: needed downstream and dropped here. Its
+# MEANING IS SOURCE-DEPENDENT, which matters more than its presence -- fao1952 uses it for the
+# MEASURE (13 values: crops:area, population:population total, ...) while mitchell uses it for
+# PROVENANCE (152 values: `page_17_table_1`, `copia de page_17_table_1`). A consumer must decide
+# per source; see 25_same_polity_overlaps.py, where keying on it for mitchell would separate the
+# very duplicates the table exists to find.
+work[["source","country","iso3c","year","period","item","indicator","value","unit","whep_code","match_method"]] \
     .to_parquet(f"{OUT}/matched_rows.parquet", index=False)
 
 # coverage by source after

--- a/pipelines/polity-autoimprove/25_same_polity_overlaps.py
+++ b/pipelines/polity-autoimprove/25_same_polity_overlaps.py
@@ -118,8 +118,20 @@ def build(matched: str) -> list[dict]:
             continue
         for a, b in itertools.combinations(labels, 2):
             ga, gb = g[g.country == a], g[g.country == b]
-            ka = ga.set_index(["item", "unit", "year"]).value
-            kb = gb.set_index(["item", "unit", "year"]).value
+            # KEY ON `indicator` FOR fao1952 ONLY. That source packs five indicators under
+            # `r_fao_population_1952_10_18` (issue 13), so without it two labels are reported as
+            # sharing a cell they do not share, and the `~duplicated()` below then keeps whichever
+            # came first. It removed 13 pairs whose ONLY shared cell was such an artefact.
+            #
+            # NOT for the other sources, and this is the whole subtlety: mitchell's `indicator` is a
+            # PROVENANCE string, not a measure -- `cape natal` is `page_17_table_1` and `south africa`
+            # is `copia de page_17_table_1`, a copy of one table with identical values. Keying on it
+            # there DELETED that pair, which source_conventions.csv documents with a passing re-test
+            # and a warning that dropping it loses 21 years of national cattle, plus every
+            # orthographic-variant pair. Verified by doing it: 37 pairs became 21.
+            idx_cols = ["item", "unit", "year"] + (["indicator"] if src == "fao1952" else [])
+            ka = ga.set_index(idx_cols).value
+            kb = gb.set_index(idx_cols).value
             ka, kb = ka[~ka.index.duplicated()], kb[~kb.index.duplicated()]
             shared = ka.index.intersection(kb.index)
             if len(shared) == 0:
@@ -130,7 +142,9 @@ def build(matched: str) -> list[dict]:
             agt = int((va - vb > tol).sum())
             bgt = int((vb - va > tol).sum())
             distinct = len(set(va.round(9)) | set(vb.round(9)))
-            years = sorted({int(y) for _, _, y in shared if not pd.isna(y)})
+            # the index gains `indicator` for fao1952, so take the year by POSITION rather than
+            # unpacking a fixed arity -- unpacking crashed when the key first grew.
+            years = sorted({int(t[2]) for t in shared if not pd.isna(t[2])})
             out.append({
                 "whep_code": code, "source": src, "label_a": a, "label_b": b,
                 "relation": classify(eq, agt, bgt, len(shared), distinct, norm(a) == norm(b)),

--- a/pipelines/polity-autoimprove/state/same_polity_overlaps.csv
+++ b/pipelines/polity-autoimprove/state/same_polity_overlaps.csv
@@ -1,6 +1,4 @@
 whep_code,source,label_a,label_b,relation,shared_cells,n_equal,n_a_gt_b,n_b_gt_a,distinct_values,years,rows_a,rows_b
-BLI-1833-1960,fao1952,British West Indies Leeward Islands,Leeward Islands,undetermined,1,0,1,0,2,1951-1951,16,6
-BSW-1841-1963,fao1952,British Borneo Sarawak,Sarawak,undetermined,1,0,1,0,2,1951-1951,44,1
 CHN-1921-1932,mitchell,"china, mainland","china, manchuria province of",undetermined,3,0,3,0,6,1931-1931,25,27
 CHN-1947-1949,fao1952,China,China 22 provinces,undetermined,3,0,3,0,6,1947-1948,7,4
 CHN-1947-1949,fao1952,China,China Manchuria,undetermined,3,0,3,0,6,1947-1947,7,4
@@ -9,30 +7,19 @@ CHN-1949-1950,fao1952,China,China 22 provinces,undetermined,2,0,0,2,4,1949-1949,
 CHN-1949-1950,fao1952,China 22 provinces,China Manchuria,undetermined,4,0,4,0,8,1949-1949,29,5
 CHN-1950-2025,fao1952,China 22 provinces,China Manchuria,undetermined,2,0,2,0,3,1950-1951,23,7
 CHN-1950-2025,mitchell,"china, mainland","china, manchuria province of",containment,8,0,8,0,16,1951-1952,305,13
-DEU-1920-1938,fao1952,Germany,Germany  Western,undetermined,1,0,1,0,2,1937-1937,41,3
+DEU-1920-1938,fao1952,Germany,Germany  Western,undetermined,3,0,3,0,6,1937-1937,41,3
 DEU-1920-1938,fao1952,Germany,Germany Berlin,containment,8,0,8,0,15,1937-1937,41,14
-DEU-1920-1938,fao1952,Germany,Germany Western,containment,22,0,22,0,43,1937-1937,41,36
-DEU-1920-1938,fao1952,Germany  Western,Germany Berlin,undetermined,1,0,1,0,2,1937-1937,3,14
-DEU-1920-1938,fao1952,Germany  Western,Germany Western,orthographic_variant,1,0,0,1,2,1937-1937,3,36
+DEU-1920-1938,fao1952,Germany,Germany Western,containment,25,0,25,0,49,1937-1937,41,36
 DEU-1920-1938,fao1952,Germany Berlin,Germany Western,containment,9,0,0,9,17,1937-1937,14,36
 ETH-1907-1936,iia,ethiopia,ethiopia pdr,identical_indistinct,1,1,0,0,1,,1,4
 ETH-1936-1941,iia,ethiopia,ethiopia pdr,identical_indistinct,1,1,0,0,1,,1,5
 ETH-1941-1952,iia,ethiopia,ethiopia pdr,identical_indistinct,1,1,0,0,1,1945-1945,1,4
-F78-1949-1990,fao1952,Germany  Western,Germany Western,orthographic_variant,1,0,0,1,2,1951-1951,3,209
-GBR-1921-2025,fao1952,United Kingdom,United Kingdom Great Britain,containment,6,0,6,0,10,1937-1951,227,9
-JAM-1800-2025,fao1952,British West Indies Jamaica,British West Indies Jamaica and Dependencies,undetermined,1,0,0,1,2,1951-1951,108,2
-JAM-1800-2025,fao1952,British West Indies Jamaica,Jamaica,undetermined,1,0,0,1,2,1951-1951,108,22
-JAM-1800-2025,fao1952,British West Indies Jamaica and Dependencies,Jamaica,undetermined,1,0,1,0,2,1951-1951,2,22
+GBR-1921-2025,fao1952,United Kingdom,United Kingdom Great Britain,undetermined,4,0,4,0,6,1949-1949,227,9
 JPN-1895-1945,iia,japan,palau,undetermined,4,0,4,0,5,1915-1918,737,4
-KOR-1948-2025,fao1952,Korea,Korea South,undetermined,4,2,2,0,6,1949-1951,11,104
-PAL-1920-1948,fao1952,Israel,Palestine,undetermined,2,0,1,1,4,1937-1937,7,25
+KOR-1948-2025,fao1952,Korea,Korea South,disagreement,5,3,2,0,7,1949-1951,11,104
+PAL-1920-1948,fao1952,Israel,Palestine,undetermined,1,0,1,0,2,1937-1937,7,25
 PNG-1949-1975,fao1952,New Guinea,Papua,disagreement,9,1,3,5,15,1950-1951,11,11
-SAA-1947-1957,fao1952,France  Saar,Saar,undetermined,1,0,0,1,2,1951-1951,3,14
-SAC-1935-1947,fao1952,France  Saar,Saar,undetermined,1,0,0,1,2,1937-1937,3,1
 SER-1878-1913,juan,serbia,yugoslav sfr,undetermined,2,0,1,1,3,1909-1910,308,11
-SLV-1821-2025,fao1952,EI Salvador,El Salvador,undetermined,1,0,1,0,2,1937-1937,45,40
-TTO-1800-2025,fao1952,British West Indies Trinidad and Tobago,Trinidad and Tobago,undetermined,1,0,1,0,2,1951-1951,49,3
 VGB-1800-2025,fao1952,British West Indies Virgin Islands,Virgin Islands,undetermined,1,0,1,0,2,1950-1950,3,6
-WBL-1949-1990,fao1952,Germany  Berlin,Germany Berlin,orthographic_variant,1,0,0,1,2,1951-1951,3,21
 ZAF-1910-2025,mitchell,cape natal,south africa,identical,12,12,0,0,12,1946-1957,33,938
 ZAF-1910-2025,mitchell,natal,south africa,undetermined,1,0,0,1,2,1957-1957,7,938

--- a/scripts/validate_same_polity_overlaps.py
+++ b/scripts/validate_same_polity_overlaps.py
@@ -20,23 +20,30 @@ year) cell can, because a parent and its part disagree there and two synonyms do
 WHAT THE FIRST RUN MEASURED: 37 pairs share at least one cell, 13 of them with enough cells to
 support any verdict at all.
 
-    containment           5    `Germany` over `Germany Western` (22 cells), over `Germany Berlin`
-                               (8); `United Kingdom` over `United Kingdom Great Britain` (6);
-                               mitchell `china, mainland` over `china, manchuria province of` (8)
+    containment           4    `Germany` over `Germany Western` (25 cells) and over `Germany Berlin`
+                               (8); `Germany Berlin` over `Germany Western` (9); mitchell
+                               `china, mainland` over `china, manchuria province of` (8)
     identical             1    mitchell `cape natal` equals `south africa` in all 12 shared cattle
                                cells, 1946-1957, over 12 distinct values -- a province carrying the
                                national series
-    disagreement          1    fao1952 `New Guinea` / `Papua`, 9 cells running both directions
-    orthographic_variant  3    one label reached under two spellings (`Germany  Western` with the
-                               doubled space, `Germany  Berlin`)
+    disagreement          2    fao1952 `New Guinea` / `Papua`, 9 cells running both directions; and
+                               `Korea` / `Korea South`, 5 cells, see the KOR note below
     identical_indistinct  3    equal, but on one cell, which proves nothing
-    undetermined         24    too few shared cells to say anything
+    undetermined         14    too few shared cells to say anything
 
-NONE OF ISSUE 355'S FOUR SURVIVE AS SUPPORTED FINDINGS, which is the main thing this gate records.
+    (Counts as of the fao1952 `indicator` key, issue 451. Before it: 37 pairs, with 5 containment,
+    3 orthographic_variant and 24 undetermined. `orthographic_variant` is now empty and
+    `United Kingdom`/`United Kingdom Great Britain` fell from containment to undetermined at 4 cells,
+    below the floor -- both because their extra "shared" cells were population-indicator artefacts.)
+
+ONE OF ISSUE 355'S FOUR NOW SURVIVES AS A SUPPORTED FINDING, and three still do not.
 `indochina viet nam` no longer routes to FID-1887-1954 at all; RWB's `rwanda`/`rwanda and burundi`
-share no cells; GBM's two labels are disjoint in year; and KOR's `Korea`/`Korea South` has 4 shared
-cells, one below the floor where direction means anything. The overlaps that are real are different
-ones, and a string test could not have found them.
+share no cells; GBM's two labels are disjoint in year. KOR's `Korea`/`Korea South` DOES survive since
+the fao1952 `indicator` key (issue 451): it has 5 shared cells rather than 4, exactly at the floor
+where direction means anything, and classifies as `disagreement`. Before the key it sat one cell below
+that floor -- so the string test issue 355 used happened to name a real pair, but only the cell
+evidence can say which, and it could only say so once the indicator stopped merging cells.
+The other real overlaps are different pairs, which a string test could not have found.
 
 Two signals:
   A. COUNT CEILING   pairs sharing cells may not grow. Bidirectional: reroute some and the ceiling
@@ -57,9 +64,17 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/same_polity_overlaps.csv")
 POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
 
-# Measured 2026-08-19 on the first run. BIDIRECTIONAL: rerouting a label must lower this, with a note
-# saying which pair was resolved, so a later regression cannot hide inside the old headroom.
-BASELINE_PAIRS = 37
+# Measured 2026-08-19. BIDIRECTIONAL: rerouting a label must lower this, with a note saying which
+# pair was resolved, so a later regression cannot hide inside the old headroom.
+#
+# LOWERED 37 -> 24 when the generator began keying fao1952 on `indicator` (issue 451). The 13 pairs
+# that went were not resolved by a reroute -- they were never real: their ONLY shared cell was an
+# `r_fao_population_1952_10_18` cell, and that item code carries five distinct indicators (issue 13),
+# so two labels reporting DIFFERENT measures read as sharing one. Three of the 13 carried
+# `orthographic_variant`; that loses a row, not a finding, because the generator's own docstring
+# already records all 30 such fao1952 groups in prose and explains why shared-cell pairs are the
+# only ones tabled.
+BASELINE_PAIRS = 24
 
 # The floor 25_same_polity_overlaps.py needs before it will call a direction; restated here so the
 # gate does not depend on the generator's constant to know what `undetermined` means.
@@ -70,19 +85,23 @@ RELATIONS = {"containment", "identical", "identical_indistinct", "disagreement",
 
 # Every pair with a supported verdict on the first run. GENERATED FROM THE TABLE, never hand-typed --
 # transcribing a baseline from a truncated printout once missed 18 of 30 entries.
+# KOR-1948-2025 enters this set as a `disagreement` only once fao1952 is keyed on `indicator`: with
+# the key, `Korea` and `Korea South` share 5 cells instead of 4, and the added one is decisive --
+# 1951 population, both rows `indicator = population:population total`, 29,300 thousand against
+# 20,500. The first is the whole peninsula and the second is South Korea, so the polity carries a
+# figure for a territory 43% larger than itself alongside the correct one. RECORDED, NOT RESOLVED:
+# `data_errors.csv`'s `layerb-nested-reporting-levels-one-polity` already lists this pair among 52
+# such cells with status `pending_audit`, and the audit is where the reroute decision belongs.
 BASELINE_SUPPORTED = frozenset({
     ('CHN-1950-2025', 'mitchell', 'china, mainland', 'china, manchuria province of', 'containment'),
     ('DEU-1920-1938', 'fao1952', 'Germany', 'Germany Berlin', 'containment'),
     ('DEU-1920-1938', 'fao1952', 'Germany', 'Germany Western', 'containment'),
-    ('DEU-1920-1938', 'fao1952', 'Germany  Western', 'Germany Western', 'orthographic_variant'),
     ('DEU-1920-1938', 'fao1952', 'Germany Berlin', 'Germany Western', 'containment'),
     ('ETH-1907-1936', 'iia', 'ethiopia', 'ethiopia pdr', 'identical_indistinct'),
     ('ETH-1936-1941', 'iia', 'ethiopia', 'ethiopia pdr', 'identical_indistinct'),
     ('ETH-1941-1952', 'iia', 'ethiopia', 'ethiopia pdr', 'identical_indistinct'),
-    ('F78-1949-1990', 'fao1952', 'Germany  Western', 'Germany Western', 'orthographic_variant'),
-    ('GBR-1921-2025', 'fao1952', 'United Kingdom', 'United Kingdom Great Britain', 'containment'),
+    ('KOR-1948-2025', 'fao1952', 'Korea', 'Korea South', 'disagreement'),
     ('PNG-1949-1975', 'fao1952', 'New Guinea', 'Papua', 'disagreement'),
-    ('WBL-1949-1990', 'fao1952', 'Germany  Berlin', 'Germany Berlin', 'orthographic_variant'),
     ('ZAF-1910-2025', 'mitchell', 'cape natal', 'south africa', 'identical'),
 })
 


### PR DESCRIPTION
`25_same_polity_overlaps.py` keyed shared cells on `(item, unit, year)`. fao1952 packs **five indicators** under
`r_fao_population_1952_10_18` (#13), so two labels reporting *different measures* read as sharing one cell — and
the generator's `~index.duplicated()` then kept whichever came first, so a pair could be reported on a cell the
two labels do not share.

```
pairs 37 -> 24     supported 13 -> 10     undetermined 24 -> 14
```

The 13 that went were never real: each had exactly **one** shared cell, and it was a population cell holding two
different indicators.

### Not keyed on `indicator` for the other sources — this is the whole subtlety

mitchell's `indicator` is a **provenance** string, not a measure:

```
cape natal    cattle 1946-1957   indicator = page_17_table_1
south africa  cattle 1946-1957   indicator = copia de page_17_table_1     identical values
```

I tried the blanket version first and it deleted that pair — which `source_conventions.csv` documents with a
passing re-test and a warning that dropping it loses **21 years of national cattle** — plus every
orthographic-variant pair. 37 became 21. So the same column must be *in* the key for one source and *out* of it
for another.

### Two findings the key makes visible

**`KOR-1948-2025`** rises from 4 shared cells to 5 — exactly the `MIN_DIRECTIONAL` floor — and classifies as
`disagreement`. The added cell is decisive: 1951 population, both rows `population:population total`, **29,300
thousand against 20,500**. The first is the whole Korean peninsula, the second South Korea, so the polity carries
a figure for a territory 43% larger than itself beside the correct one.

**`GBR-1921-2025`** falls from 6 cells to 4 and from `containment` to `undetermined`. Its two population "shared"
cells were *agricultural* vs *male agricultural* population. What remains is the real evidence — 1949 tractors,
Great Britain at 94.9–98.5% of the United Kingdom, i.e. the Northern Ireland share.

### One of issue 355's four now survives

The docstring said none did, and KOR was the near-miss at one cell below the floor. It survives now — so #355's
string test did name a real pair, but only cell evidence can say *which*, and it could only say so once the
indicator stopped merging cells. Docstring corrected, along with the class distribution.

`orthographic_variant` is now empty. That loses a row, not a finding: the generator's own docstring records all
30 such fao1952 groups in prose and explains that only shared-cell pairs are tabled.

### Baselines

`BASELINE_PAIRS` lowered 37 → 24 with the reason. `BASELINE_SUPPORTED` **regenerated from the table** as its own
comment requires, rather than hand-transcribed — that comment exists because transcribing from a truncated
printout once missed 18 of 30 entries. KOR's new entry carries a note that it is **recorded, not resolved**:
`data_errors.csv`'s `layerb-nested-reporting-levels-one-polity` already lists this pair among 52 such cells at
`pending_audit`, and the reroute decision belongs to that audit.

Also carries `indicator` through `01_match_and_findings.py` into `matched_rows.parquet`, as #436 did for
`period`, with the source-dependent meaning recorded at the write site.

All 71 gates pass; full 91-case selftest green.