### PR TITLE
Print the provenance table's own classification columns (#315)

### DIFF
--- a/scripts/validate_iia_label_provenance.py
+++ b/scripts/validate_iia_label_provenance.py
@@ -42,6 +42,7 @@ Usage:
 """
 from __future__ import annotations
 
+import collections
 import csv
 import json
 import os
@@ -206,6 +207,25 @@ def main() -> int:
     print(f"provenance rows: {len(prov)}")
     print(f"  targets assembled from a whole plus parts, or several countries: {len(mixed_targets)}")
     print(f"  labels the mapping's own notes call multi-country: {len(declared_multi)}")
+
+    # PRINT THE TABLE'S OWN CLASSIFICATION COLUMNS (issue 315). Not a check -- observability. Issue
+    # 315's headline is "25 IIA assertions carry a territory the label does not name", and that figure
+    # could not be reproduced from this table because it is unclear which column it meant: three
+    # candidates span very different populations, and nothing printed them. A number no gate prints is
+    # a number nobody can cite, which is the pattern behind every unreproducible figure in this
+    # backlog. So print all three distributions and let the definition be pinned to one.
+    for col in ("kind", "mixing_observed", "territory_signal"):
+        if not prov or col not in prov[0]:
+            continue
+        dist = collections.Counter((r.get(col) or "").strip() or "(blank)" for r in prov)
+        labels = {
+            v: len({(r.get("layer_b_label") or "").strip()
+                    for r in prov if (r.get(col) or "").strip() == v and r.get("layer_b_label")})
+            for v in dist
+        }
+        parts = ", ".join(f"{v}={n} rows/{labels[v]} labels"
+                          for v, n in sorted(dist.items(), key=lambda kv: -kv[1]))
+        print(f"  {col}: {parts}")
     print(f"`verified_equal` verdicts on such a label: {len(offenders)} "
           f"(ceiling {BASELINE_VERIFIED_EQUAL_ON_MIXED})")
 


### PR DESCRIPTION
Observability, not a check.

#315's headline is *"25 IIA assertions carry a territory the label does not name"*. Re-measuring it today gave
**17, 16 or 11** depending on which column was meant — none of them 25, and **none of them banked**, so the gap is
a definition rather than work since done. `iia_label_provenance.csv` carries three candidate classifications and
the gate printed none of them, so there was no way to pin the figure to one.

### After

```
provenance rows: 335
  targets assembled from a whole plus parts, or several countries: 11
  labels the mapping's own notes call multi-country: 8
  kind: one_to_one=104 rows/93 labels, shares_target=97/44, sub_of_sibling=86/36,
        whole_with_sub_siblings=40/36, multi_country=8/8
  mixing_observed: no=259 rows/149 labels, yes=43/13, unknown=33/0
  territory_signal: clean=136 rows/90 labels, redirected=109/57, mixed=37/8, unknown=33/0,
                    sequential_other=14/4, sequential_scope=6/3
`verified_equal` verdicts on such a label: 6 (ceiling 6)
```

**Row and label counts both**, because they differ by an order of magnitude on some values and #315 counts
*assertions* rather than rows — `mixing_observed=yes` is 43 rows but only 13 labels, and every candidate reading of
"25" falls somewhere in that gap.

`unknown=33 rows/0 labels` is informative on its own: those rows carry no `layer_b_label`, so they are raw labels
the harmonisation never matched, and no assertion can sit on them.

### Why this is worth a commit rather than a comment

Five open issues' headline figures were re-measured today, and the split is exact:

```
reproduce                                    printed by
  #367  3,081 rows / 239 groups              validate_item_axis_aggregates
  #143  188 pairs / 331,319 km2              validate_coexisting_overlaps
  #414  83 contradicted zeros                validate_edition_conflicts
  #308  460 verdicts / 2 uncarried           validate_verdict_carryover

do not reproduce                             printed by
  #414  770 false zeros                      nothing
  #308  34,143 double-queued rows            nothing
  #315  25 assertions                        nothing
```

That is not a coincidence about difficulty. #143's figure needs reprojection to an equal-area CRS, dropping 44
retired polities and excluding legitimate nesting — and it reproduces exactly, because a gate does that work and
prints the answer. Meanwhile #414's 770 needs only a count and cannot be reproduced, because nothing defines it.
**A number no gate prints is a number nobody can cite.**

This does not decide which column #315 meant — that is a judgement about what "carries a territory the label does
not name" should mean. It makes the three candidates visible so the decision can be made against numbers.

All 71 gates pass; the gate's selftest case still names its defect (case 33); full selftest green.