### PR TITLE
smaller_label named the LARGER label in all six rows, and the column beside it stayed correct (#468)

### DIFF
--- a/pipelines/polity-autoimprove/31_cross_label_duplication.py
+++ b/pipelines/polity-autoimprove/31_cross_label_duplication.py
@@ -120,10 +120,18 @@ def build(matched: str) -> list[dict]:
                 continue                                   # effectively one series outside too
             # DIRECTION: outside the block one label is consistently larger. The block's own level
             # tells which one it came from, and that side is the donor.
-            smaller = a if om > 1 else b                   # om = median(a/b) over differing years
-            larger = b if om > 1 else a
-            lvl_s = float(x[both][~eq].median() if smaller == a else y[both][~eq].median())
-            lvl_l = float(y[both][~eq].median() if smaller == a else x[both][~eq].median())
+            # om = median(a/b) over the DIFFERING years, so om < 1 means a is the smaller series.
+            # The first version had this backwards -- `a if om > 1 else b` -- and shipped a
+            # `smaller_label` column that named the LARGER label in all six rows. It went unnoticed
+            # because `block_matches_level_of` stayed correct: the names and the levels were swapped
+            # together and the double swap cancelled, so the one column anybody would sanity-check
+            # read right while the other was wrong. Gate arm E now ties this column to
+            # `outside_ratio_median` so an inversion cannot pass again.
+            smaller = a if om < 1 else b
+            larger = b if om < 1 else a
+            lvl_a = float(x[both][~eq].median())
+            lvl_b = float(y[both][~eq].median())
+            lvl_s, lvl_l = (lvl_a, lvl_b) if smaller == a else (lvl_b, lvl_a)
             bl = float(block.median())
             # A LEVEL COMPARISON NEEDS THE BLOCK TO HAVE A LEVEL. The first version of this column
             # answered "serbia" for the iia czech/serbia case -- the one instance whose direction is

--- a/pipelines/polity-autoimprove/state/cross_label_duplication.csv
+++ b/pipelines/polity-autoimprove/state/cross_label_duplication.csv
@@ -1,7 +1,7 @@
 source,item,unit,label_a,label_b,shared_years,block_years,block_first,block_last,block_distinct,outside_ratio_median,block_spread,smaller_label,block_matches_level_of
-juan,potatoes,ha,luxembourg,malta,49,8,1914,1921,7,4.5,1.2417,luxembourg,luxembourg
-juan,flax fibre and tow,ha,czechoslovakia,sweden,35,7,1939,1945,7,10.85,2.4737,czechoslovakia,czechoslovakia
-juan,hempseed,ha,argentina,chile,11,7,1940,1946,4,0.0067,4,chile,chile
-juan,linseed,ha,czechoslovakia,sweden,35,7,1939,1945,7,10.85,2.4737,czechoslovakia,czechoslovakia
-iia,rye,ha,czech republic,serbia,22,4,1941,1944,4,4.2402,35.1923,czech republic,
-juan,barley,tonnes,finland,france,83,4,1942,1945,4,0.1168,1.2121,france,france
+juan,potatoes,ha,luxembourg,malta,49,8,1914,1921,7,4.5,1.2417,malta,luxembourg
+juan,flax fibre and tow,ha,czechoslovakia,sweden,35,7,1939,1945,7,10.85,2.4737,sweden,czechoslovakia
+juan,hempseed,ha,argentina,chile,11,7,1940,1946,4,0.0067,4,argentina,chile
+juan,linseed,ha,czechoslovakia,sweden,35,7,1939,1945,7,10.85,2.4737,sweden,czechoslovakia
+iia,rye,ha,czech republic,serbia,22,4,1941,1944,4,4.2402,35.1923,serbia,
+juan,barley,tonnes,finland,france,83,4,1942,1945,4,0.1168,1.2121,finland,france

--- a/scripts/validate_cross_label_duplication.py
+++ b/scripts/validate_cross_label_duplication.py
@@ -99,6 +99,21 @@ def main() -> int:
                 problems.append(f"D {w}: block_spread {spread!r} is not numeric")
         if (r["smaller_label"] or "").strip() not in (r["label_a"], r["label_b"]):
             problems.append(f"D {w}: smaller_label {r['smaller_label']!r} names neither label")
+        # --- E: smaller_label must AGREE with the ratio it is derived from ---
+        # `outside_ratio_median` is median(label_a / label_b) over the differing years, so a value
+        # below 1 means label_a is the smaller series. The generator's first version wrote
+        # `a if om > 1 else b` and shipped this column naming the LARGER label in all six rows. It
+        # survived review because `block_matches_level_of` stayed correct -- names and levels were
+        # swapped together, so the double swap cancelled and the column anyone would sanity-check read
+        # right while this one was wrong. Checking a derived column against its own input is the only
+        # thing that catches that.
+        want_smaller = r["label_a"] if om < 1 else r["label_b"]
+        if (r["smaller_label"] or "").strip() != want_smaller:
+            problems.append(
+                f"E {w}: smaller_label is {r['smaller_label']!r} but outside_ratio_median {om} says "
+                f"{want_smaller!r} is the smaller series (the ratio is a/b, so below 1 means a). An "
+                f"inverted direction column reads as authoritative and points remediation at the "
+                f"wrong label")
 
     by_src = {}
     for r in rows:


### PR DESCRIPTION
`outside_ratio_median` is `median(label_a / label_b)` over the differing years, so a value **below 1** means
`label_a` is the smaller series. The generator wrote `smaller = a if om > 1 else b` — backwards — and the
column shipped in #469 naming the **larger** label in every one of its six rows.

### Why it survived review, which is the part worth recording

`block_matches_level_of` was derived from the same swapped variables, so the names and the levels were
inverted **together** and the double swap cancelled. That column is correct in all five attributable rows,
both before and after this fix. So the one column a reader would sanity-check read right while the one beside
it was wrong.

I found it by re-reading the committed table against the ratio it is derived from — not by inspecting the
code, and not by any gate, because **every existing arm was satisfied**. `smaller_label` named a real label,
the floor held, contiguity held, the outside ratio held.

### Corrected, and the table now says what #468 claimed

```
potatoes      smaller = malta       block matches luxembourg's level
flax/linseed  smaller = sweden      block matches czechoslovakia's level
hempseed      smaller = argentina   block matches chile's level
barley        smaller = finland     block matches france's level
rye           smaller = serbia      direction withheld (block swings 35x)
```

The smaller reporter carries the larger's values, in all five cases where direction is attributable — which
is the generalisation #468 stated in prose and the table now states correctly.

### The gate arm this needed

Arm E checks `smaller_label` against `outside_ratio_median`, the input it is derived from. That is the only
check that could have caught this: an inversion is invisible unless a derived column is tested against its
own source. Verified by re-inverting one row — arm E fires and names both the recorded and the correct label.

75 gates pass; the cross-label selftest case still bites.