### PR TITLE
Document the period-average exclusion instead of leaving it as a filter: 9,865 rows, 5.12% (#310)

### DIFF
--- a/pipelines/historical-production-harmonized/README.md
+++ b/pipelines/historical-production-harmonized/README.md
@@ -99,3 +99,30 @@ The build excludes rows needing stronger assumptions:
 - ambiguous animal aggregates like cattle, pigs, chickens/poultry unless split
   rules are explicitly added
 - aggregate regional rows
+- **period averages — rows carrying a period label instead of a year.** This is
+  the largest single exclusion and it was previously implicit, visible only as a
+  `!is.na(year)` filter, so a coverage measurement read the gap as missing
+  sources rather than as a deliberate exclusion (whep-polities #310):
+
+  ```
+  layer B rows                          192,670
+  valued rows with NO year                9,865   5.12%   iia 6,163 | fao1952 3,702
+     ...carrying a period label           9,865   100%    none is genuinely undated
+  distinct periods                           21
+     1934-1938 5,629 | 1925-1929 1,649 | 1928-1932 1,600 | 1909-1913 845
+  series affected (label, item)           3,589   over 100 items and 401 labels
+  ```
+
+  These are the printed sources' five-year-mean convention, not sparse residue.
+  They are excluded because a period average is not an observation of a year and
+  placing it on one would invent a datum — but note the asymmetry with the
+  assertion pipeline, which does reason about them: `matchlib.eff_year` reads the
+  period's end year, `01_match_and_findings.py` routes a period average to the
+  polity covering the MOST of its span (the midpoint was rejected on
+  measurement), and `00_intake.py` refuses to run without `--period-col` (#437).
+  None of that reaches here, because this build has no `period` column at all.
+
+  If they are ever to be published, the option that needs no semantic decision is
+  a separate table keyed on `(period_start, period_end)` rather than a flag on a
+  chosen year — choosing the year is what #434's four lifetime-overlap failures
+  ran into.

--- a/pipelines/historical-production-harmonized/build.R
+++ b/pipelines/historical-production-harmonized/build.R
@@ -449,6 +449,20 @@ base <- dplyr::bind_cols(
     !is.na(.data$unit),
     !is.na(.data$whep_code),
     !is.na(.data$value),
+    # PERIOD AVERAGES ARE EXCLUDED HERE, and this is the largest single exclusion
+    # the build makes: 9,865 valued layer-B rows (5.12%) carry a period label
+    # like `1934-1938` instead of a year -- iia 6,163, fao1952 3,702, across
+    # 3,589 (label, item) series, 100 items and 401 labels. Every one of them has
+    # a period, so none is genuinely undated; they are the printed sources'
+    # five-year-mean convention.
+    #
+    # A period average is not an observation of a year, so placing it on one
+    # would invent a datum. But the exclusion used to be INVISIBLE -- just this
+    # predicate -- and a coverage measurement then reads the gap as missing
+    # sources (whep-polities #310). `period` is not even carried into this
+    # pipeline, so there is no path by which the label could supply a year, and
+    # `.prepare_historical_production()` would drop them again anyway via
+    # `year %in% years` (NA %in% years is FALSE in R).
     !is.na(.data$year)
   )
 


### PR DESCRIPTION
Addresses option 3 of the three I set out on #310. **No filter changes and no row's treatment moves.**

The harmonized build drops every row whose `year` is NA. That is the **largest single exclusion it makes**,
and it was visible only as a predicate, so a coverage measurement reads the gap as missing sources rather
than as a deliberate choice.

```
layer B rows                          192,670
valued rows with NO year                9,865   5.12%   iia 6,163 | fao1952 3,702
   ...carrying a period label           9,865    100%   none is genuinely undated
distinct periods                           21
   1934-1938 5,629 | 1925-1929 1,649 | 1928-1932 1,600 | 1909-1913 845
series affected (label, item)           3,589   over 100 items and 401 labels
```

These are the printed sources' five-year-mean convention across a fifth of the panel's labels — not sparse
residue.

### Dropped twice, and the second one is easy to miss

```r
# pipelines/historical-production-harmonized/build.R
dplyr::filter(..., !is.na(.data$value), !is.na(.data$year))

# WHEP .prepare_historical_production()
dt <- dt[year %in% years & ...]        # NA %in% years is FALSE in R
```

I verified the R semantics rather than assuming them: `NA %in% c(1961,1962)` returns `FALSE`. And `build.R`
contains **zero references to `period`**, so there is no path by which the label could supply a year.

### The asymmetry the comment records

The whep-polities side reasons carefully about these rows — `matchlib.eff_year` takes the period's end year,
`01_match_and_findings.py` routes a period average to the polity covering the **most** of its span (with the
midpoint alternative rejected on measurement), `00_intake.py` refuses to run without `--period-col` (#437),
and the assertion queue keys on the derived span. None of that reaches the publication path.

### Why this is worth committing on its own

It is the one option of the three that needs no semantic decision. Whether to publish period averages, and
how, stays open — and the option needing no decision there is a separate table keyed on
`(period_start, period_end)` rather than a flag on a chosen year, because choosing the year is exactly what
#434's four lifetime-overlap failures ran into.

It also settles where two other issues' harm lands: **#411**'s 24 period cells are inert downstream (its one
published cell is population 1937), and **#450**'s 122 back-projected rows would change no published number
even if routed correctly — 5,629 of the 9,865 are that same `1934-1938` period.

`build.R` parses. All 71 gates pass on merged main.