### PR TITLE
Record the invocation that builds iia_label_provenance.csv, and make its --check complete (#472)

### DIFF
--- a/pipelines/polity-autoimprove/15_label_provenance.py
+++ b/pipelines/polity-autoimprove/15_label_provenance.py
@@ -60,6 +60,9 @@ from collections import defaultdict
 DEFAULT_RAW = os.path.expanduser(
     "~/3itkt6h41pb7jdan/2025-10-06_iia-dataframe/outputs/processed data/harmonized_data.xlsx"
 )
+# Floors for the two modes; see the note in main() for how MIN_ROWS_TABLE was recovered.
+MIN_ROWS_REPORT = 30    # ranked report: a fingerprint over <30 values is noise
+MIN_ROWS_TABLE = 1      # the tracked table: reproduces all 302 fingerprinted rows exactly
 DEFAULT_PROV = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "state/iia_label_provenance.csv")
 DEFAULT_ASSERT = os.path.join(
@@ -263,8 +266,12 @@ def main() -> int:
                          "its 1909-1917 values draw on `russia`, `russia in europe` AND "
                          "`russia in asia` -- the empire plus both halves -- while 1922-1940 is "
                          "cleanly 73% `ussr`. Verification asks about a SPAN, so this does too.")
-    ap.add_argument("--min-rows", type=int, default=30,
-                    help="skip labels with fewer dated values (default: %(default)s)")
+    # DEFAULT None, NOT 30, so the code below can tell "the caller chose 30" from "the caller said
+    # nothing" -- the distinction --check needs. See MIN_ROWS_REPORT / MIN_ROWS_TABLE.
+    ap.add_argument("--min-rows", type=int, default=None,
+                    help=f"skip labels with fewer dated values (default: {MIN_ROWS_REPORT} for the "
+                         f"ranked report, {MIN_ROWS_TABLE} for --check/--write, which is what the "
+                         f"tracked table was built with)")
     ap.add_argument("--write-assertions", metavar="CSV", nargs="?", const=DEFAULT_ASSERT,
                     help="write a PER-ASSERTION provenance table (default: %(const)s) from the "
                          "pending/banked IIA assertion keys. The label table averages over all a "
@@ -278,12 +285,11 @@ def main() -> int:
     # erasing measurements it did not take, a default run is IDEMPOTENT -- it reproduces the tracked
     # table byte for byte.
     #
-    # But idempotent is not the same as fully regenerated, and the difference is the check's reach.
-    # A default run recomputes 241 of the 335 rows; the other 94 hold a measurement this run does not
-    # cover and are carried forward UNCHECKED. Verified by setting `territory_signal` on all 335 rows
-    # and re-checking: 204 are caught. The 37-row gap is not a blind spot -- 37 rows legitimately read
-    # `mixed`, so the mutation was a no-op there, and 241 - 37 = 204 closes exactly. So the guard
-    # covers 241 rows and cannot see 94, which is worth having and worth not overstating.
+    # AND NOW COMPLETE, which it was not when first added. With --min-rows defaulting to 30 for every
+    # mode, a check recomputed only 241 of 335 rows and 94 were carried forward unchecked -- so a
+    # corrupted `albania` row passed as "current". At MIN_ROWS_TABLE the check recomputes all 302 rows
+    # that have a layer_b_label, and the remaining 33 have none at all, so there is nothing about them
+    # a fingerprint could assert. The same albania mutation is now caught.
     ap.add_argument("--check", action="store_true",
                     help="exit 1 if the 204 rows a default run recomputes differ from the tracked table")
     ap.add_argument("--write", metavar="CSV", nargs="?", const=DEFAULT_PROV,
@@ -293,6 +299,18 @@ def main() -> int:
                          "already did once, when a hand-rolled derivation used a share-ratio test "
                          "this script had replaced with a union-gain test")
     args = ap.parse_args()
+    # THE INVOCATION THAT PRODUCED THE TRACKED TABLE IS NOW RECORDED HERE, which issue 472 asked for:
+    # it was nowhere, so the table could not be reproduced without guessing and every default run
+    # degraded it. Recovered empirically -- at --min-rows 1 the run recomputes 302 of the 335 rows and
+    # ALL 302 match the tracked table; the other 33 carry a BLANK layer_b_label, i.e. raw labels with
+    # no layer-B counterpart, so there is nothing to fingerprint and "not measured" is correct for
+    # them rather than a floor artefact. The table is therefore fully verified at this setting.
+    #
+    # The ranked report keeps 30, because a floor of 1 fills it with one-value labels whose
+    # fingerprint means nothing (the MIN_SPAN_VALUES logic exists for exactly that). So the two modes
+    # want different floors and the flag now defaults per mode instead of globally.
+    if args.min_rows is None:
+        args.min_rows = MIN_ROWS_TABLE if (args.check or args.write) else MIN_ROWS_REPORT
 
     for path, what in ((args.raw, "raw extract"), (args.layer_b, "layer-B panel")):
         if not os.path.exists(path):
@@ -615,8 +633,8 @@ def main() -> int:
                 print(f"STALE {os.path.basename(DEFAULT_PROV)}: {changed} signal(s) would change; "
                       f"rerun with --write", file=sys.stderr)
                 return 1
-            print(f"table is current: the {len(table) - kept} row(s) this run recomputes match the "
-                  f"tracked table; {kept} row(s) it does not cover were carried forward unchecked")
+            print(f"table is current: all {len(table) - kept} fingerprinted row(s) match the tracked "
+                  f"table; the other {kept} carry no layer_b_label, so there is nothing to fingerprint")
             return 0
         with open(args.write, "w", newline="", encoding="utf-8") as fh:
             w = csv.DictWriter(fh, fieldnames=fields)

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -498,6 +498,15 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        validate_iia_label_provenance.py enforces, so tool and table cannot
                        drift — they already did once, when a hand-rolled derivation kept a
                        share-ratio test this script had replaced with a union-gain test.
+                       THE INVOCATION THAT BUILDS THE TABLE IS `--write` OR `--check` WITH NO
+                       `--min-rows`, which defaults to 1 for those modes (30 for the ranked
+                       report, where a fingerprint over fewer values is noise). That was
+                       unrecorded until issue 472 and cost real trouble: `--write` used to
+                       overwrite every row the run had not covered with `unknown`, so a default
+                       run destroyed 61 of 302 recorded fingerprints, and nothing said what
+                       argument would reproduce them. At the table floor the run recomputes all
+                       302 rows carrying a layer_b_label and they match exactly; the other 33 have
+                       no layer_b_label at all, so a fingerprint has nothing to assert about them.
                        `--assertion 'label|source|LO-HI'` measures ONE assertion's own span,
                        which is what verification actually asks. A label-level signal averages
                        over all years and misses a problem confined to one era: `russian


### PR DESCRIPTION
#472's remaining ask. The table was built with a lower `--min-rows` than the default 30, and that invocation
was recorded **nowhere** — not in the tool, not in either README — so it could not be reproduced without
guessing, and (before #473) every default run degraded it.

### Recovered empirically, not guessed

Running `--check` at descending floors:

```
min-rows  30 -> 241 rows recomputed, 94 uncovered
          20 -> 257 / 78
          10 -> 279 / 56
           5 -> 292 / 43
           2 -> 300 / 35
           1 -> 302 / 33
```

**At every floor the recomputed rows match the tracked table**, so the values do not depend on the floor —
only the coverage does. At 1 the run recomputes all **302** rows carrying a `layer_b_label`. The remaining
**33** have a *blank* `layer_b_label` — raw labels with no layer-B counterpart, verified to have **zero** iia
rows in the panel — so "not measured" is correct for them rather than a floor artefact.

That makes the table fully verified at this setting, which is a stronger statement than "it reproduces": all
302 fingerprints are confirmed against the raw extract.

### `--min-rows` now defaults per mode

**1** for `--check`/`--write`, **30** for the ranked report, where a fingerprint over fewer than 30 values is
noise. The report still examines 118 labels, unchanged. The flag's default is `None` so the code can
distinguish "the caller chose 30" from "the caller said nothing".

### The check was incomplete and is now not, with a concrete before/after

At the old floor it recomputed 241 of 335 rows, leaving 94 unchecked. Earlier in this work I mutated an
`albania` row and the check reported **"table is current"** — I recorded that as a limitation at the time.
The same mutation is now **detected**:

```
STALE iia_label_provenance.csv: 1 signal(s) would change; rerun with --write
```

That is the point: a check whose reach is 72% of the table lets a defect through *while reporting success* —
the same failure shape as a guard that never fires.

Verified: ranked report unchanged at 118 labels; `--write` still byte-identical to the tracked table; the
albania mutation now fails; 75 gates and the full 97-case selftest pass. No tracked table changed.