### PR TITLE
The ledger gate passed on ZERO rows when its own filter emptied: pin unit_kind, floor the population, and state the evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ python3 scripts/validate_data_without_geometry.py  # joins matching to geometry:
 python3 scripts/validate_landuse_corrections.py    # a repair table's stated reason must match its own numbers
 python3 scripts/validate_yield_corrections.py      # and the area x yield repairs: which column moved, by what factor, and whether it may be repaired unseen
 python3 scripts/validate_subnational_sums.py       # and the whole/part sums: an "exact aggregate" row may not carry a residual
-python3 scripts/validate_review_ledger.py        # a banked verdict must name a live polity, and its status must be a known one
+python3 scripts/validate_review_ledger.py        # a banked verdict must name a live polity; status and unit_kind must be known, and the check must not be empty
 python3 scripts/validate_source_conventions.py     # the conventions registry: well-formed, live patterns, corroborated, re-tested
 python3 scripts/validate_iia_label_provenance.py   # 335 raw IIA labels -> 173 countries: no equality claim on a label that mixes territories
 python3 scripts/validate_source_splices.py         # a series spliced across sources must not change scale at the seam

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -1956,6 +1956,42 @@ def mutate_overlap_code_not_a_polity(root, gpd, make_valid, affinity):
             f"has, leaving the row count, the arithmetic, the floor and every identity pin intact")
 
 
+def mutate_ledger_unit_kind_typo(root, gpd, make_valid, affinity):
+    """Typo `unit_kind` so the gate's own filter selects nothing, and see whether it still passes.
+
+    `validate_review_ledger` scopes arms A and B with `pol = [r for r in rows if unit_kind ==
+    "polity"]`. So that column decides HOW MUCH the gate checks, and until this case nothing validated
+    it. Measured before the fix: typo'ing it on all 256 polity rows took the checked population from
+    256 to ZERO and the gate printed "PASS: every banked verdict names a polity that exists" -- its
+    strongest claim, on no evidence. That is the shape of issues 407, 412 and 420, this time in the
+    scoping of a gate rather than in an arm.
+
+    The mutation typos EVERY polity row rather than one, because one row leaving the population is a
+    quiet weakening and all of them leaving is the failure mode -- an empty check that reports
+    success. Two arms now catch it: the unit_kind vocabulary, and the floor on how many rows the
+    filter may select. `status` is untouched, so arm C stays quiet.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/review_ledger.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rd = csv.DictReader(fh)
+        rows = list(rd)
+        fields = list(rd.fieldnames)
+    n = 0
+    for r in rows:
+        if (r.get("unit_kind") or "").strip() == "polity":
+            r["unit_kind"] = "polty"
+            n += 1
+    if not n:
+        raise AssertionError("no polity-keyed rows in review_ledger.csv, so this mutation cannot "
+                             "empty the filter and the case would pass vacuously")
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"typo'd unit_kind on all {n} polity-keyed rows, which empties the population arms A and "
+            f"B examine -- before the floor and the vocabulary arm, the gate reported PASS on zero "
+            f"rows")
+
 def mutate_ledger_status_typo(root, gpd, make_valid, affinity):
     """Typo one ledger status, the way a hand edit or a new writer would.
 
@@ -3630,6 +3666,13 @@ CASES = (
         "a row with 85,000 tonnes of production on ZERO hectares reclassified as fine, with "
         "`convicted` flipped to match so arms A, B and C stay quiet -- only the zero-area rule stands "
         "between the `if area > 0` guard and 14 exonerated impossible rows",
+    ),
+    (
+        "validate_review_ledger.py",
+        mutate_ledger_unit_kind_typo,
+        "polity-keyed row(s) of",
+        "the column that SCOPES this gate typo'd on every row, so its arms examine nothing -- before "
+        "the floor, that reported PASS on zero rows while claiming a property of every banked verdict",
     ),
     (
         "validate_review_ledger.py",

--- a/scripts/validate_review_ledger.py
+++ b/scripts/validate_review_ledger.py
@@ -57,6 +57,19 @@ BASELINE_RETIRED_CORRECT = 7
 # The five statuses the ledger actually carries. `correct` and `fixed` mean judged; `issue` means a
 # verdict recorded a problem; `unreviewed` is not yet looked at; `suppressed` is deliberately excluded.
 LEDGER_STATUSES = frozenset({"correct", "fixed", "issue", "unreviewed", "suppressed"})
+# `unit_kind` says what a ledger row is ABOUT, and this gate's arms A and B are scoped by it:
+# `pol = [r for r in rows if unit_kind == "polity"]`. So the filter decides how much the gate checks,
+# and nothing validated it. Measured: typo'ing it on all 256 polity rows takes the checked population
+# from 256 to ZERO and the gate still prints "PASS: every banked verdict names a polity that exists"
+# -- vacuously true, the exact shape of issues 407, 412 and 420. `unit_kind` is ALSO what separates an
+# assertion verdict from a polity decision when counting banked work (issue 308: ignoring it produced
+# a 55.4% orphan rate against a true 15.7%, because 415 polity-level rows were counted as orphaned
+# assertions).
+LEDGER_UNIT_KINDS = frozenset({"match", "polity", "ingest"})
+# A floor, not a pinned count: the population moves as work is banked, but it cannot legitimately be
+# empty while the ledger holds 993 rows. This is what catches the filter emptying for ANY reason,
+# including ones a vocabulary check cannot see.
+MIN_POLITY_KEYED = 1
 
 
 def main() -> int:
@@ -97,6 +110,12 @@ def main() -> int:
     # A count is NOT pinned here: `unreviewed` and `issue` rows come and go legitimately. What is
     # pinned is the SET, so a new status has to be added deliberately and its effect on those four
     # filters considered at that moment rather than discovered later.
+    seen_kind = {}
+    for r in rows:
+        k = (r.get("unit_kind") or "").strip()
+        seen_kind[k] = seen_kind.get(k, 0) + 1
+    unknown_kind = {k: v for k, v in seen_kind.items() if k not in LEDGER_UNIT_KINDS}
+
     seen_status = {}
     for r in rows:
         st = (r.get("status") or "").strip()
@@ -107,8 +126,20 @@ def main() -> int:
     print(f"A. keys absent from the database: {len(dead_key)}")
     print(f"B. keys that are retired or superseded but judged `correct`: {len(retired_key)}")
     print(f"C. status vocabulary: " + ", ".join(f"{k}={v}" for k, v in sorted(seen_status.items())))
+    print(f"D. unit_kind vocabulary: " + ", ".join(f"{k}={v}" for k, v in sorted(seen_kind.items())))
 
     problems = []
+    if len(pol) < MIN_POLITY_KEYED:
+        problems.append(
+            f"D {len(pol)} polity-keyed row(s) of {len(rows)}, below the floor of {MIN_POLITY_KEYED}. "
+            f"Arms A and B are scoped by `unit_kind == \"polity\"`, so an empty selection makes them "
+            f"check nothing while this gate still reports success -- measured, typo'ing that column "
+            f"takes the checked population from 256 to 0 and the gate passes vacuously")
+    for k, n in sorted(unknown_kind.items()):
+        problems.append(
+            f"D unit_kind {k!r} on {n} row(s) is not one of {sorted(LEDGER_UNIT_KINDS)}. This column "
+            f"scopes arms A and B and separates assertion verdicts from polity decisions when banked "
+            f"work is counted (issue 308), so an unrecognised value silently shrinks both")
     for st, n in sorted(unknown_status.items()):
         problems.append(
             f"C status {st!r} on {n} row(s) is not one of {sorted(LEDGER_STATUSES)}. Four tools "
@@ -147,7 +178,11 @@ def main() -> int:
             print(f"  {p}")
         return 1
 
-    print("\nPASS: every banked verdict names a polity that exists")
+    # SAY HOW MUCH WAS CHECKED, not just that it passed. The old message asserted a property of
+    # "every banked verdict" while the population it examined was whatever the unit_kind filter
+    # happened to select -- so at zero rows it made its strongest claim on no evidence.
+    print(f"\nPASS: all {len(pol)} polity-keyed row(s) name a live polity; {len(rows)} ledger rows "
+          f"carry a known status and unit_kind")
     return 0
 
 


### PR DESCRIPTION
`validate_review_ledger` scopes arms A and B with

```python
pol = [r for r in rows if (r.get("unit_kind") or "") == "polity"]
```

and nothing validated that column. **Measured: typo'ing `unit_kind` on all 256 polity rows takes the checked
population from 256 to zero and the gate prints**

```
PASS: every banked verdict names a polity that exists
```

— its strongest claim, on no evidence. Same shape as #407 (guarded on a filename the repo does not contain),
#412 and #420, except here it is the gate's **scoping** rather than an arm, which is worse: every arm stays
individually correct while the population they run over disappears.

### Three changes

- **`unit_kind` vocabulary pinned** to `{match, polity, ingest}`. This column also separates assertion
  verdicts from polity decisions when banked work is counted — ignoring it produced a **55.4%** orphan rate
  against a true **15.7%** on #308, because 415 polity-level rows were counted as orphaned assertions.
- **A floor on how many rows the filter may select.** Not a pinned count — the population moves as work is
  banked — but it cannot legitimately be empty while the ledger holds 993 rows. This catches the filter
  emptying for *any* reason, including causes a vocabulary check cannot see.
- **The PASS message states its evidence**: `all 256 polity-keyed row(s) name a live polity; 993 ledger rows
  carry a known status and unit_kind`. A gate that reports how much it checked cannot make its strongest
  claim on nothing without saying so.

The selftest case typos **every** polity row rather than one, because one row leaving the population is a
quiet weakening and all of them leaving is the failure mode. Verified: exit 1, naming the floor.

### How I got here, and what I am not claiming

Generalising #477's status-vocabulary gap, I swept tracked tables for vocabularies that tools filter on but
nothing pins: **13 candidates**. Rather than file all 13 — my last sweep produced 21 findings and was wrong
about essentially all of them — I checked the one I had direct evidence for: `unit_kind`, which I had needed
hours earlier to correct my own #308 measurement. Its only filter turned out to be *inside this gate*, which
is what made it worth fixing.

**The other 12 are unverified and I am not claiming them.**

Gates 75 (unchanged), selftest 98 → 99. All 75 gates pass; full selftest green.