### PR TITLE
Verify every arm of the three newest gates actually fires: 9 unverified, 0 dead

### DIFF
--- a/scripts/validate_collapse_groups.py
+++ b/scripts/validate_collapse_groups.py
@@ -23,6 +23,13 @@ A label-pair screen is therefore not a partial view of this defect; it is very n
 
 WHAT IS PINNED, AND WHAT DELIBERATELY IS NOT. The group counts above are a routine SCREENING total:
 they move whenever the panel or the matcher legitimately moves, and a gate that pinned them would fail
+ALL 5 ARMS WERE VERIFIED TO FIRE on 2026-08-20, by mutating this table to trigger each in turn.
+An arm that cannot fire passes every run while asserting nothing, and this repo has shipped three of
+those (issues 407, 412, 420), so "the gate is green" is only meaningful once each arm is known live.
+Verified: an unknown verdict (A); a mean outside its group's range (B, permanent case); an anchor
+rewritten as agreement (C, permanent case); a composition contradicting n_labels (D); a
+duplicate_class contradicting n_indicators (E, permanent case).
+
 on every honest regeneration. They are printed, not asserted. What IS pinned both ways is the handful of
 CURATED anchors below -- the specific groups quoted in issues 411, 449 and 451 -- because those are
 findings a human confirmed, and if one silently changes its value the issue text has gone stale.

--- a/scripts/validate_cross_label_duplication.py
+++ b/scripts/validate_cross_label_duplication.py
@@ -22,6 +22,14 @@ turns the screen into a false-positive generator:
      whose direction is independently established, and it runs the other way (issue 433). Its block
      swings 35x, so it has no level to match; blocks that do swing 1.2x-2.4x.
 
+ALL 5 ARMS WERE VERIFIED TO FIRE on 2026-08-20, by mutating this table to trigger each in turn.
+An arm that cannot fire passes every run while asserting nothing, and this repo has shipped three of
+those (issues 407, 412, 420), so "the gate is green" is only meaningful once each arm is known live.
+Verified: a block below the distinctness floor (A); a non-contiguous block (B); a pair that does
+not differ outside its block (C); a direction claimed on a block with no level (D, permanent
+case); a smaller_label contradicting its own ratio (E, which shipped INVERTED in all six rows and
+is why arm E exists at all).
+
 The COUNT is printed, not pinned: a new instance is a finding, not a regression, and pinning it would
 make an honest discovery fail CI.
 """

--- a/scripts/validate_era_shift_verdicts.py
+++ b/scripts/validate_era_shift_verdicts.py
@@ -37,6 +37,13 @@ Checks:
   E. THE ERA FLOOR -- every row is 1934 or later, since 1933 is the last year a second yearbook volume
      offers an opinion (issue 414) and a row before it belongs to a different question.
 
+ALL 5 ARMS WERE VERIFIED TO FIRE on 2026-08-20, by mutating this table to trigger each in turn.
+An arm that cannot fire passes every run while asserting nothing, and this repo has shipped three of
+those (issues 407, 412, 420), so "the gate is green" is only meaningful once each arm is known live.
+Verified: an unknown verdict (A); an implied_yield disagreeing with production/area (B); an
+`impossible_yield` row pushed below the 20 t/ha line (C); a zero-area row reclassified (D, which
+also carries the permanent selftest case); a row dated before 1934 (E).
+
 The class COUNTS are printed, not pinned: they move whenever the panel or the matcher legitimately moves.
 What is pinned is arithmetic and the zero-area rule, neither of which can legitimately break.
 """


### PR DESCRIPTION
15 arms across `validate_era_shift_verdicts`, `validate_collapse_groups` and
`validate_cross_label_duplication`; only **5** carried a permanent selftest case. So 10 arms were asserting
nothing as far as any reader could tell.

That matters because **an arm that cannot fire passes every run while checking nothing**, and this repo has
shipped three of those: #407 guarded on a filename the repo does not contain, #412 published a flag that
resolved to nothing, #420 filtered away the 177 most impossible cells before testing for impossible cells.
"The gate is green" is only meaningful once each arm is known live.

### Audited by mutation: all nine fire

```
era_shift        A unknown verdict | B yield != production/area | C impossible below 20 t/ha
                 E year before 1934                          (D already had a case)
collapse_groups  A unknown verdict | D composition contradicts n_labels
                                                             (B, C, E already had cases)
cross_label      A below the distinctness floor | B non-contiguous | C no difference outside
                                                             (D had a case; E was added in #470
                                                              after shipping INVERTED)
```

**A clean negative result — no dead arms.** Recorded in each docstring rather than left in a terminal,
because the next reader's question is "are these arms real?" and re-deriving the answer costs another audit.

Docstrings only; no behaviour change. 75 gates and the full 97-case selftest pass.

### The harness produced its own lesson

It passed `open(path, "w")` to `DictWriter` without closing it, so the late GC flush clobbered the file
**after** the restore, and the next read failed with `dict contains fields not in fieldnames: None` — which
reads exactly like a ragged row in the tracked table. I checked: the committed file is intact (14 header
fields, 427 rows, clean). The harness was not. A backup/restore harness that leaves handles open can undo
its own restore after the check that said the restore worked — worth knowing before trusting one.