### PR TITLE
The last eight --write tools now have --check: all 17 covered, and the precondition was checked first (#472)

### DIFF
--- a/pipelines/polity-autoimprove/16_source_splices.py
+++ b/pipelines/polity-autoimprove/16_source_splices.py
@@ -101,6 +101,13 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -124,9 +131,23 @@ def main() -> int:
               f"{r['year_before']}->{r['year_after']} {r['source_before']:9}->{r['source_after']:9} "
               f"x{float(r['ratio']):.2f}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["country", "item", "unit", "year_before", "year_after", "source_before",
                 "source_after", "value_before", "value_after", "ratio"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/17_constant_runs.py
+++ b/pipelines/polity-autoimprove/17_constant_runs.py
@@ -144,6 +144,13 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -167,9 +174,23 @@ def main() -> int:
               f"{r['year_first']}-{r['year_last']}  grid {float(r['grid']):>7,.0f}  "
               f"elsewhere {float(r['finest_elsewhere']):>12,.1f}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["source", "country", "item", "unit", "constant", "n_values", "year_first",
                 "year_last", "series_n", "grid", "finest_elsewhere", "n_finer_elsewhere"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/18_isolated_spikes.py
+++ b/pipelines/polity-autoimprove/18_isolated_spikes.py
@@ -123,6 +123,13 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -145,9 +152,23 @@ def main() -> int:
               f"{float(r['value']):>15,.0f}  {r['year_prev']}:{float(r['value_prev']):,.0f} "
               f"{r['year_next']}:{float(r['value_next']):,.0f}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["source", "country", "item", "unit", "indicator", "year", "value", "year_prev",
                 "value_prev", "year_next", "value_next", "factor_vs_larger_neighbour"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/19_composition_overlaps.py
+++ b/pipelines/polity-autoimprove/19_composition_overlaps.py
@@ -115,6 +115,13 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -184,10 +191,24 @@ def main() -> int:
               f"{str(r['shared_cells']):>6} {str(r['shared_item_units']):>6}  "
               f"{r['whole_method']} / {r['part_method']}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["whole_code", "part_code", "source", "year_first", "year_last", "whole_labels",
                 "part_labels", "whole_method", "part_method", "shared_item_units", "shared_cells",
                 "alias_visible"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/20_item_provenance.py
+++ b/pipelines/polity-autoimprove/20_item_provenance.py
@@ -270,6 +270,13 @@ def main() -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
     ap.add_argument("--raw", default=DEFAULT_RAW)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -296,9 +303,23 @@ def main() -> int:
         for c, items in sorted(per.items(), key=lambda t: -len(t[1])):
             print(f"      {c[:42]:44} <- {'; '.join(sorted(items))[:90]}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["layer_b_label", "item", "unit", "n_values", "n_distinct", "raw_label",
                 "raw_product", "product_agrees", "share", "status", "runner_up", "label_is_mixed"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/21_item_product_switches.py
+++ b/pipelines/polity-autoimprove/21_item_product_switches.py
@@ -163,6 +163,13 @@ def main() -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
     ap.add_argument("--raw", default=DEFAULT_RAW)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -180,9 +187,23 @@ def main() -> int:
               f"{r['item'][:20]:22} {r['unit'][:5]:6} {r['n_cells']:>5} {r['n_products']:>4}  "
               f"{r['worst_switch'][:64]}")
 
-    if args.write:
+    if args.write or args.check:
         cols = ["layer_b_label", "item", "unit", "n_cells", "n_traced", "n_ambiguous",
                 "n_products", "products", "worst_switch_ratio", "worst_switch"]
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in cols} for r in have] != \
+                    [{k: r.get(k, "") for k in cols} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/22_item_equivalences.py
+++ b/pipelines/polity-autoimprove/22_item_equivalences.py
@@ -99,6 +99,13 @@ def main() -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
     ap.add_argument("--raw", default=DEFAULT_RAW)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"merge into {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -156,7 +163,21 @@ def main() -> int:
             print(f"   {r['verdict']:12} {r['item'][:26]:28} <- {r['raw_product'][:30]:32} "
                   f"{r['cells']:>4} cells in {r['series']:>2} series")
 
-    if args.write:
+    if args.write or args.check:
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in COLS} for r in have] != \
+                    [{k: r.get(k, "") for k in COLS} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:

--- a/pipelines/polity-autoimprove/24_item_axis_aggregates.py
+++ b/pipelines/polity-autoimprove/24_item_axis_aggregates.py
@@ -112,6 +112,13 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--layer-b", default=DEFAULT_PANEL)
+    # Every tool from 25 up carries --check; these eight did not, so their tracked tables could drift
+    # undetected. That is not hypothetical: 04's --check caught territory_basis.csv drifting after a
+    # routing fix, and 23's absence let verdict_carryover.csv go stale (issues 308, 472). Safe here
+    # because all eight were verified to regenerate byte-identically with default arguments -- the
+    # precondition 15_label_provenance did NOT meet, where a check would have invited data loss.
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the tracked table is not what this run produces")
     ap.add_argument("--write", action="store_true", help=f"refresh {os.path.relpath(OUT, REPO)}")
     args = ap.parse_args()
 
@@ -134,7 +141,21 @@ def main() -> int:
               f"{float(r['largest']):>10,.0f} == {r['values'].split(';', 1)[1][:34]}")
     print(f"\n   by item: {dict(Counter(r['item'] for r in tot).most_common(8))}")
 
-    if args.write:
+    if args.write or args.check:
+        if args.check:
+            if not os.path.exists(OUT):
+                print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+                return 1
+            with open(OUT, newline="", encoding="utf-8") as fh:
+                have = list(csv.DictReader(fh))
+            want = [{k: ("" if v is None else str(v)) for k, v in dict(r).items()} for r in rows]
+            if [{k: r.get(k, "") for k in COLS} for r in have] != \
+                    [{k: r.get(k, "") for k in COLS} for r in want]:
+                print(f"STALE {os.path.relpath(OUT, REPO)}: committed {len(have)} row(s), this run "
+                      f"produces {len(want)}; rerun with --write", file=sys.stderr)
+                return 1
+            print(f"table is current ({len(have)} rows)")
+            return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
         with open(tmp, "w", newline="", encoding="utf-8") as fh:


### PR DESCRIPTION
Every tool from `25` up carries `--check`; `16`–`22` and `24` did not, so their tracked tables could drift
undetected. That is not hypothetical — `04`'s check caught `territory_basis.csv` drifting after a routing fix
(#464), and `23`'s absence let `verdict_carryover.csv` go stale (#471). **After this, all 17 `--write` tools
have one.**

### Safe because the precondition was checked first, not assumed

A staleness mode is only meaningful where regeneration is deterministic and complete.
`15_label_provenance.py` is the counter-example that made this obvious: its default run used to **destroy 61
of 302 recorded fingerprints**, so a `--check` would have reported STALE and invited someone to do exactly
that (#472, fixed in #473). I verified all eight tools here regenerate **byte-identical** tables with default
arguments before giving any of them a check.

That is why this is eight tools and not nine: the flag is the easy part, the precondition is the work.

### Verified they DETECT, not just report

Dropping the last row from four of the tables makes `--check` say STALE:

```
16_source_splices        DETECTED      20_item_provenance       DETECTED
17_constant_runs         DETECTED      24_item_axis_aggregates  DETECTED
```

A check that only ever prints "current" is worse than no check, because it converts an unexamined table into
an apparently examined one.

```
16_source_splices          373 rows      20_item_provenance        1918 rows
17_constant_runs           246 rows      21_item_product_switches     9 rows
18_isolated_spikes          21 rows      22_item_equivalences        96 rows
19_composition_overlaps     55 rows      24_item_axis_aggregates   1130 rows
```

### One implementation detail worth stating

The comparison is **column-projected**, not raw dict equality: a tracked CSV reads every field as a string
while a fresh run holds ints and floats, so comparing dicts directly would report STALE on every table
forever — a check that always fails is as useless as one that never does. Only the columns the writer
declares are compared, so an extra column in the file is not a false failure either.

75 gates and the full 97-case selftest pass; no tracked table changed by this PR.