### PR TITLE
Fall back to the name when the iso family cannot reach the year: 97 rows, 27 years of Mandate Palestine (#448)

### DIFF
--- a/pipelines/polity-autoimprove/matchlib.py
+++ b/pipelines/polity-autoimprove/matchlib.py
@@ -413,5 +413,59 @@ class Matcher:
             if fam_cache is not None: fam_cache[key] = (fam, how)
         if fam is None: return (None, "unresolved", how)
         rec, st = self.pick_by_year(fam, year)
-        if rec is None: return (None, st, how)               # year_uncovered / no_year
+        if rec is None:
+            # ISO-RESOLVED FAMILY THAT DOES NOT REACH THE YEAR: try the NAME.
+            # A label's iso code and its name can resolve to DIFFERENT families
+            # when a territory's successor took a new code. Mitchell stamps
+            # `pse` on every Palestine row, but `pse` reaches only
+            # PSE-1948-2025, so 1920-1946 -- the entire British Mandate -- came
+            # back `year_uncovered` and the name route to the live, correct
+            # PAL-1920-1948 was never tried. 97 rows were dropped this way
+            # (95 mitchell/palestine 1920-1946, 2 iia/morocco 1909-1910); the
+            # other 53 `year_uncovered` rows are genuine database gaps, where
+            # name-matching returns `year_uncovered` too, and are unaffected.
+            #
+            # THE ISO PREFERENCE IS PROTECTED STRUCTURALLY, NOT BY THESE
+            # CONDITIONS (issue #448). Names are ambiguous across families,
+            # which is why iso is preferred at all, so the requirement was that
+            # a currently-correct row cannot be rerouted. That holds because
+            # this block sits inside the `rec is None` branch: a row the iso
+            # route MATCHED never reaches it. The explicit conditions below are
+            # documentary, and I measured that rather than assuming it --
+            # removing all three changes ZERO of the panel's 17,599 (label,
+            # iso, source, year) tuples. They are kept because they state the
+            # intended scope at the point of the retry, and because each would
+            # become load-bearing under a plausible future edit; none of them is
+            # what makes the change safe today.
+            #   1. only when the iso route failed on the year -- restates the
+            #      enclosing branch.
+            #   2. only `year_uncovered`, never `no_year`. This one states
+            #      intent and is PROVABLY INERT rather than load-bearing:
+            #      pick_by_year's FIRST line returns `no_year` for a NaN year
+            #      whatever family it is given, so widening the trigger to
+            #      no_year changes no answer -- measured, and the fixture case
+            #      below could not tell the two apart. Issue #310's 9,210
+            #      year-less rows are therefore untouched by construction, not
+            #      by this condition. If pick_by_year ever learns to resolve a
+            #      year-less row, this becomes load-bearing and needs a case
+            #      that bites.
+            #   3. only a DIFFERENT family, and never a second iso route.
+            #      Also inert today: re-picking inside the same family repeats
+            #      the same year test and returns the same refusal, and
+            #      resolve_family(name, None) cannot answer "iso" with no iso
+            #      passed. The condition keeps a same-family retry from ever
+            #      being STAMPED as a fallback, which would misdescribe a row
+            #      that nothing rescued.
+            # The result is stamped `name_after_iso_year_gap`, NOT `name`, so
+            # these rows stay auditable instead of blending into ordinary name
+            # matches -- this repo has been bitten by a routing change that
+            # could not be told apart afterwards.
+            if how == "iso" and st == "year_uncovered":
+                nfam, nhow = self.resolve_family(name, None)
+                if nfam is not None and nhow != "iso" \
+                        and {r[0] for r in nfam} != {r[0] for r in fam}:
+                    nrec, nst = self.pick_by_year(nfam, year)
+                    if nrec is not None:
+                        return (nrec[0], "matched", "name_after_iso_year_gap")
+            return (None, st, how)                           # year_uncovered / no_year
         return (rec[0], "matched", how)

--- a/scripts/crosscheck_matchers.py
+++ b/scripts/crosscheck_matchers.py
@@ -302,14 +302,22 @@ BASELINE_PRE1961_DIFFERENT = frozenset({
 # Cost of that choice, stated: a NEW unresolved year at an entity already listed here does
 # not fail. "Korea" shows why the entities and not the years are the unit — it resolves by
 # name at 1948 (see the DIFFERENT baseline) and not at 1954 or 1960.
-# 34 probes across these 8 entities as of 2026-08-17.
+# 34 probes across these 8 entities as of 2026-08-17; 7 entities from 2026-08-19, when
+# ("Palestine","PSE") was REMOVED because the Python matcher stopped disagreeing. That
+# entry recorded exactly the remap this list's header names -- `PSE -> PAL` -- and the
+# fallback of issue #448 now reaches PAL-1920-1948 from the NAME instead, so the two
+# matchers agree and the gate said so unprompted. The R side remaps iso codes from a
+# table; Python derives the same answer from the family the name resolves to, which is
+# why the OTHER seven entries did NOT follow: for Libya pre-1912, Somalia pre-1960 and
+# North Korea pre-1948 the name route is year_uncovered too, so those are real gaps in
+# the database rather than routing defects (measured: 53 such rows, against the 97 that
+# the fallback recovered).
 BASELINE_PRE1961_UNRESOLVED = frozenset({
     ("Cape Natal", "-"),            # name_override -> NAT, then ZAF after Union (1910)
     ("Czechoslovakia", "CSK"),      # pre-1918 -> AUH (Austria-Hungary)
     ("Korea", "-"),                 # name_override -> KOR
     ("Libya", "LBY"),               # pre-1912 -> OTT (Ottoman Empire)
     ("North Korea", "PRK"),         # pre-1948 -> KOR (undivided Korea)
-    ("Palestine", "PSE"),           # -> PAL (British Mandate)
     ("Somalia", "SOM"),             # pre-1960 -> ITS (Italian Somaliland)
     ("Yugoslav SFR", "YUG"),        # pre-1918 -> SER (Kingdom of Serbia)
 })

--- a/scripts/validate_matcher_fixture.py
+++ b/scripts/validate_matcher_fixture.py
@@ -150,7 +150,32 @@ CASES = (
      "whole subtlety: the ended period is kept only at its own end_year, where the "
      "inclusive gather still reaches it, and not for every later year"),
     ("Alpina", "XAA", None, 1700, None, "year_uncovered", "iso",
-     "a year before the family begins is refused, not rounded to the first period"),
+     "a year before the family begins is refused, not rounded to the first period. This "
+     "is ALSO the control for the fallback below: `alpina` as a NAME reaches a different "
+     "family than XAA does (the iso set includes the border district), so the fallback is "
+     "reachable here — and it must still refuse, because the name family does not cover "
+     "1700 either. A fallback that fired on family-difference alone would break this"),
+    ("Mandaria", "XAN", None, 1930, "MND-1920-1948", "matched",
+     "name_after_iso_year_gap",
+     "AN ISO CODE WHOSE FAMILY DOES NOT REACH THE YEAR FALLS BACK TO THE NAME (issue "
+     "448). MDW-1948-2025 owns XAN and starts in 1948, so 1930 is year_uncovered on the "
+     "iso route while `mandaria` as a name reaches MND-1920-1948, which covers it. Before "
+     "the fallback the row was DROPPED: real case mitchell/palestine, whose rows all "
+     "carry iso `pse` (PSE-1948-2025) while the British Mandate polity is PAL-1920-1948 "
+     "— 27 consecutive years, 95 rows, silently absent from the panel"),
+    ("Mandaria", "XAN", None, 1990, "MDW-1948-2025", "matched", "iso",
+     "GUARD 1, and the reason this gate needs both Mandaria cases: where the iso route "
+     "MATCHES it still wins. iso is preferred precisely because names are ambiguous "
+     "across families, so the fallback must be unreachable for a matching row — not "
+     "merely outranked by it"),
+    ("Mandaria", "XAN", None, None, None, "no_year", "iso",
+     "a year-less row stays unrouted. NOT a guard case, and the distinction is worth "
+     "recording: I wrote it as one, then mutated the fallback to fire on `no_year` too "
+     "and this case still passed. pick_by_year returns `no_year` on its FIRST line for "
+     "any NaN year, whatever family it is handed, so no family can rescue such a row and "
+     "the no_year restriction cannot change an answer. What this case pins is that "
+     "outcome itself — if a year-less row ever starts resolving, the restriction becomes "
+     "load-bearing and this case is where that will show up"),
 )
 
 # --- C. what the intake run must produce ------------------------------------------

--- a/tests/fixtures/matcher/polities.csv
+++ b/tests/fixtures/matcher/polities.csv
@@ -21,3 +21,5 @@ TWA-1900-2000,Twinpeak North,1900,2000,national,XAJ,reviewed
 TWB-1900-2000,Twinpeak South,1900,2000,national,XAK,reviewed
 SUP-1800-2025,Supland,1800,2025,national,XAL,superseded
 SUP-1900-1950,Supland,1900,1950,national,XAL,reviewed
+MND-1920-1948,Mandaria,1920,1948,national,XAM,reviewed
+MDW-1948-2025,Mandaria West Zone,1948,2025,national,XAN,reviewed


### PR DESCRIPTION
Closes #448.

`assign()` resolved a row's polity **family** first (preferring the iso code) and then picked a period
within that family by year. When the iso-resolved family had no polity covering the row's year it returned
`None` — it never tried the family the label's **name** resolves to, even when that family covered the year.

```python
M.assign("palestine", "pse", "mitchell", 1920)  ->  (None, 'year_uncovered', 'iso')   # before
M.assign("palestine", "pse", "mitchell", 1920)  ->  ('PAL-1920-1948', 'matched', 'name_after_iso_year_gap')
```

### Before/after routing over the whole panel

192,670 rows / 17,599 `(label, iso, source, year)` tuples. **29 tuples, 97 rows change; nothing else moves.**

```
                          before    after
matched  iso              12,081   12,081     <- unchanged: the iso preference is untouched
matched  name               919      919
matched  name_after_iso_year_gap      –       29
no_year  (all routes)        296      296     <- unchanged (#310's rows)
unresolved none              375      375
year_uncovered iso            40       11
```

The 29 tuples are `mitchell/palestine` 1920–1946 → `PAL-1920-1948` (95 rows, 27 consecutive years of the
British Mandate) and `iia/morocco` 1909–1910 → `MOR-1904-1911` (2 rows). Rows are stamped
**`name_after_iso_year_gap`**, not `name`, so they stay auditable instead of blending into ordinary name
matches.

### The iso preference is protected structurally, and I measured that rather than claiming guards

The issue asked that the fallback not weaken iso routing. It cannot: the retry sits inside the
`rec is None` branch, so a row the iso route **matched** never reaches it. My first version of this comment
credited "three load-bearing guards" — so I removed all three conditions and re-measured. **Zero of the
17,599 tuples change.** The conditions state the intended scope at the point of the retry and each would
become load-bearing under a plausible future edit; none of them is what makes this safe today. The comment
now says that.

### Two of the three fixture cases do not bite, and each says which

Three cases added to `validate_matcher_fixture` (24 total) on two new synthetic polities that share a name
across **different** iso codes — the Palestine shape, reproduced without the real database.

- The fallback case **does** bite: reverting `matchlib.py` alone fails it and names issue #448.
- The `no_year` case **cannot** bite. I wrote it as a guard case, then mutated the trigger to include
  `no_year` — and it still passed. `pick_by_year` returns `no_year` on its **first line** for any NaN year
  whatever family it is handed, so no family can rescue a year-less row and #310's 9,210 rows are untouched
  *by construction*, not by the condition. Recorded in the case text rather than quietly kept.
- `Alpina` 1700 doubles as the control: the fallback **is** reachable there (name and iso resolve to
  different families) and must still refuse, because the name family does not cover 1700 either.

### Independent corroboration I did not go looking for

`crosscheck_matchers` then failed on its own, reporting that `("Palestine","PSE")` no longer disagrees with
`pre1961-matching/match.R` and must leave `BASELINE_PRE1961_UNRESOLVED`. **The R matcher already reached
`PAL-1920-1948`**, via the explicit `normalise_iso` remap `PSE -> PAL` that the baseline's own header
documents. Python now derives the same answer from the name's family.

The other seven baseline entries did **not** follow, which is the consistency check on the whole reading:
for Libya pre-1912, Somalia pre-1960 and North Korea pre-1948 the name route returns `year_uncovered` too,
so those are genuine gaps in the database rather than routing defects — the 53 rows I separated from the 97
when filing the issue, still separated after the fix.

All 71 gates pass; full 91-case selftest green.