### PR TITLE
Pin the review_ledger status vocabulary: four tools gate on it and nothing checked it (#308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ python3 scripts/validate_data_without_geometry.py  # joins matching to geometry:
 python3 scripts/validate_landuse_corrections.py    # a repair table's stated reason must match its own numbers
 python3 scripts/validate_yield_corrections.py      # and the area x yield repairs: which column moved, by what factor, and whether it may be repaired unseen
 python3 scripts/validate_subnational_sums.py       # and the whole/part sums: an "exact aggregate" row may not carry a residual
-python3 scripts/validate_review_ledger.py        # a banked verdict must name a live polity
+python3 scripts/validate_review_ledger.py        # a banked verdict must name a live polity, and its status must be a known one
 python3 scripts/validate_source_conventions.py     # the conventions registry: well-formed, live patterns, corroborated, re-tested
 python3 scripts/validate_iia_label_provenance.py   # 335 raw IIA labels -> 173 countries: no equality claim on a label that mixes territories
 python3 scripts/validate_source_splices.py         # a series spliced across sources must not change scale at the seam

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1956,6 +1956,38 @@ def mutate_overlap_code_not_a_polity(root, gpd, make_valid, affinity):
             f"has, leaving the row count, the arithmetic, the floor and every identity pin intact")
 
 
+def mutate_ledger_status_typo(root, gpd, make_valid, affinity):
+    """Typo one ledger status, the way a hand edit or a new writer would.
+
+    `review_ledger.csv` is the record of what has already been judged, and FOUR tools select banked
+    work from it with `status in ("correct", "fixed")` -- 00_intake, 01_match_and_findings,
+    02_territorial_evidence and reconcile_quarantine. A status they do not recognise raises nothing:
+    the row simply falls out of the filter, so a verdict that WAS reached stops counting as reached
+    and its assertion is re-selected for verification as though nobody had looked at it. Nothing
+    pinned the vocabulary before this case.
+
+    The mutation is one character on one row -- `correct` -> `corrct` -- because that is the realistic
+    failure and because it leaves every other signal quiet: the key still names a live polity, so arm
+    A stays silent, and the row is no longer `correct` so arm B (retired-but-judged-correct) cannot
+    fire either. Only the vocabulary arm can see it.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/review_ledger.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rd = csv.DictReader(fh)
+        rows = list(rd)
+        fields = list(rd.fieldnames)
+    hit = next((r for r in rows if (r.get("status") or "").strip() == "correct"), None)
+    if hit is None:
+        raise AssertionError("no `correct` row in review_ledger.csv, so this mutation has nothing to "
+                             "typo and the case would pass vacuously")
+    hit["status"] = "corrct"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"typo'd the status of {hit.get('key')!r} from `correct` to `corrct`, which drops a "
+            f"banked verdict out of the filter four tools use to decide what has already been judged")
+
 def mutate_ledger_write_untruncated_to_atomic(root, gpd, make_valid, affinity):
     """Put back the truncating write that issue 431 removed from the ledger writer.
 
@@ -3600,6 +3632,14 @@ CASES = (
         "between the `if area > 0` guard and 14 exonerated impossible rows",
     ),
     (
+        "validate_review_ledger.py",
+        mutate_ledger_status_typo,
+        "is not one of",
+        "one character changed in one ledger status, which silently drops a banked verdict out of "
+        "the filter four tools use to decide what has already been judged -- arms A and B both stay "
+        "quiet, so only the vocabulary arm can see it",
+    ),
+    (
         "validate_atomic_state_writes.py",
         mutate_ledger_write_untruncated_to_atomic,
         "truncates review_ledger.csv",
@@ -4232,6 +4272,10 @@ WRITABLE = {
     # The case rewrites era_shift_verdicts.csv in place (it reclassifies one row), so a real copy.
     "validate_era_shift_verdicts.py": (
         "pipelines/polity-autoimprove/state/era_shift_verdicts.csv",
+    ),
+    # The case typos one status in review_ledger.csv, so a real copy rather than a symlink.
+    "validate_review_ledger.py": (
+        "pipelines/polity-autoimprove/state/review_ledger.csv",
     ),
     # The case rewrites a PIPELINE MODULE rather than a state table (it restores a truncating write),
     # so the module itself must be materialised as a real copy in the scratch tree.

--- a/scripts/validate_review_ledger.py
+++ b/scripts/validate_review_ledger.py
@@ -54,6 +54,11 @@ BASELINE_DEAD_KEYS = frozenset()
 BASELINE_RETIRED_CORRECT = 7
 
 
+# The five statuses the ledger actually carries. `correct` and `fixed` mean judged; `issue` means a
+# verdict recorded a problem; `unreviewed` is not yet looked at; `suppressed` is deliberately excluded.
+LEDGER_STATUSES = frozenset({"correct", "fixed", "issue", "unreviewed", "suppressed"})
+
+
 def main() -> int:
     for path in (LEDGER, DB):
         if not os.path.exists(path):
@@ -80,11 +85,38 @@ def main() -> int:
         elif live.get(key) in DEAD and (r.get("status") or "") == "correct":
             retired_key.append((key, r.get("status"), r.get("last_run")))
 
+    # --- C. the STATUS VOCABULARY, because four tools gate on it ---
+    # `00_intake.py`, `01_match_and_findings.py`, `02_territorial_evidence.py` and
+    # `reconcile_quarantine.py` all select ledger rows with `status in ("correct", "fixed")`. So a
+    # typo'd status does not raise anywhere -- it silently drops a banked verdict out of the filter
+    # that decides what has already been judged, and the assertion is re-selected for verification as
+    # though nobody had looked at it. Nothing pinned this vocabulary, and the ledger is written by
+    # several tools (issue 308 found 6 applied verdicts with no ledger row and 55 banked rows with no
+    # applied record, so this file does drift).
+    #
+    # A count is NOT pinned here: `unreviewed` and `issue` rows come and go legitimately. What is
+    # pinned is the SET, so a new status has to be added deliberately and its effect on those four
+    # filters considered at that moment rather than discovered later.
+    seen_status = {}
+    for r in rows:
+        st = (r.get("status") or "").strip()
+        seen_status[st] = seen_status.get(st, 0) + 1
+    unknown_status = {k: v for k, v in seen_status.items() if k not in LEDGER_STATUSES}
+
     print(f"ledger rows: {len(rows)} ({len(pol)} polity-keyed)")
     print(f"A. keys absent from the database: {len(dead_key)}")
     print(f"B. keys that are retired or superseded but judged `correct`: {len(retired_key)}")
+    print(f"C. status vocabulary: " + ", ".join(f"{k}={v}" for k, v in sorted(seen_status.items())))
 
     problems = []
+    for st, n in sorted(unknown_status.items()):
+        problems.append(
+            f"C status {st!r} on {n} row(s) is not one of {sorted(LEDGER_STATUSES)}. Four tools "
+            f"select banked work with `status in (\"correct\", \"fixed\")` -- 00_intake, 01, 02 and "
+            f"reconcile_quarantine -- so an unrecognised status silently drops those rows out of the "
+            f"filter that decides what has already been judged, and the assertions are re-verified "
+            f"as though nobody had looked at them. If this status is intended, add it to "
+            f"LEDGER_STATUSES and say what those four filters should do with it")
     for key, status, last in sorted(dead_key):
         if key in BASELINE_DEAD_KEYS:
             continue


### PR DESCRIPTION
`00_intake.py`, `01_match_and_findings.py`, `02_territorial_evidence.py` and `reconcile_quarantine.py` all
select banked work with `status in ("correct", "fixed")`. **Nothing pinned that vocabulary**, so a typo'd
status raises nowhere — the row silently falls out of the filter that decides what has already been judged,
and the assertion is re-selected for verification as though nobody had looked at it.

The file does drift: #308 found **6** applied verdicts with no ledger row and **55** banked rows with no
applied record, and several tools write it.

```
C. status vocabulary: correct=723, fixed=158, issue=94, suppressed=3, unreviewed=15
```

The **set** is pinned, not the counts — `unreviewed` and `issue` come and go legitimately. A new status now
has to be added deliberately, with its effect on those four filters considered at that moment rather than
discovered later.

The selftest case changes **one character** on one row, `correct` → `corrct`, because that is the realistic
failure and it leaves every other arm quiet: the key still names a live polity so arm A is silent, and the row
is no longer `correct` so arm B cannot fire. Only the vocabulary arm sees it.

### How I got here, including the part that failed

I swept all 75 gates looking for one that notices **nothing** about its own tracked input — the #407 shape,
where a gate is guarded on a condition that never occurs. The sweep flagged **21 gates and was wrong about
essentially all of them**:

- generic mutations (blank a field, duplicate a row, drop a row) do not violate a gate that checks *per-row
  consistency* and deliberately pins no counts — three of the flagged gates were ones whose arms I had
  verified live minutes earlier;
- the table list was polluted by **filename mentions**: `validate_atomic_state_writes` "reads" 11 tables that
  are string keys in its `PROTECTED` dict. That is the same over-count #431's original sweep made, and the
  third time I have made it today.

Refuted by targeted probes — `item_provenance` caught a bad status immediately. So the sweep supports no
finding and I am not filing one.

**One real gap survived that refutation, and this PR is it.** Reporting the failed sweep alongside it because
"21 gates check nothing" is exactly the sort of alarming number that would have been repeated later.

Gates 75 (unchanged), selftest 97 → 98. All 75 gates pass; full selftest green.