### PR TITLE
Count pre-era period rows in the baseline: 50 labels had none, and 5 of the 6 newly testable rows are fine (#416)

### DIFF
--- a/pipelines/polity-autoimprove/29_era_shift_verdicts.py
+++ b/pipelines/polity-autoimprove/29_era_shift_verdicts.py
@@ -93,6 +93,10 @@ def build(matched: str) -> list[dict]:
     t = d[d.source.eq(SOURCE) & d.item.isin(ITEMS)]
     prod = t[t.unit.eq("tonnes")]
     area = t[t.unit.eq("ha")]
+    def _period_end(p):
+        yy = re.findall(r"\d{4}", str(p or ""))
+        return int(yy[-1]) if yy else None
+
     key = ["country", "item", "year"]
     # median where a group holds several rows: this screen is about the ERA, not about within-group
     # duplication, which state/collapse_groups.csv covers separately.
@@ -100,7 +104,16 @@ def build(matched: str) -> list[dict]:
     # PERIOD ROWS PAIR ON THEIR PERIOD: an area average matches a production average of the same span.
     a_per = area[area.year.isna() & area.period.notna()].groupby(
         ["country", "item", "period"]).value.median()
-    base = prod[prod.year <= ERA_FROM - 1].groupby(["country", "item"]).value.median()
+    # THE BASELINE COUNTS PRE-ERA PERIOD ROWS TOO, and leaving them out was the same exclusion as the
+    # scope bug one block below: `prod.year <= ERA_FROM - 1` is False for NaN. Measured, 50 (label, item)
+    # pairs have ONLY a period baseline -- no dated pre-1934 production at all -- so their era rows had
+    # nothing to compare against and fell to `untestable`, which is the class this screen is least able
+    # to act on. A five-year mean is a legitimate level baseline and arguably a better one than a single
+    # year, being smoother; what it cannot do is date a defect, and it is not asked to.
+    pre_dated = prod[prod.year <= ERA_FROM - 1]
+    pre_per = prod[prod.year.isna() & prod.period.notna()]
+    pre_per = pre_per[pre_per.period.map(lambda p: (_period_end(p) or 9999) < ERA_FROM)]
+    base = pd.concat([pre_dated, pre_per]).groupby(["country", "item"]).value.median()
 
     # PERIOD ROWS ARE IN THE ERA TOO, and the first version of this screen dropped them silently.
     # 341 of the 1,037 production rows carry a period label instead of a year, and 99 of those are
@@ -114,10 +127,6 @@ def build(matched: str) -> list[dict]:
     # carries its `period`, so a five-year mean can never be read as an observation of one year. Note
     # these rows are excluded from publication anyway (issue 310, #460), so they are evidence about the
     # era's EXTENT, not about published figures.
-    def _period_end(p):
-        yy = re.findall(r"\d{4}", str(p or ""))
-        return int(yy[-1]) if yy else None
-
     per = prod[prod.year.isna() & prod.period.notna()]
     per = per[per.period.map(lambda p: (_period_end(p) or 0) >= ERA_FROM)]
 

--- a/pipelines/polity-autoimprove/state/era_shift_verdicts.csv
+++ b/pipelines/polity-autoimprove/state/era_shift_verdicts.csv
@@ -1,35 +1,35 @@
 source,label,whep_code,item,year,period,unit,production,area_ha,implied_yield,own_pre_era_median,ratio_to_own,verdict,convicted
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1942,,tonnes,15800,1000,15.8,33.75,468.148148,high_yield_3to20,False
-iia,congo,AEF-1910-1960,"tobacco, unmanufactured",,1934-1938,tonnes,102100,7000,14.585714,311,328.29582,high_yield_3to20,False
-iia,congo,AEF-1910-1960,"tobacco, unmanufactured",1934,,tonnes,108500,7000,15.5,311,348.874598,high_yield_3to20,False
-iia,congo,AEF-1910-1960,"tobacco, unmanufactured",1935,,tonnes,100000,6000,16.666667,311,321.543408,high_yield_3to20,False
-iia,czech republic,F51-1918-1938,hops,1934,,tonnes,707400,109000,6.489908,6651.05,106.359146,high_yield_3to20,False
-iia,czech republic,F51-1918-1938,hops,1935,,tonnes,761900,112000,6.802679,6651.05,114.553341,high_yield_3to20,False
-iia,czech republic,F51-1918-1938,hops,1936,,tonnes,1208100,114000,10.597368,6651.05,181.640493,high_yield_3to20,False
-iia,czech republic,F51-1918-1938,hops,1937,,tonnes,1216500,113000,10.765487,6651.05,182.903451,high_yield_3to20,False
-iia,czech republic,F51-1938-1945,hops,1944,,tonnes,46100,7000,6.585714,6651.05,6.931236,high_yield_3to20,False
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",,1934-1938,tonnes,13700,4000,3.425,223.7,61.242736,high_yield_3to20,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",,1934-1938,tonnes,20700,3000,6.9,630,32.857143,high_yield_3to20,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1934,,tonnes,27600,3000,9.2,630,43.809524,high_yield_3to20,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1935,,tonnes,22100,3000,7.366667,630,35.079365,high_yield_3to20,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1936,,tonnes,22000,3000,7.333333,630,34.920635,high_yield_3to20,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1937,,tonnes,23500,3000,7.833333,630,37.301587,high_yield_3to20,False
-iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",,1934-1938,tonnes,16000,2000,8,564.45,28.346178,high_yield_3to20,False
+iia,congo,AEF-1910-1960,"tobacco, unmanufactured",,1934-1938,tonnes,102100,7000,14.585714,566.65,180.18177,high_yield_3to20,False
+iia,congo,AEF-1910-1960,"tobacco, unmanufactured",1934,,tonnes,108500,7000,15.5,566.65,191.47622,high_yield_3to20,False
+iia,congo,AEF-1910-1960,"tobacco, unmanufactured",1935,,tonnes,100000,6000,16.666667,566.65,176.475779,high_yield_3to20,False
+iia,czech republic,F51-1918-1938,hops,1934,,tonnes,707400,109000,6.489908,7278.15,97.195029,high_yield_3to20,False
+iia,czech republic,F51-1918-1938,hops,1935,,tonnes,761900,112000,6.802679,7278.15,104.683196,high_yield_3to20,False
+iia,czech republic,F51-1918-1938,hops,1936,,tonnes,1208100,114000,10.597368,7278.15,165.989984,high_yield_3to20,False
+iia,czech republic,F51-1918-1938,hops,1937,,tonnes,1216500,113000,10.765487,7278.15,167.144123,high_yield_3to20,False
+iia,czech republic,F51-1938-1945,hops,1944,,tonnes,46100,7000,6.585714,7278.15,6.334027,high_yield_3to20,False
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",,1934-1938,tonnes,13700,4000,3.425,333.5,41.07946,high_yield_3to20,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",,1934-1938,tonnes,20700,3000,6.9,654,31.651376,high_yield_3to20,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1934,,tonnes,27600,3000,9.2,654,42.201835,high_yield_3to20,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1935,,tonnes,22100,3000,7.366667,654,33.792049,high_yield_3to20,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1936,,tonnes,22000,3000,7.333333,654,33.639144,high_yield_3to20,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1937,,tonnes,23500,3000,7.833333,654,35.932722,high_yield_3to20,False
+iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",,1934-1938,tonnes,16000,2000,8,580.9,27.543467,high_yield_3to20,False
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1944,,tonnes,5200,1000,5.2,4,1300,high_yield_3to20,False
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1945,,tonnes,5000,1000,5,4,1250,high_yield_3to20,False
-iia,mozambique,MOZ-1891-1975,"tobacco, unmanufactured",1935,,tonnes,18700,1000,18.7,0.7,26714.285714,high_yield_3to20,False
-iia,mozambique,MOZ-1891-1975,"tobacco, unmanufactured",1936,,tonnes,18700,1000,18.7,0.7,26714.285714,high_yield_3to20,False
-iia,serbia,F248-1920-1947,hops,1934,,tonnes,143300,24000,5.970833,1489.55,96.203551,high_yield_3to20,False
-iia,serbia,F248-1920-1947,hops,1935,,tonnes,189100,26000,7.273077,1489.55,126.951093,high_yield_3to20,False
-iia,serbia,F248-1920-1947,hops,1936,,tonnes,196200,27000,7.266667,1489.55,131.717633,high_yield_3to20,False
-iia,serbia,F248-1920-1947,hops,1937,,tonnes,213200,29000,7.351724,1489.55,143.130476,high_yield_3to20,False
-iia,serbia,F248-1920-1947,hops,1938,,tonnes,160000,28000,5.714286,1489.55,107.414991,high_yield_3to20,False
+iia,mozambique,MOZ-1891-1975,"tobacco, unmanufactured",1935,,tonnes,18700,1000,18.7,3.5,5342.857143,high_yield_3to20,False
+iia,mozambique,MOZ-1891-1975,"tobacco, unmanufactured",1936,,tonnes,18700,1000,18.7,3.5,5342.857143,high_yield_3to20,False
+iia,serbia,F248-1920-1947,hops,1934,,tonnes,143300,24000,5.970833,1550.95,92.394984,high_yield_3to20,False
+iia,serbia,F248-1920-1947,hops,1935,,tonnes,189100,26000,7.273077,1550.95,121.925272,high_yield_3to20,False
+iia,serbia,F248-1920-1947,hops,1936,,tonnes,196200,27000,7.266667,1550.95,126.503111,high_yield_3to20,False
+iia,serbia,F248-1920-1947,hops,1937,,tonnes,213200,29000,7.351724,1550.95,137.464135,high_yield_3to20,False
+iia,serbia,F248-1920-1947,hops,1938,,tonnes,160000,28000,5.714286,1550.95,103.162578,high_yield_3to20,False
 iia,sri lanka,LKA-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,95400,6000,15.9,4540,21.013216,high_yield_3to20,False
 iia,syrian arab republic,SYR-1922-1946,"tobacco, unmanufactured",1942,,tonnes,60400,6000,10.066667,2835.5,21.301358,high_yield_3to20,False
 iia,tanzania,TAN-1922-1964,"tobacco, unmanufactured",,1934-1938,tonnes,24800,2000,12.4,,,high_yield_3to20,False
-iia,albania,ALB-1913-2025,"tobacco, unmanufactured",,1934-1938,tonnes,161200,2000,80.6,,,impossible_yield,True
-iia,algeria,DZA-1919-1962,"tobacco, unmanufactured",,1934-1938,tonnes,1913900,23000,83.213043,,,impossible_yield,True
-iia,algeria,DZA-1919-1962,"tobacco, unmanufactured",1945,,tonnes,680400,10000,68.04,,,impossible_yield,True
+iia,albania,ALB-1913-2025,"tobacco, unmanufactured",,1934-1938,tonnes,161200,2000,80.6,49002.55,3.289625,impossible_yield,True
+iia,algeria,DZA-1919-1962,"tobacco, unmanufactured",,1934-1938,tonnes,1913900,23000,83.213043,24599.7,77.801762,impossible_yield,True
+iia,algeria,DZA-1919-1962,"tobacco, unmanufactured",1945,,tonnes,680400,10000,68.04,24599.7,27.658874,impossible_yield,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",,1934-1938,tonnes,237100,4000,59.275,1903.2,124.579655,impossible_yield,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1934,,tonnes,201700,3000,67.233333,1903.2,105.979403,impossible_yield,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1935,,tonnes,241400,4000,60.35,1903.2,126.839008,impossible_yield,True
@@ -39,102 +39,102 @@ iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1939,,tonnes,204900,3000,68.3
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1940,,tonnes,220200,4000,55.05,1903.2,115.699874,impossible_yield,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1941,,tonnes,273700,5000,54.74,1903.2,143.810425,impossible_yield,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1942,,tonnes,357800,6000,59.633333,1903.2,187.999159,impossible_yield,True
-iia,argentina,ARG-1902-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1552200,16000,97.0125,,,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,,1934-1938,tonnes,104500,400,261.25,848.35,123.180291,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1934,,tonnes,93700,4000,23.425,848.35,110.449696,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1935,,tonnes,109000,4000,27.25,848.35,128.484706,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1936,,tonnes,107800,5000,21.56,848.35,127.070195,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1937,,tonnes,103300,4000,25.825,848.35,121.765781,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1939,,tonnes,90400,500,180.8,848.35,106.559793,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1940,,tonnes,146400,500,292.8,848.35,172.570283,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1941,,tonnes,137500,500,275,848.35,162.07933,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1942,,tonnes,126000,500,252,848.35,148.523605,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1943,,tonnes,133900,500,267.8,848.35,157.835799,impossible_yield,True
-iia,australia,AUS-1901-2025,hops,1944,,tonnes,118500,500,237,848.35,139.682914,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",,1934-1938,tonnes,215700,4000,53.925,873.1,247.050739,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1934,,tonnes,141200,3000,47.066667,873.1,161.722598,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1935,,tonnes,252100,4000,63.025,873.1,288.741267,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1936,,tonnes,235800,5000,47.16,873.1,270.072157,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1937,,tonnes,271200,4000,67.8,873.1,310.617341,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1939,,tonnes,224800,3000,74.933333,873.1,257.473371,impossible_yield,True
-iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1940,,tonnes,248400,3000,82.8,873.1,284.503493,impossible_yield,True
-iia,belgium,BEL-1831-2025,hops,,1934-1938,tonnes,120600,900,134,,,impossible_yield,True
-iia,belgium,BEL-1831-2025,"tobacco, unmanufactured",,1934-1938,tonnes,633800,3000,211.266667,,,impossible_yield,True
+iia,argentina,ARG-1902-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1552200,16000,97.0125,11599.2,133.819574,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,,1934-1938,tonnes,104500,400,261.25,853.9,122.37967,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1934,,tonnes,93700,4000,23.425,853.9,109.731819,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1935,,tonnes,109000,4000,27.25,853.9,127.649608,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1936,,tonnes,107800,5000,21.56,853.9,126.244291,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1937,,tonnes,103300,4000,25.825,853.9,120.974353,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1939,,tonnes,90400,500,180.8,853.9,105.867198,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1940,,tonnes,146400,500,292.8,853.9,171.448647,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1941,,tonnes,137500,500,275,853.9,161.025881,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1942,,tonnes,126000,500,252,853.9,147.558262,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1943,,tonnes,133900,500,267.8,853.9,156.809931,impossible_yield,True
+iia,australia,AUS-1901-2025,hops,1944,,tonnes,118500,500,237,853.9,138.775032,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",,1934-1938,tonnes,215700,4000,53.925,920.8,234.252824,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1934,,tonnes,141200,3000,47.066667,920.8,153.344917,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1935,,tonnes,252100,4000,63.025,920.8,273.783666,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1936,,tonnes,235800,5000,47.16,920.8,256.081668,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1937,,tonnes,271200,4000,67.8,920.8,294.526499,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1939,,tonnes,224800,3000,74.933333,920.8,244.135534,impossible_yield,True
+iia,australia,AUS-1901-2025,"tobacco, unmanufactured",1940,,tonnes,248400,3000,82.8,920.8,269.765421,impossible_yield,True
+iia,belgium,BEL-1831-2025,hops,,1934-1938,tonnes,120600,900,134,3179,37.936458,impossible_yield,True
+iia,belgium,BEL-1831-2025,"tobacco, unmanufactured",,1934-1938,tonnes,633800,3000,211.266667,9404.6,67.392553,impossible_yield,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1943,,tonnes,22900,1000,22.9,33.75,678.518519,impossible_yield,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1944,,tonnes,56600,1000,56.6,33.75,1677.037037,impossible_yield,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1945,,tonnes,56200,2000,28.1,33.75,1665.185185,impossible_yield,True
-iia,bolivia,BOL-1909-1938,"tobacco, unmanufactured",,1934-1938,tonnes,353500,3000,117.833333,,,impossible_yield,True
-iia,brazil,BRA-1909-2025,"tobacco, unmanufactured",,1934-1938,tonnes,9265800,99000,93.593939,45000,205.906667,impossible_yield,True
-iia,bulgaria,BGR-1919-1940,"tobacco, unmanufactured",,1934-1938,tonnes,13056700,34000,384.020588,,,impossible_yield,True
-iia,canada,CAN-1886-1949,hops,,1934-1938,tonnes,73100,400,182.75,,,impossible_yield,True
-iia,canada,CAN-1886-1949,"tobacco, unmanufactured",,1934-1938,tonnes,2846800,24000,118.616667,,,impossible_yield,True
-iia,chile,CHL-1902-2025,"tobacco, unmanufactured",,1934-1938,tonnes,691800,3000,230.6,8778.2,78.808867,impossible_yield,True
-iia,chile,CHL-1902-2025,"tobacco, unmanufactured",1939,,tonnes,956500,5000,191.3,8778.2,108.963113,impossible_yield,True
+iia,bolivia,BOL-1909-1938,"tobacco, unmanufactured",,1934-1938,tonnes,353500,3000,117.833333,242252,1.459224,impossible_yield,True
+iia,brazil,BRA-1909-2025,"tobacco, unmanufactured",,1934-1938,tonnes,9265800,99000,93.593939,90512.5,102.370391,impossible_yield,True
+iia,bulgaria,BGR-1919-1940,"tobacco, unmanufactured",,1934-1938,tonnes,13056700,34000,384.020588,27478.6,475.158851,impossible_yield,True
+iia,canada,CAN-1886-1949,hops,,1934-1938,tonnes,73100,400,182.75,512.8,142.550702,impossible_yield,True
+iia,canada,CAN-1886-1949,"tobacco, unmanufactured",,1934-1938,tonnes,2846800,24000,118.616667,15772.5,180.491362,impossible_yield,True
+iia,chile,CHL-1902-2025,"tobacco, unmanufactured",,1934-1938,tonnes,691800,3000,230.6,8579.3,80.635949,impossible_yield,True
+iia,chile,CHL-1902-2025,"tobacco, unmanufactured",1939,,tonnes,956500,5000,191.3,8579.3,111.489282,impossible_yield,True
 iia,"china, mainland",CHN-1932-1945,"tobacco, unmanufactured",,1934-1938,tonnes,64152300,566000,113.343286,,,impossible_yield,True
 iia,"china, mainland",CHN-1932-1945,"tobacco, unmanufactured",1940,,tonnes,51345800,442000,116.166968,,,impossible_yield,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",,1934-1938,tonnes,225300,1000,225.3,861.7,261.459905,impossible_yield,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1934,,tonnes,214000,1000,214,861.7,248.346292,impossible_yield,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1935,,tonnes,203500,1000,203.5,861.7,236.161077,impossible_yield,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1937,,tonnes,261100,1000,261.1,861.7,303.005686,impossible_yield,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1940,,tonnes,471700,4000,117.925,861.7,547.40629,impossible_yield,True
-iia,colombia,COL-1922-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1224100,11000,111.281818,,,impossible_yield,True
-iia,costa rica,CRI-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,26500,1000,26.5,,,impossible_yield,True
-iia,cuba,CUB-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,2192100,45000,48.713333,,,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",,1934-1938,tonnes,23600,1000,23.6,27,874.074074,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1934,,tonnes,72500,2000,36.25,27,2685.185185,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1941,,tonnes,21300,1000,21.3,27,788.888889,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1943,,tonnes,68100,2000,34.05,27,2522.222222,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1944,,tonnes,56800,1000,56.8,27,2103.703704,impossible_yield,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1945,,tonnes,81300,2000,40.65,27,3011.111111,impossible_yield,True
-iia,czech republic,F51-1918-1938,hops,,1934-1938,tonnes,973500,11300,86.150442,6651.05,146.367867,impossible_yield,True
-iia,czech republic,F51-1938-1945,hops,1939,,tonnes,763400,10500,72.704762,6651.05,114.77887,impossible_yield,True
-iia,czech republic,F51-1938-1945,hops,1940,,tonnes,457600,8900,51.41573,6651.05,68.801167,impossible_yield,True
-iia,czech republic,F51-1938-1945,hops,1941,,tonnes,352700,7500,47.026667,6651.05,53.029221,impossible_yield,True
-iia,czech republic,F51-1938-1945,hops,1942,,tonnes,310700,7300,42.561644,6651.05,46.714429,impossible_yield,True
-iia,czech republic,F51-1938-1945,hops,1943,,tonnes,315200,6300,50.031746,6651.05,47.391013,impossible_yield,True
-iia,czech republic,F51-1945-1947,hops,1945,,tonnes,372100,8300,44.831325,6651.05,55.946054,impossible_yield,True
-iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",,1934-1938,tonnes,41410600,10000,4141.06,6323.05,6549.14954,impossible_yield,True
-iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1934,,tonnes,1368300,10000,136.83,6323.05,216.398732,impossible_yield,True
-iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1935,,tonnes,1363100,10000,136.31,6323.05,215.576344,impossible_yield,True
-iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1936,,tonnes,1507200,10000,150.72,6323.05,238.365978,impossible_yield,True
-iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1937,,tonnes,1403600,10000,140.36,6323.05,221.98148,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1939,,tonnes,933000,6000,155.5,6323.05,147.555373,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1940,,tonnes,780000,6000,130,6323.05,123.358189,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1941,,tonnes,691400,5000,138.28,6323.05,109.345964,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1942,,tonnes,746800,5000,149.36,6323.05,118.107559,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1943,,tonnes,542900,2000,271.45,6323.05,85.860463,impossible_yield,True
-iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1944,,tonnes,392800,3000,130.933333,6323.05,62.121919,impossible_yield,True
-iia,dr congo,COD-1910-1960,"tobacco, unmanufactured",,1934-1938,tonnes,404600,5000,80.92,1100,367.818182,impossible_yield,True
-iia,france,FRA-1919-2025,hops,,1934-1938,tonnes,223900,1800,124.388889,,,impossible_yield,True
-iia,france,FRA-1919-2025,"tobacco, unmanufactured",,1934-1938,tonnes,3566700,18000,198.15,,,impossible_yield,True
-iia,germany,DEU-1920-1938,hops,,1934-1938,tonnes,908700,9600,94.65625,,,impossible_yield,True
-iia,germany,DEU-1920-1938,"tobacco, unmanufactured",,1934-1938,tonnes,3360700,13000,258.515385,,,impossible_yield,True
-iia,greece,GRC-1919-1947,"tobacco, unmanufactured",,1934-1938,tonnes,5737600,89000,64.467416,,,impossible_yield,True
-iia,guatemala,GTM-1821-2025,"tobacco, unmanufactured",,1934-1938,tonnes,82200,2000,41.1,257.7,318.975553,impossible_yield,True
-iia,honduras,HND-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,337300,6000,56.216667,,,impossible_yield,True
-iia,hungary,HUN-1920-1938,hops,,1934-1938,tonnes,6600,100,66,42.2,156.398104,impossible_yield,True
-iia,hungary,HUN-1920-1938,"tobacco, unmanufactured",,1934-1938,tonnes,2047600,15000,136.506667,,,impossible_yield,True
-iia,indonesia,IDN-1800-1945,"tobacco, unmanufactured",,1934-1938,tonnes,3471000,41000,84.658537,,,impossible_yield,True
-iia,indonesia,IDN-1800-1945,"tobacco, unmanufactured",1940,,tonnes,2079600,19000,109.452632,,,impossible_yield,True
-iia,iran,IRN-1828-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1500000,12000,125,,,impossible_yield,True
-iia,iran,IRN-1828-2025,"tobacco, unmanufactured",1940,,tonnes,1270000,13000,97.692308,,,impossible_yield,True
-iia,iraq,IRQ-1932-2025,"tobacco, unmanufactured",,1934-1938,tonnes,510700,4000,127.675,,,impossible_yield,True
-iia,iraq,IRQ-1932-2025,"tobacco, unmanufactured",1940,,tonnes,422000,7000,60.285714,,,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",,1934-1938,tonnes,138600,3000,46.2,573.75,241.568627,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1934,,tonnes,101100,2000,50.55,573.75,176.20915,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1935,,tonnes,100000,2000,50,573.75,174.291939,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1936,,tonnes,123700,3000,41.233333,573.75,215.599129,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1937,,tonnes,250400,6000,41.733333,573.75,436.427015,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1939,,tonnes,52300,2000,26.15,573.75,91.154684,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1940,,tonnes,98500,2000,49.25,573.75,171.67756,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1941,,tonnes,58900,1000,58.9,573.75,102.657952,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1942,,tonnes,141900,3000,47.3,573.75,247.320261,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1943,,tonnes,128900,3000,42.966667,573.75,224.662309,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1944,,tonnes,168300,3000,56.1,573.75,293.333333,impossible_yield,True
-iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1945,,tonnes,136000,3000,45.333333,573.75,237.037037,impossible_yield,True
-iia,italy,ITA-1919-2025,"tobacco, unmanufactured",,1934-1938,tonnes,4375800,33000,132.6,,,impossible_yield,True
-iia,japan,JPN-1895-1945,"tobacco, unmanufactured",,1934-1938,tonnes,6410500,35000,183.157143,,,impossible_yield,True
-iia,japan,JPN-1895-1945,"tobacco, unmanufactured",1940,,tonnes,8705400,49000,177.661224,,,impossible_yield,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",,1934-1938,tonnes,225300,1000,225.3,940.4,239.578903,impossible_yield,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1934,,tonnes,214000,1000,214,940.4,227.562739,impossible_yield,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1935,,tonnes,203500,1000,203.5,940.4,216.397278,impossible_yield,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1937,,tonnes,261100,1000,261.1,940.4,277.647809,impossible_yield,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1940,,tonnes,471700,4000,117.925,940.4,501.595066,impossible_yield,True
+iia,colombia,COL-1922-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1224100,11000,111.281818,11072.2,110.556168,impossible_yield,True
+iia,costa rica,CRI-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,26500,1000,26.5,62569.55,0.423529,impossible_yield,True
+iia,cuba,CUB-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,2192100,45000,48.713333,28117,77.96351,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",,1934-1938,tonnes,23600,1000,23.6,41.45,569.360676,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1934,,tonnes,72500,2000,36.25,41.45,1749.095296,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1941,,tonnes,21300,1000,21.3,41.45,513.872135,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1943,,tonnes,68100,2000,34.05,41.45,1642.943305,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1944,,tonnes,56800,1000,56.8,41.45,1370.325694,impossible_yield,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1945,,tonnes,81300,2000,40.65,41.45,1961.399276,impossible_yield,True
+iia,czech republic,F51-1918-1938,hops,,1934-1938,tonnes,973500,11300,86.150442,7278.15,133.756518,impossible_yield,True
+iia,czech republic,F51-1938-1945,hops,1939,,tonnes,763400,10500,72.704762,7278.15,104.889292,impossible_yield,True
+iia,czech republic,F51-1938-1945,hops,1940,,tonnes,457600,8900,51.41573,7278.15,62.87312,impossible_yield,True
+iia,czech republic,F51-1938-1945,hops,1941,,tonnes,352700,7500,47.026667,7278.15,48.460117,impossible_yield,True
+iia,czech republic,F51-1938-1945,hops,1942,,tonnes,310700,7300,42.561644,7278.15,42.68942,impossible_yield,True
+iia,czech republic,F51-1938-1945,hops,1943,,tonnes,315200,6300,50.031746,7278.15,43.307709,impossible_yield,True
+iia,czech republic,F51-1945-1947,hops,1945,,tonnes,372100,8300,44.831325,7278.15,51.125629,impossible_yield,True
+iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",,1934-1938,tonnes,41410600,10000,4141.06,7144.5,5796.150885,impossible_yield,True
+iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1934,,tonnes,1368300,10000,136.83,7144.5,191.517951,impossible_yield,True
+iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1935,,tonnes,1363100,10000,136.31,7144.5,190.790118,impossible_yield,True
+iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1936,,tonnes,1507200,10000,150.72,7144.5,210.959479,impossible_yield,True
+iia,czech republic,F51-1918-1938,"tobacco, unmanufactured",1937,,tonnes,1403600,10000,140.36,7144.5,196.458814,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1939,,tonnes,933000,6000,155.5,7144.5,130.589964,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1940,,tonnes,780000,6000,130,7144.5,109.17489,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1941,,tonnes,691400,5000,138.28,7144.5,96.773742,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1942,,tonnes,746800,5000,149.36,7144.5,104.527959,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1943,,tonnes,542900,2000,271.45,7144.5,75.988523,impossible_yield,True
+iia,czech republic,F51-1938-1945,"tobacco, unmanufactured",1944,,tonnes,392800,3000,130.933333,7144.5,54.979355,impossible_yield,True
+iia,dr congo,COD-1910-1960,"tobacco, unmanufactured",,1934-1938,tonnes,404600,5000,80.92,1141.65,354.399334,impossible_yield,True
+iia,france,FRA-1919-2025,hops,,1934-1938,tonnes,223900,1800,124.388889,6211.5,36.046044,impossible_yield,True
+iia,france,FRA-1919-2025,"tobacco, unmanufactured",,1934-1938,tonnes,3566700,18000,198.15,27523,129.589798,impossible_yield,True
+iia,germany,DEU-1920-1938,hops,,1934-1938,tonnes,908700,9600,94.65625,8741.5,103.952411,impossible_yield,True
+iia,germany,DEU-1920-1938,"tobacco, unmanufactured",,1934-1938,tonnes,3360700,13000,258.515385,25833.9,130.088759,impossible_yield,True
+iia,greece,GRC-1919-1947,"tobacco, unmanufactured",,1934-1938,tonnes,5737600,89000,64.467416,63154.9,90.849641,impossible_yield,True
+iia,guatemala,GTM-1821-2025,"tobacco, unmanufactured",,1934-1938,tonnes,82200,2000,41.1,187.8,437.699681,impossible_yield,True
+iia,honduras,HND-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,337300,6000,56.216667,337300,1,impossible_yield,True
+iia,hungary,HUN-1920-1938,hops,,1934-1938,tonnes,6600,100,66,383.75,17.198697,impossible_yield,True
+iia,hungary,HUN-1920-1938,"tobacco, unmanufactured",,1934-1938,tonnes,2047600,15000,136.506667,46078.3,44.437403,impossible_yield,True
+iia,indonesia,IDN-1800-1945,"tobacco, unmanufactured",,1934-1938,tonnes,3471000,41000,84.658537,63566.6,54.604147,impossible_yield,True
+iia,indonesia,IDN-1800-1945,"tobacco, unmanufactured",1940,,tonnes,2079600,19000,109.452632,63566.6,32.715294,impossible_yield,True
+iia,iran,IRN-1828-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1500000,12000,125,1353300,1.108402,impossible_yield,True
+iia,iran,IRN-1828-2025,"tobacco, unmanufactured",1940,,tonnes,1270000,13000,97.692308,1353300,0.938447,impossible_yield,True
+iia,iraq,IRQ-1932-2025,"tobacco, unmanufactured",,1934-1938,tonnes,510700,4000,127.675,206854.95,2.46888,impossible_yield,True
+iia,iraq,IRQ-1932-2025,"tobacco, unmanufactured",1940,,tonnes,422000,7000,60.285714,206854.95,2.040077,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",,1934-1938,tonnes,138600,3000,46.2,583.05,237.715462,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1934,,tonnes,101100,2000,50.55,583.05,173.398508,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1935,,tonnes,100000,2000,50,583.05,171.511877,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1936,,tonnes,123700,3000,41.233333,583.05,212.160192,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1937,,tonnes,250400,6000,41.733333,583.05,429.465741,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1939,,tonnes,52300,2000,26.15,583.05,89.700712,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1940,,tonnes,98500,2000,49.25,583.05,168.939199,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1941,,tonnes,58900,1000,58.9,583.05,101.020496,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1942,,tonnes,141900,3000,47.3,583.05,243.375354,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1943,,tonnes,128900,3000,42.966667,583.05,221.07881,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1944,,tonnes,168300,3000,56.1,583.05,288.654489,impossible_yield,True
+iia,israel,PAL-1920-1948,"tobacco, unmanufactured",1945,,tonnes,136000,3000,45.333333,583.05,233.256153,impossible_yield,True
+iia,italy,ITA-1919-2025,"tobacco, unmanufactured",,1934-1938,tonnes,4375800,33000,132.6,41318.9,105.90311,impossible_yield,True
+iia,japan,JPN-1895-1945,"tobacco, unmanufactured",,1934-1938,tonnes,6410500,35000,183.157143,64313.3,99.676117,impossible_yield,True
+iia,japan,JPN-1895-1945,"tobacco, unmanufactured",1940,,tonnes,8705400,49000,177.661224,64313.3,135.359249,impossible_yield,True
 iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",,1934-1938,tonnes,108000,2000,54,,,impossible_yield,True
 iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",1939,,tonnes,62400,1000,62.4,,,impossible_yield,True
 iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",1940,,tonnes,76000,1000,76,,,impossible_yield,True
@@ -142,25 +142,25 @@ iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",1941,,tonnes,49700,1000,49.7
 iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",1942,,tonnes,44800,1000,44.8,,,impossible_yield,True
 iia,lebanon,LBN-1920-1944,"tobacco, unmanufactured",1943,,tonnes,23600,1000,23.6,,,impossible_yield,True
 iia,lebanon,LBN-1944-2025,"tobacco, unmanufactured",1944,,tonnes,74900,1000,74.9,,,impossible_yield,True
-iia,madagascar,MDG-1882-2025,"tobacco, unmanufactured",,1934-1938,tonnes,559200,7000,79.885714,,,impossible_yield,True
-iia,madagascar,MDG-1882-2025,"tobacco, unmanufactured",1945,,tonnes,193300,3000,64.433333,,,impossible_yield,True
-iia,malawi,MWI-1891-1953,"tobacco, unmanufactured",,1934-1938,tonnes,129900,3000,43.3,,,impossible_yield,True
-iia,malawi,MWI-1891-1953,"tobacco, unmanufactured",1945,,tonnes,101200,2000,50.6,,,impossible_yield,True
+iia,madagascar,MDG-1882-2025,"tobacco, unmanufactured",,1934-1938,tonnes,559200,7000,79.885714,1906.6,293.296968,impossible_yield,True
+iia,madagascar,MDG-1882-2025,"tobacco, unmanufactured",1945,,tonnes,193300,3000,64.433333,1906.6,101.384664,impossible_yield,True
+iia,malawi,MWI-1891-1953,"tobacco, unmanufactured",,1934-1938,tonnes,129900,3000,43.3,3314.5,39.191432,impossible_yield,True
+iia,malawi,MWI-1891-1953,"tobacco, unmanufactured",1945,,tonnes,101200,2000,50.6,3314.5,30.532509,impossible_yield,True
 iia,mali,MLI-1890-1960,"tobacco, unmanufactured",,1934-1938,tonnes,139000,2000,69.5,1600,86.875,impossible_yield,True
 iia,mali,MLI-1890-1960,"tobacco, unmanufactured",1934,,tonnes,150000,3000,50,1600,93.75,impossible_yield,True
 iia,mali,MLI-1890-1960,"tobacco, unmanufactured",1935,,tonnes,155000,3000,51.666667,1600,96.875,impossible_yield,True
 iia,mali,MLI-1890-1960,"tobacco, unmanufactured",1936,,tonnes,150000,1000,150,1600,93.75,impossible_yield,True
 iia,mali,MLI-1890-1960,"tobacco, unmanufactured",1937,,tonnes,120000,1000,120,1600,75,impossible_yield,True
-iia,mexico,MEX-1848-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1543100,18000,85.727778,,,impossible_yield,True
+iia,mexico,MEX-1848-2025,"tobacco, unmanufactured",,1934-1938,tonnes,1543100,18000,85.727778,12000,128.591667,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1939,,tonnes,41100,1000,41.1,201.35,204.122175,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1940,,tonnes,60100,1000,60.1,201.35,298.485225,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1941,,tonnes,60500,1000,60.5,201.35,300.471815,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1942,,tonnes,51700,1000,51.7,201.35,256.766824,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1943,,tonnes,103400,1000,103.4,201.35,513.533648,impossible_yield,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1944,,tonnes,100500,1000,100.5,201.35,499.130867,impossible_yield,True
-iia,myanmar,MMR-1885-2025,"tobacco, unmanufactured",,1934-1938,tonnes,4519600,40000,112.99,,,impossible_yield,True
-iia,myanmar,MMR-1885-2025,"tobacco, unmanufactured",1940,,tonnes,6247200,56000,111.557143,,,impossible_yield,True
-iia,new zealand,NZL-1840-2025,hops,,1934-1938,tonnes,39700,300,132.333333,358.3,110.801005,impossible_yield,True
+iia,myanmar,MMR-1885-2025,"tobacco, unmanufactured",,1934-1938,tonnes,4519600,40000,112.99,4938000,0.915269,impossible_yield,True
+iia,myanmar,MMR-1885-2025,"tobacco, unmanufactured",1940,,tonnes,6247200,56000,111.557143,4938000,1.265128,impossible_yield,True
+iia,new zealand,NZL-1840-2025,hops,,1934-1938,tonnes,39700,300,132.333333,365,108.767123,impossible_yield,True
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",,1934-1938,tonnes,62000,1000,62,580.25,106.850495,impossible_yield,True
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1934,,tonnes,50200,1000,50.2,580.25,86.514433,impossible_yield,True
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1935,,tonnes,48300,1000,48.3,580.25,83.239983,impossible_yield,True
@@ -173,49 +173,49 @@ iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1942,,tonnes,144500,1000
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1943,,tonnes,139100,1000,139.1,580.25,239.724257,impossible_yield,True
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1944,,tonnes,149100,1000,149.1,580.25,256.958208,impossible_yield,True
 iia,new zealand,NZL-1840-2025,"tobacco, unmanufactured",1945,,tonnes,158800,1000,158.8,580.25,273.67514,impossible_yield,True
-iia,nicaragua,NIC-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,55000,1000,55,,,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",,1934-1938,tonnes,44900,1000,44.9,169.5,264.896755,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1934,,tonnes,42400,1000,42.4,169.5,250.147493,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1935,,tonnes,50000,1000,50,169.5,294.985251,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1937,,tonnes,35000,1000,35,169.5,206.489676,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1939,,tonnes,36000,1000,36,169.5,212.389381,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1940,,tonnes,43000,1000,43,169.5,253.687316,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1941,,tonnes,50500,1000,50.5,169.5,297.935103,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1942,,tonnes,39800,1000,39.8,169.5,234.80826,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1943,,tonnes,48000,1000,48,169.5,283.185841,impossible_yield,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1944,,tonnes,47000,1000,47,169.5,277.286136,impossible_yield,True
-iia,paraguay,PRY-1932-1938,"tobacco, unmanufactured",,1934-1938,tonnes,765300,9000,85.033333,,,impossible_yield,True
-iia,philippines,PHL-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,3212700,65000,49.426154,,,impossible_yield,True
-iia,philippines,PHL-1800-2025,"tobacco, unmanufactured",1940,,tonnes,3440600,72000,47.786111,,,impossible_yield,True
-iia,poland,POL-1921-1945,hops,,1934-1938,tonnes,177200,3200,55.375,1614.1,109.782541,impossible_yield,True
-iia,poland,POL-1921-1945,"tobacco, unmanufactured",,1934-1938,tonnes,1137200,6000,189.533333,,,impossible_yield,True
-iia,romania,ROU-1920-1940,"tobacco, unmanufactured",,1934-1938,tonnes,1132300,16000,70.76875,,,impossible_yield,True
-iia,russian federation,F228-1921-1940,hops,,1934-1938,tonnes,100000,2000,50,4422.7,22.610622,impossible_yield,True
-iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",,1934-1938,tonnes,22403500,199000,112.580402,92549.6,242.070198,impossible_yield,True
-iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",1934,,tonnes,17207000,191000,90.089005,92549.6,185.921927,impossible_yield,True
-iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",1936,,tonnes,27600000,203000,135.960591,92549.6,298.218469,impossible_yield,True
-iia,serbia,F248-1920-1947,hops,,1934-1938,tonnes,180400,2700,66.814815,1489.55,121.110402,impossible_yield,True
-iia,serbia,F248-1920-1947,hops,1939,,tonnes,181500,2800,64.821429,1489.55,121.848881,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",,1934-1938,tonnes,1348200,15000,89.88,12693.55,106.211422,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1934,,tonnes,604900,7000,86.414286,12693.55,47.654124,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1935,,tonnes,924900,12000,77.075,12693.55,72.863777,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1936,,tonnes,1662400,18000,92.355556,12693.55,130.964151,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1937,,tonnes,2078300,21000,98.966667,12693.55,163.728823,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1938,,tonnes,1470800,16000,91.925,12693.55,115.869871,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1939,,tonnes,1543300,18000,85.738889,12693.55,121.581433,impossible_yield,True
-iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1945,,tonnes,1270100,14000,90.721429,12693.55,100.058691,impossible_yield,True
-iia,south africa,ZAF-1910-2025,"tobacco, unmanufactured",,1934-1938,tonnes,913100,14000,65.221429,6609.8,138.143363,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",,1934-1938,tonnes,2252500,17000,132.5,13433.25,167.680941,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1934,,tonnes,1540400,15000,102.693333,13433.25,114.670687,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1935,,tonnes,2192100,16000,137.00625,13433.25,163.184635,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1936,,tonnes,2062600,17000,121.329412,13433.25,153.544377,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1937,,tonnes,2648800,19000,139.410526,13433.25,197.182365,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1938,,tonnes,2798400,20000,139.92,13433.25,208.31891,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1939,,tonnes,3101900,22000,140.995455,13433.25,230.912102,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1940,,tonnes,2924900,22000,132.95,13433.25,217.735842,impossible_yield,True
-iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1941,,tonnes,3512000,23000,152.695652,13433.25,261.440828,impossible_yield,True
-iia,spain,ESP-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,707100,4000,176.775,,,impossible_yield,True
-iia,switzerland,CHE-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,106700,1000,106.7,,,impossible_yield,True
+iia,nicaragua,NIC-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,55000,1000,55,73300,0.750341,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",,1934-1938,tonnes,44900,1000,44.9,170.35,263.574993,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1934,,tonnes,42400,1000,42.4,170.35,248.899325,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1935,,tonnes,50000,1000,50,170.35,293.513355,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1937,,tonnes,35000,1000,35,170.35,205.459348,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1939,,tonnes,36000,1000,36,170.35,211.329615,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1940,,tonnes,43000,1000,43,170.35,252.421485,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1941,,tonnes,50500,1000,50.5,170.35,296.448488,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1942,,tonnes,39800,1000,39.8,170.35,233.63663,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1943,,tonnes,48000,1000,48,170.35,281.772821,impossible_yield,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1944,,tonnes,47000,1000,47,170.35,275.902554,impossible_yield,True
+iia,paraguay,PRY-1932-1938,"tobacco, unmanufactured",,1934-1938,tonnes,765300,9000,85.033333,10670.3,71.722445,impossible_yield,True
+iia,philippines,PHL-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,3212700,65000,49.426154,46232.4,69.490228,impossible_yield,True
+iia,philippines,PHL-1800-2025,"tobacco, unmanufactured",1940,,tonnes,3440600,72000,47.786111,46232.4,74.419671,impossible_yield,True
+iia,poland,POL-1921-1945,hops,,1934-1938,tonnes,177200,3200,55.375,1971.8,89.867126,impossible_yield,True
+iia,poland,POL-1921-1945,"tobacco, unmanufactured",,1934-1938,tonnes,1137200,6000,189.533333,382836,2.970463,impossible_yield,True
+iia,romania,ROU-1920-1940,"tobacco, unmanufactured",,1934-1938,tonnes,1132300,16000,70.76875,19252.5,58.813141,impossible_yield,True
+iia,russian federation,F228-1921-1940,hops,,1934-1938,tonnes,100000,2000,50,4416.15,22.644158,impossible_yield,True
+iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",,1934-1938,tonnes,22403500,199000,112.580402,100536.05,222.840464,impossible_yield,True
+iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",1934,,tonnes,17207000,191000,90.089005,100536.05,171.152537,impossible_yield,True
+iia,russian federation,F228-1921-1940,"tobacco, unmanufactured",1936,,tonnes,27600000,203000,135.960591,100536.05,274.528391,impossible_yield,True
+iia,serbia,F248-1920-1947,hops,,1934-1938,tonnes,180400,2700,66.814815,1550.95,116.315806,impossible_yield,True
+iia,serbia,F248-1920-1947,hops,1939,,tonnes,181500,2800,64.821429,1550.95,117.025049,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",,1934-1938,tonnes,1348200,15000,89.88,12061.2,111.779922,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1934,,tonnes,604900,7000,86.414286,12061.2,50.152555,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1935,,tonnes,924900,12000,77.075,12061.2,76.683912,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1936,,tonnes,1662400,18000,92.355556,12061.2,137.830398,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1937,,tonnes,2078300,21000,98.966667,12061.2,172.312871,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1938,,tonnes,1470800,16000,91.925,12061.2,121.944748,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1939,,tonnes,1543300,18000,85.738889,12061.2,127.955759,impossible_yield,True
+iia,serbia,F248-1920-1947,"tobacco, unmanufactured",1945,,tonnes,1270100,14000,90.721429,12061.2,105.304613,impossible_yield,True
+iia,south africa,ZAF-1910-2025,"tobacco, unmanufactured",,1934-1938,tonnes,913100,14000,65.221429,6786.3,134.550491,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",,1934-1938,tonnes,2252500,17000,132.5,13781.7,163.441375,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1934,,tonnes,1540400,15000,102.693333,13781.7,111.771407,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1935,,tonnes,2192100,16000,137.00625,13781.7,159.058752,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1936,,tonnes,2062600,17000,121.329412,13781.7,149.662233,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1937,,tonnes,2648800,19000,139.410526,13781.7,192.196899,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1938,,tonnes,2798400,20000,139.92,13781.7,203.051873,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1939,,tonnes,3101900,22000,140.995455,13781.7,225.07383,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1940,,tonnes,2924900,22000,132.95,13781.7,212.230712,impossible_yield,True
+iia,south korea,KOR-1800-1945,"tobacco, unmanufactured",1941,,tonnes,3512000,23000,152.695652,13781.7,254.830681,impossible_yield,True
+iia,spain,ESP-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,707100,4000,176.775,290617.7,2.433093,impossible_yield,True
+iia,switzerland,CHE-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,106700,1000,106.7,623.4,171.158165,impossible_yield,True
 iia,syrian arab republic,SYR-1922-1946,"tobacco, unmanufactured",,1934-1938,tonnes,272200,4000,68.05,2835.5,95.997179,impossible_yield,True
 iia,syrian arab republic,SYR-1922-1946,"tobacco, unmanufactured",1934,,tonnes,335600,5000,67.12,2835.5,118.356551,impossible_yield,True
 iia,syrian arab republic,SYR-1922-1946,"tobacco, unmanufactured",1935,,tonnes,201400,4000,50.35,2835.5,71.028037,impossible_yield,True
@@ -232,15 +232,15 @@ iia,tanzania,TAN-1922-1964,"tobacco, unmanufactured",1942,,tonnes,83000,3000,27.
 iia,tanzania,TAN-1922-1964,"tobacco, unmanufactured",1943,,tonnes,106900,4000,26.725,,,impossible_yield,True
 iia,tanzania,TAN-1922-1964,"tobacco, unmanufactured",1944,,tonnes,104000,4000,26,,,impossible_yield,True
 iia,tanzania,TAN-1922-1964,"tobacco, unmanufactured",1945,,tonnes,95000,4000,23.75,,,impossible_yield,True
-iia,thailand,THA-1909-2025,"tobacco, unmanufactured",,1934-1938,tonnes,882800,10000,88.28,,,impossible_yield,True
-iia,thailand,THA-1909-2025,"tobacco, unmanufactured",1940,,tonnes,937900,8000,117.2375,,,impossible_yield,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1934,,tonnes,65000,1000,65,285,228.070175,impossible_yield,True
-iia,turkey,TUR-1920-2025,"tobacco, unmanufactured",,1934-1938,tonnes,5543300,72000,76.990278,,,impossible_yield,True
-iia,turkey,TUR-1920-2025,"tobacco, unmanufactured",1940,,tonnes,7135600,78000,91.482051,,,impossible_yield,True
-iia,united kingdom,GBR-1921-2025,hops,,1934-1938,tonnes,1271100,7400,171.77027,,,impossible_yield,True
-iia,united states of america,USA-1867-1959,hops,,1934-1938,tonnes,1768000,14000,126.285714,,,impossible_yield,True
-iia,united states of america,USA-1867-1959,"tobacco, unmanufactured",,1934-1938,tonnes,60387500,627000,96.311802,,,impossible_yield,True
-iia,uruguay,URY-1828-2025,"tobacco, unmanufactured",,1934-1938,tonnes,54000,1000,54,35.4,1525.423729,impossible_yield,True
+iia,thailand,THA-1909-2025,"tobacco, unmanufactured",,1934-1938,tonnes,882800,10000,88.28,5430.8,162.55432,impossible_yield,True
+iia,thailand,THA-1909-2025,"tobacco, unmanufactured",1940,,tonnes,937900,8000,117.2375,5430.8,172.700155,impossible_yield,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1934,,tonnes,65000,1000,65,294.7,220.563285,impossible_yield,True
+iia,turkey,TUR-1920-2025,"tobacco, unmanufactured",,1934-1938,tonnes,5543300,72000,76.990278,1984975.5,2.792629,impossible_yield,True
+iia,turkey,TUR-1920-2025,"tobacco, unmanufactured",1940,,tonnes,7135600,78000,91.482051,1984975.5,3.594805,impossible_yield,True
+iia,united kingdom,GBR-1921-2025,hops,,1934-1938,tonnes,1271100,7400,171.77027,15677.5,81.077978,impossible_yield,True
+iia,united states of america,USA-1867-1959,hops,,1934-1938,tonnes,1768000,14000,126.285714,23431.9,75.452695,impossible_yield,True
+iia,united states of america,USA-1867-1959,"tobacco, unmanufactured",,1934-1938,tonnes,60387500,627000,96.311802,630805.5,95.730776,impossible_yield,True
+iia,uruguay,URY-1828-2025,"tobacco, unmanufactured",,1934-1938,tonnes,54000,1000,54,577.95,93.433688,impossible_yield,True
 iia,venezuela,VEN-1821-2025,"tobacco, unmanufactured",,1934-1938,tonnes,322100,8000,40.2625,,,impossible_yield,True
 iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",,1934-1938,tonnes,168700,2000,84.35,1275.6,132.251489,impossible_yield,True
 iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",1934,,tonnes,124500,1000,124.5,1275.6,97.601129,impossible_yield,True
@@ -252,69 +252,73 @@ iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",1940,,tonnes,165100,2000,82
 iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",1941,,tonnes,240000,3000,80,1275.6,188.146754,impossible_yield,True
 iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",1942,,tonnes,249000,3000,83,1275.6,195.202258,impossible_yield,True
 iia,viet nam,VNM-1887-1954,"tobacco, unmanufactured",1943,,tonnes,250000,3000,83.333333,1275.6,195.986203,impossible_yield,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",,1934-1938,tonnes,73800,2000,36.9,537.7,137.251255,impossible_yield,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1934,,tonnes,70600,1000,70.6,537.7,131.299981,impossible_yield,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1935,,tonnes,57800,1000,57.8,537.7,107.494886,impossible_yield,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1936,,tonnes,57200,1000,57.2,537.7,106.379022,impossible_yield,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1937,,tonnes,93700,2000,46.85,537.7,174.26074,impossible_yield,True
-iia,zimbabwe,ZWE-1900-1953,"tobacco, unmanufactured",,1934-1938,tonnes,1050600,19000,55.294737,,,impossible_yield,True
-iia,zimbabwe,ZWE-1900-1953,"tobacco, unmanufactured",1945,,tonnes,2141800,35000,61.194286,,,impossible_yield,True
-iia,american samoa,ASM-1900-2025,"tobacco, unmanufactured",1934,,tonnes,2000,0,,45.9,43.572985,impossible_yield_zero_area,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",,1934-1938,tonnes,73800,2000,36.9,574.5,128.45953,impossible_yield,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1934,,tonnes,70600,1000,70.6,574.5,122.889469,impossible_yield,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1935,,tonnes,57800,1000,57.8,574.5,100.609225,impossible_yield,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1936,,tonnes,57200,1000,57.2,574.5,99.564839,impossible_yield,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1937,,tonnes,93700,2000,46.85,574.5,163.098346,impossible_yield,True
+iia,zimbabwe,ZWE-1900-1953,"tobacco, unmanufactured",,1934-1938,tonnes,1050600,19000,55.294737,5692.9,184.545662,impossible_yield,True
+iia,zimbabwe,ZWE-1900-1953,"tobacco, unmanufactured",1945,,tonnes,2141800,35000,61.194286,5692.9,376.223015,impossible_yield,True
+iia,american samoa,ASM-1900-2025,"tobacco, unmanufactured",1934,,tonnes,2000,0,,46.8,42.735043,impossible_yield_zero_area,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1934,,tonnes,4000,0,,33.75,118.518519,impossible_yield_zero_area,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1935,,tonnes,4000,0,,33.75,118.518519,impossible_yield_zero_area,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1936,,tonnes,4000,0,,33.75,118.518519,impossible_yield_zero_area,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1937,,tonnes,4000,0,,33.75,118.518519,impossible_yield_zero_area,True
-iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1934,,tonnes,52500,0,,602.05,87.20206,impossible_yield_zero_area,True
-iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1935,,tonnes,52500,0,,602.05,87.20206,impossible_yield_zero_area,True
-iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1936,,tonnes,23000,0,,602.05,38.202807,impossible_yield_zero_area,True
-iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1935,,tonnes,4400,0,,,,impossible_yield_zero_area,True
-iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1936,,tonnes,10000,0,,,,impossible_yield_zero_area,True
-iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1937,,tonnes,7000,0,,,,impossible_yield_zero_area,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1936,,tonnes,13700,0,,27,507.407407,impossible_yield_zero_area,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1937,,tonnes,3400,0,,27,125.925926,impossible_yield_zero_area,True
+iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1934,,tonnes,52500,0,,604.7,86.819911,impossible_yield_zero_area,True
+iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1935,,tonnes,52500,0,,604.7,86.819911,impossible_yield_zero_area,True
+iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",1936,,tonnes,23000,0,,604.7,38.035389,impossible_yield_zero_area,True
+iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1935,,tonnes,4400,0,,7700,0.571429,impossible_yield_zero_area,True
+iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1936,,tonnes,10000,0,,7700,1.298701,impossible_yield_zero_area,True
+iia,cameroon,FCM-1920-1960,"tobacco, unmanufactured",1937,,tonnes,7000,0,,7700,0.909091,impossible_yield_zero_area,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1936,,tonnes,13700,0,,41.45,330.518697,impossible_yield_zero_area,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1937,,tonnes,3400,0,,41.45,82.026538,impossible_yield_zero_area,True
 iia,eritrea,ERI-1889-1952,"tobacco, unmanufactured",1934,,tonnes,3500,0,,27.5,127.272727,impossible_yield_zero_area,True
 iia,eritrea,ERI-1889-1952,"tobacco, unmanufactured",1935,,tonnes,2500,0,,27.5,90.909091,impossible_yield_zero_area,True
 iia,eritrea,ERI-1889-1952,"tobacco, unmanufactured",1936,,tonnes,2700,0,,27.5,98.181818,impossible_yield_zero_area,True
 iia,eritrea,ERI-1889-1952,"tobacco, unmanufactured",1937,,tonnes,2100,0,,27.5,76.363636,impossible_yield_zero_area,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1934,,tonnes,11900,0,,223.7,53.196245,impossible_yield_zero_area,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1935,,tonnes,12800,0,,223.7,57.21949,impossible_yield_zero_area,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1936,,tonnes,9100,0,,223.7,40.679481,impossible_yield_zero_area,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1937,,tonnes,10600,0,,223.7,47.38489,impossible_yield_zero_area,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1934,,tonnes,11900,0,,333.5,35.682159,impossible_yield_zero_area,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1935,,tonnes,12800,0,,333.5,38.38081,impossible_yield_zero_area,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1936,,tonnes,9100,0,,333.5,27.286357,impossible_yield_zero_area,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1937,,tonnes,10600,0,,333.5,31.784108,impossible_yield_zero_area,True
 iia,french polynesia,PYF-1800-2025,"tobacco, unmanufactured",1934,,tonnes,300,0,,22,13.636364,impossible_yield_zero_area,True
 iia,french polynesia,PYF-1800-2025,"tobacco, unmanufactured",1935,,tonnes,300,0,,22,13.636364,impossible_yield_zero_area,True
 iia,french polynesia,PYF-1800-2025,"tobacco, unmanufactured",1936,,tonnes,300,0,,22,13.636364,impossible_yield_zero_area,True
 iia,french polynesia,PYF-1800-2025,"tobacco, unmanufactured",1937,,tonnes,300,0,,22,13.636364,impossible_yield_zero_area,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1937,,tonnes,9700,0,,13,746.153846,impossible_yield_zero_area,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1937,,tonnes,9700,0,,18.45,525.745257,impossible_yield_zero_area,True
 iia,libya,LBY-1934-1943,"tobacco, unmanufactured",1935,,tonnes,69600,0,,415.5,167.509025,impossible_yield_zero_area,True
 iia,libya,LBY-1934-1943,"tobacco, unmanufactured",1936,,tonnes,68400,0,,415.5,164.620939,impossible_yield_zero_area,True
 iia,libya,LBY-1934-1943,"tobacco, unmanufactured",1937,,tonnes,85000,0,,415.5,204.572804,impossible_yield_zero_area,True
-iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1934,,tonnes,12600,0,,564.45,22.322615,impossible_yield_zero_area,True
-iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1935,,tonnes,13500,0,,564.45,23.917087,impossible_yield_zero_area,True
-iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1936,,tonnes,14300,0,,564.45,25.334396,impossible_yield_zero_area,True
-iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1937,,tonnes,21100,0,,564.45,37.381522,impossible_yield_zero_area,True
+iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1934,,tonnes,12600,0,,580.9,21.69048,impossible_yield_zero_area,True
+iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1935,,tonnes,13500,0,,580.9,23.2398,impossible_yield_zero_area,True
+iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1936,,tonnes,14300,0,,580.9,24.616974,impossible_yield_zero_area,True
+iia,malaysia,BNB-1881-1963,"tobacco, unmanufactured",1937,,tonnes,21100,0,,580.9,36.322947,impossible_yield_zero_area,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1934,,tonnes,500,0,,4,125,impossible_yield_zero_area,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1935,,tonnes,700,0,,4,175,impossible_yield_zero_area,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1937,,tonnes,200,0,,4,50,impossible_yield_zero_area,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1934,,tonnes,27600,0,,12.3,2243.902439,impossible_yield_zero_area,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1935,,tonnes,32000,0,,12.3,2601.626016,impossible_yield_zero_area,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1936,,tonnes,47800,0,,12.3,3886.178862,impossible_yield_zero_area,True
-iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1934,,tonnes,1000,0,,1300,0.769231,impossible_yield_zero_area,True
-iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1935,,tonnes,1100,0,,1300,0.846154,impossible_yield_zero_area,True
-iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1936,,tonnes,400,0,,1300,0.307692,impossible_yield_zero_area,True
-iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1937,,tonnes,200,0,,1300,0.153846,impossible_yield_zero_area,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1934,,tonnes,27600,0,,17.7,1559.322034,impossible_yield_zero_area,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1935,,tonnes,32000,0,,17.7,1807.909605,impossible_yield_zero_area,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1936,,tonnes,47800,0,,17.7,2700.564972,impossible_yield_zero_area,True
+iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1934,,tonnes,1000,0,,1350,0.740741,impossible_yield_zero_area,True
+iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1935,,tonnes,1100,0,,1350,0.814815,impossible_yield_zero_area,True
+iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1936,,tonnes,400,0,,1350,0.296296,impossible_yield_zero_area,True
+iia,micronesia (federated states of),CAR-1920-1945,"tobacco, unmanufactured",1937,,tonnes,200,0,,1350,0.148148,impossible_yield_zero_area,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1934,,tonnes,32100,0,,201.35,159.423889,impossible_yield_zero_area,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1935,,tonnes,17600,0,,201.35,87.409983,impossible_yield_zero_area,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1936,,tonnes,47400,0,,201.35,235.410976,impossible_yield_zero_area,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",1937,,tonnes,41700,0,,201.35,207.102061,impossible_yield_zero_area,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1935,,tonnes,59500,0,,285,208.77193,impossible_yield_zero_area,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1936,,tonnes,71700,0,,285,251.578947,impossible_yield_zero_area,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1937,,tonnes,55900,0,,285,196.140351,impossible_yield_zero_area,True
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1939,,tonnes,5800,,,630,9.206349,no_area_level_consistent,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1940,,tonnes,2900,,,630,4.603175,no_area_level_consistent,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1942,,tonnes,2800,,,630,4.444444,no_area_level_consistent,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1943,,tonnes,3100,,,630,4.920635,no_area_level_consistent,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1944,,tonnes,2100,,,630,3.333333,no_area_level_consistent,False
-iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1945,,tonnes,7700,,,630,12.222222,no_area_level_consistent,False
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1935,,tonnes,59500,0,,294.7,201.900238,impossible_yield_zero_area,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1936,,tonnes,71700,0,,294.7,243.298269,impossible_yield_zero_area,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1937,,tonnes,55900,0,,294.7,189.684425,impossible_yield_zero_area,True
+iia,austria,AUT-1919-2025,hops,,1934-1938,tonnes,4900,,,327.5,14.961832,no_area_level_consistent,False
+iia,ecuador,ECU-1800-1942,"tobacco, unmanufactured",,1934-1938,tonnes,69000,,,12751.05,5.411319,no_area_level_consistent,False
+iia,germany,DEU-1945-1949,"tobacco, unmanufactured",1945,,tonnes,0,,,25833.9,0,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1939,,tonnes,5800,,,654,8.868502,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1940,,tonnes,2900,,,654,4.434251,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1942,,tonnes,2800,,,654,4.281346,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1943,,tonnes,3100,,,654,4.740061,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1944,,tonnes,2100,,,654,3.211009,no_area_level_consistent,False
+iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1945,,tonnes,7700,,,654,11.7737,no_area_level_consistent,False
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1936,,tonnes,500,,,18.45,27.100271,no_area_level_consistent,False
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1939,,tonnes,100,,,4,25,no_area_level_consistent,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1934,,tonnes,20000,,,20000,1,no_area_level_consistent,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1935,,tonnes,20000,,,20000,1,no_area_level_consistent,False
@@ -326,6 +330,7 @@ iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1942,,tonnes,19600,,,20000,0
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1943,,tonnes,18400,,,20000,0.92,no_area_level_consistent,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1944,,tonnes,16900,,,20000,0.845,no_area_level_consistent,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1945,,tonnes,22300,,,20000,1.115,no_area_level_consistent,False
+iia,romania,ROU-1920-1940,hops,,1934-1938,tonnes,1900,,,1770.3,1.073264,no_area_level_consistent,False
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1943,,tonnes,271300,,,1903.2,142.549391,no_area_level_shift,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1944,,tonnes,256500,,,1903.2,134.773014,no_area_level_shift,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1945,,tonnes,267800,,,1903.2,140.710383,no_area_level_shift,True
@@ -333,27 +338,27 @@ iia,benin,BEN-1898-1960,"tobacco, unmanufactured",,1934-1938,tonnes,5200,,,33.75
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1939,,tonnes,6900,,,33.75,204.444444,no_area_level_shift,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1940,,tonnes,6600,,,33.75,195.555556,no_area_level_shift,True
 iia,benin,BEN-1898-1960,"tobacco, unmanufactured",1941,,tonnes,7300,,,33.75,216.296296,no_area_level_shift,True
-iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",,1934-1938,tonnes,34800,,,602.05,57.802508,no_area_level_shift,True
-iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1936,,tonnes,222400,,,861.7,258.094464,no_area_level_shift,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1935,,tonnes,26800,,,27,992.592593,no_area_level_shift,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1938,,tonnes,1600,,,27,59.259259,no_area_level_shift,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1939,,tonnes,5200,,,27,192.592593,no_area_level_shift,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1940,,tonnes,16500,,,27,611.111111,no_area_level_shift,True
-iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1942,,tonnes,46500,,,27,1722.222222,no_area_level_shift,True
-iia,czech republic,F51-1945-1947,"tobacco, unmanufactured",1945,,tonnes,250000,,,6323.05,39.537881,no_area_level_shift,True
+iia,burundi,RWB-1922-1962,"tobacco, unmanufactured",,1934-1938,tonnes,34800,,,604.7,57.549198,no_area_level_shift,True
+iia,"china, taiwan province of",TWN-1895-1945,"tobacco, unmanufactured",1936,,tonnes,222400,,,940.4,236.495108,no_area_level_shift,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1935,,tonnes,26800,,,41.45,646.562123,no_area_level_shift,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1938,,tonnes,1600,,,41.45,38.600724,no_area_level_shift,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1939,,tonnes,5200,,,41.45,125.452352,no_area_level_shift,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1940,,tonnes,16500,,,41.45,398.069964,no_area_level_shift,True
+iia,cyprus,CYP-1879-2025,"tobacco, unmanufactured",1942,,tonnes,46500,,,41.45,1121.833534,no_area_level_shift,True
+iia,czech republic,F51-1945-1947,"tobacco, unmanufactured",1945,,tonnes,250000,,,7144.5,34.991952,no_area_level_shift,True
+iia,dominican republic,DOM-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,696394900,,,16102.4,43247.894724,no_area_level_shift,True
 iia,eritrea,ERI-1889-1952,"tobacco, unmanufactured",,1934-1938,tonnes,2600,,,27.5,94.545455,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1939,,tonnes,19200,,,223.7,85.829236,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1940,,tonnes,15600,,,223.7,69.736254,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1941,,tonnes,13200,,,223.7,59.007599,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1942,,tonnes,26300,,,223.7,117.568172,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1943,,tonnes,16000,,,223.7,71.524363,no_area_level_shift,True
-iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1944,,tonnes,15600,,,223.7,69.736254,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",,1934-1938,tonnes,4000,,,13,307.692308,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1934,,tonnes,1400,,,13,107.692308,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1935,,tonnes,4100,,,13,315.384615,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1936,,tonnes,500,,,13,38.461538,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1938,,tonnes,4300,,,13,330.769231,no_area_level_shift,True
-iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1939,,tonnes,3600,,,13,276.923077,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1939,,tonnes,19200,,,333.5,57.571214,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1940,,tonnes,15600,,,333.5,46.776612,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1941,,tonnes,13200,,,333.5,39.58021,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1942,,tonnes,26300,,,333.5,78.86057,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1943,,tonnes,16000,,,333.5,47.976012,no_area_level_shift,True
+iia,eswatini,SWZ-1894-2025,"tobacco, unmanufactured",1944,,tonnes,15600,,,333.5,46.776612,no_area_level_shift,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",,1934-1938,tonnes,4000,,,18.45,216.802168,no_area_level_shift,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1934,,tonnes,1400,,,18.45,75.880759,no_area_level_shift,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1935,,tonnes,4100,,,18.45,222.222222,no_area_level_shift,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1938,,tonnes,4300,,,18.45,233.062331,no_area_level_shift,True
+iia,jordan,JOR-1923-1946,"tobacco, unmanufactured",1939,,tonnes,3600,,,18.45,195.121951,no_area_level_shift,True
 iia,libya,LBY-1934-1943,"tobacco, unmanufactured",,1934-1938,tonnes,75000,,,415.5,180.505415,no_area_level_shift,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",,1934-1938,tonnes,1600,,,4,400,no_area_level_shift,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1936,,tonnes,6500,,,4,1625,no_area_level_shift,True
@@ -361,63 +366,59 @@ iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1940,,tonnes,200,,,4,50,n
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1941,,tonnes,300,,,4,75,no_area_level_shift,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1942,,tonnes,200,,,4,50,no_area_level_shift,True
 iia,mauritania,MRT-1920-1960,"tobacco, unmanufactured",1943,,tonnes,400,,,4,100,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,30200,,,12.3,2455.284553,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1939,,tonnes,26900,,,12.3,2186.99187,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1940,,tonnes,36300,,,12.3,2951.219512,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1941,,tonnes,36000,,,12.3,2926.829268,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1942,,tonnes,39900,,,12.3,3243.902439,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1943,,tonnes,32000,,,12.3,2601.626016,no_area_level_shift,True
-iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1944,,tonnes,28700,,,12.3,2333.333333,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,30200,,,17.7,1706.214689,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1939,,tonnes,26900,,,17.7,1519.774011,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1940,,tonnes,36300,,,17.7,2050.847458,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1941,,tonnes,36000,,,17.7,2033.898305,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1942,,tonnes,39900,,,17.7,2254.237288,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1943,,tonnes,32000,,,17.7,1807.909605,no_area_level_shift,True
+iia,mauritius,MUS-1800-2025,"tobacco, unmanufactured",1944,,tonnes,28700,,,17.7,1621.468927,no_area_level_shift,True
 iia,morocco,MAR-1911-1958,"tobacco, unmanufactured",,1934-1938,tonnes,34700,,,201.35,172.336727,no_area_level_shift,True
 iia,namibia,NAM-1920-1990,"tobacco, unmanufactured",1934,,tonnes,3100,,,12.9,240.310078,no_area_level_shift,True
 iia,namibia,NAM-1920-1990,"tobacco, unmanufactured",1935,,tonnes,2100,,,12.9,162.790698,no_area_level_shift,True
 iia,namibia,NAM-1920-1990,"tobacco, unmanufactured",1936,,tonnes,7300,,,12.9,565.891473,no_area_level_shift,True
 iia,namibia,NAM-1920-1990,"tobacco, unmanufactured",1937,,tonnes,18100,,,12.9,1403.100775,no_area_level_shift,True
 iia,namibia,NAM-1920-1990,"tobacco, unmanufactured",1938,,tonnes,4300,,,12.9,333.333333,no_area_level_shift,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1936,,tonnes,65000,,,169.5,383.480826,no_area_level_shift,True
-iia,niger,NER-1922-1947,"tobacco, unmanufactured",1945,,tonnes,50000,,,169.5,294.985251,no_area_level_shift,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1936,,tonnes,65000,,,170.35,381.567361,no_area_level_shift,True
+iia,niger,NER-1922-1947,"tobacco, unmanufactured",1945,,tonnes,50000,,,170.35,293.513355,no_area_level_shift,True
 iia,peru,PER-1922-1942,"tobacco, unmanufactured",,1934-1938,tonnes,92500,,,2900,31.896552,no_area_level_shift,True
+iia,sweden,SWE-1905-2025,"tobacco, unmanufactured",,1934-1938,tonnes,50300,,,751,66.977364,no_area_level_shift,True
 iia,syrian arab republic,SYR-1922-1946,"tobacco, unmanufactured",1940,,tonnes,553500,,,2835.5,195.203668,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",,1934-1938,tonnes,58100,,,285,203.859649,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1939,,tonnes,53600,,,285,188.070175,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1940,,tonnes,53200,,,285,186.666667,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1941,,tonnes,56900,,,285,199.649123,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1942,,tonnes,38100,,,285,133.684211,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1943,,tonnes,49700,,,285,174.385965,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1944,,tonnes,40900,,,285,143.508772,no_area_level_shift,True
-iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1945,,tonnes,25900,,,285,90.877193,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1939,,tonnes,100900,,,537.7,187.651107,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1940,,tonnes,104300,,,537.7,193.974335,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1941,,tonnes,122500,,,537.7,227.822206,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1942,,tonnes,98400,,,537.7,183.001674,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1943,,tonnes,107900,,,537.7,200.669518,no_area_level_shift,True
-iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1944,,tonnes,131500,,,537.7,244.560164,no_area_level_shift,True
-iia,el salvador,SLV-1821-2025,"tobacco, unmanufactured",,1934-1938,tonnes,21000,63000,0.333333,,,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",,1934-1938,tonnes,3000,2000,1.5,209.5,14.319809,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1934,,tonnes,4000,2000,2,209.5,19.093079,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1935,,tonnes,4000,2000,2,209.5,19.093079,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1939,,tonnes,1500,2000,0.75,209.5,7.159905,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1940,,tonnes,1500,2000,0.75,209.5,7.159905,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1941,,tonnes,3000,2000,1.5,209.5,14.319809,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1942,,tonnes,3000,2000,1.5,209.5,14.319809,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1943,,tonnes,3000,2000,1.5,209.5,14.319809,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1944,,tonnes,4500,4000,1.125,209.5,21.479714,plausible_yield,False
-iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1945,,tonnes,6000,6000,1,209.5,28.639618,plausible_yield,False
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",,1934-1938,tonnes,58100,,,294.7,197.149644,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1939,,tonnes,53600,,,294.7,181.879878,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1940,,tonnes,53200,,,294.7,180.522565,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1941,,tonnes,56900,,,294.7,193.077706,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1942,,tonnes,38100,,,294.7,129.284018,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1943,,tonnes,49700,,,294.7,168.646081,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1944,,tonnes,40900,,,294.7,138.785205,no_area_level_shift,True
+iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1945,,tonnes,25900,,,294.7,87.885986,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1939,,tonnes,100900,,,574.5,175.630983,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1940,,tonnes,104300,,,574.5,181.549173,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1941,,tonnes,122500,,,574.5,213.228895,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1942,,tonnes,98400,,,574.5,171.279373,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1943,,tonnes,107900,,,574.5,187.815492,no_area_level_shift,True
+iia,zambia,NRH-1911-1953,"tobacco, unmanufactured",1944,,tonnes,131500,,,574.5,228.894691,no_area_level_shift,True
+iia,el salvador,SLV-1821-2025,"tobacco, unmanufactured",,1934-1938,tonnes,21000,63000,0.333333,190,110.526316,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",,1934-1938,tonnes,3000,2000,1.5,334,8.982036,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1934,,tonnes,4000,2000,2,334,11.976048,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1935,,tonnes,4000,2000,2,334,11.976048,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1939,,tonnes,1500,2000,0.75,334,4.491018,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1940,,tonnes,1500,2000,0.75,334,4.491018,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1941,,tonnes,3000,2000,1.5,334,8.982036,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1942,,tonnes,3000,2000,1.5,334,8.982036,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1943,,tonnes,3000,2000,1.5,334,8.982036,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1944,,tonnes,4500,4000,1.125,334,13.473054,plausible_yield,False
+iia,ivory coast,CIV-1932-1947,"tobacco, unmanufactured",1945,,tonnes,6000,6000,1,334,17.964072,plausible_yield,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",,1934-1938,tonnes,19700,108000,0.182407,20000,0.985,plausible_yield,False
-iia,austria,AUT-1919-2025,hops,,1934-1938,tonnes,4900,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",,1934-1938,tonnes,900,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",1939,,tonnes,900,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",1940,,tonnes,800,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",1941,,tonnes,500,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",1943,,tonnes,27200,,,,,untestable,False
 iia,cabo verde,CPV-1886-1975,"tobacco, unmanufactured",1944,,tonnes,5500,,,,,untestable,False
-iia,dominican republic,DOM-1800-2025,"tobacco, unmanufactured",,1934-1938,tonnes,696394900,,,,,untestable,False
-iia,ecuador,ECU-1800-1942,"tobacco, unmanufactured",,1934-1938,tonnes,69000,,,,,untestable,False
-iia,germany,DEU-1945-1949,"tobacco, unmanufactured",1945,,tonnes,0,,,,,untestable,False
 iia,ireland,IRL-1921-2025,"tobacco, unmanufactured",,1934-1938,tonnes,18500,,,,,untestable,False
 iia,lebanon,LBN-1944-2025,"tobacco, unmanufactured",1945,,tonnes,121400,,,,,untestable,False
 iia,netherlands,NLD-1830-2025,"tobacco, unmanufactured",1945,,tonnes,0,,,,,untestable,False
-iia,romania,ROU-1920-1940,hops,,1934-1938,tonnes,1900,,,,,untestable,False
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",,1934-1938,tonnes,1000,,,,,untestable,False
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1939,,tonnes,2200,,,,,untestable,False
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1940,,tonnes,1200,,,,,untestable,False
@@ -425,4 +426,3 @@ iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1941,,tonnes,1800,,,,,untes
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1943,,tonnes,400,,,,,untestable,False
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1944,,tonnes,900,,,,,untestable,False
 iia,suriname,SUR-1886-1954,"tobacco, unmanufactured",1945,,tonnes,300,,,,,untestable,False
-iia,sweden,SWE-1905-2025,"tobacco, unmanufactured",,1934-1938,tonnes,50300,,,,,untestable,False


### PR DESCRIPTION
Follow-up to #465, same exclusion one block earlier in the same file.

`prod.year <= ERA_FROM - 1` is False for NaN, so a label whose only pre-1934 production is a **period
average** had no baseline at all, and its era rows fell to `untestable` — the class this screen can act on
least. Measured: **50 (label, item) pairs have only a period baseline**, no dated pre-1934 production
whatsoever.

```
untestable                 22 -> 16    exactly the 6 rows predicted before the change
no_area_level_consistent   17 -> 22    5 of the 6 are FINE
no_area_level_shift        66 -> 67    1 is convicted
convicted                 348 -> 349   (82%)
```

### The result is mostly negative, which is why it was worth doing

**Five of the six newly testable rows turn out not to be defects.** `untestable` reads as "we could not
say", and for these the answer was available and it is "no". A screen that leaves rows unclassified when it
could classify them overstates its own uncertainty, and the class it dumps them in is the one nobody can act
on.

A five-year mean is a legitimate level baseline — arguably better than a single year, being smoother. What it
cannot do is *date* a defect, and the baseline is not asked to.

### Third instance of one shape, and the class is now bounded

- **#464** — my #456 diff measured raw years while the pipeline reasons over period spans
- **#465** — the era's *scope* excluded 99 period rows
- **this** — the era's *baseline* excluded 50 labels' only pre-era data

I swept every `year` comparison in the pipeline and gates. The only other two sites are convention re-test
windows in `11_retest_conventions.py`, and both are **measured immaterial**: `check_iia_russia`'s medians move
from 2,033,000 → 1,990,500 ha (cotton lint) and 24,026,000 → 24,656,448 (rye) against thresholds of 1M and
15M, so its conclusion is unaffected; `check_iia_juan_germany` has zero period rows in its window. Full
working in a comment on #465.

74 gates pass; the zero-area selftest case still bites; the table is current under `--check`.