### PR TITLE
Two gates passed on an empty primary table; two others correctly do not

### DIFF
--- a/scripts/validate_era_shift_verdicts.py
+++ b/scripts/validate_era_shift_verdicts.py
@@ -147,6 +147,23 @@ def main() -> int:
         if v == "untestable" and (yld is not None or ratio is not None):
             problems.append(f"C {w}: classed untestable but carries yield {yld} / ratio {ratio}")
 
+    # A FLOOR, BECAUSE THIS TABLE IS THE EVIDENCE FOR A CONFIRMED DEFECT. `data_errors.csv` carries
+    # `iia-tobacco-implausible-magnitudes` (status confirmed, 1934-1945, tobacco), and these rows are
+    # what substantiate it. An empty table therefore means the evidence vanished -- a regeneration
+    # failure -- not that the defect was fixed. Measured: emptying it made every arm pass and the gate
+    # print its full PASS message, because each arm is per-row and had no rows to object to.
+    #
+    # It is a FLOOR OF ONE, not a pinned count: repairing the era changes a row's VERDICT (from
+    # `impossible_yield` to `plausible_yield`) and does not delete it, since the rows are simply the
+    # source's 1934+ production rows. So this cannot block a genuine fix, which is the test a floor
+    # has to pass before it is worth having.
+    if not rows:
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} holds no rows. It is the evidence for "
+              f"`iia-tobacco-implausible-magnitudes` (confirmed, 1934-1945), so an empty table means "
+              f"that evidence was lost in regeneration, not that the defect was repaired -- a repair "
+              f"changes a row's verdict and does not remove the row", file=sys.stderr)
+        return 1
+
     vc = {}
     for r in rows:
         vc[r["verdict"]] = vc.get(r["verdict"], 0) + 1

--- a/scripts/validate_magnitude_outliers.py
+++ b/scripts/validate_magnitude_outliers.py
@@ -139,7 +139,11 @@ def main() -> int:
             "partial write or a hand merge is the usual cause")
 
     print(f"magnitude outliers: {len(rows)} rows, {len({r.get('whep_code') for r in rows})} "
-          f"polities, min ratio {min(ratios) if ratios else float('nan'):,.4f} "
+          # `float('nan')` here PRINTED "min ratio nan" when the table was empty, which reads as a
+          # computation that went wrong rather than as an absence. A statistic over an empty set has
+          # no value, so say so instead of formatting a nan (same reasoning as withholding a
+          # direction when a block has no level, whep-polities#469).
+          f"polities, min ratio {f'{min(ratios):,.4f}' if ratios else 'n/a (no rows)'} "
           f"(floor {MIN_RATIO}), orphaned codes {len(orphans)}")
 
     for p in problems:

--- a/scripts/validate_source_conventions.py
+++ b/scripts/validate_source_conventions.py
@@ -193,6 +193,21 @@ def main() -> int:
         reader = csv.DictReader(fh, restkey="__extra__", restval="__missing__")
         header = tuple(reader.fieldnames or ())
         rows = list(reader)
+    # A FLOOR ON THE REGISTRY, because emptying it is reported only as warnings today. Measured: with
+    # zero rows this gate prints "PASS: 0 problem(s), 33 warning(s)" -- every registered re-test says
+    # its convention "is no longer carried", which is 33 separate notices that the registry was lost,
+    # none of which fails CI. Warnings are the right channel for one check drifting ahead of the
+    # registry; they are the wrong channel for the registry vanishing.
+    #
+    # A floor of ONE, not a pinned count: conventions are added (29 -> 33 today) and are sometimes
+    # WITHDRAWN -- I withdrew a cross-source livestock generalisation as circular earlier -- so
+    # pinning the number would block honest curation. What cannot legitimately happen is all of them
+    # disappearing at once.
+    if not rows:
+        fails.append(
+            "the registry holds no rows. Every convention here is a premise later verifiers inherit, "
+            "so an empty registry is data loss -- and it surfaces today only as one warning per "
+            "orphaned re-test, which does not fail CI")
     if header != COLUMNS:
         missing = [c for c in COLUMNS if c not in header]
         extra = [c for c in header if c not in COLUMNS]


### PR DESCRIPTION
Generalising the vacuous PASS from #478, with a test that needs no guessing about which field to corrupt:
**empty a gate's own primary table and see whether it still reports success.**

```
gates with a same-named tracked table        26
  fail or skip on an empty one (good)        22
  PASS on an empty one                        4
```

I judged the four individually rather than fixing them as a batch, **because two of them are right**.

### Floors added

**`era_shift_verdicts`** — the table is the evidence for `iia-tobacco-implausible-magnitudes`
(`data_errors.csv`, status **confirmed**, 1934–1945). An empty table means that evidence was lost in
regeneration, not that the defect was repaired: a repair changes a row's **verdict**
(`impossible_yield` → `plausible_yield`) and does not delete the row, since the rows are simply the source's
1934+ production rows. So the floor cannot block a genuine fix — which is the test a floor has to pass to be
worth having.

**`source_conventions`** — on an empty registry it printed `PASS: 0 problem(s), 33 warning(s)`, every
registered re-test reporting that its convention *"is no longer carried"*. That is 33 separate notices that
the registry was lost, none of which fails CI. Warnings are the right channel for one check drifting ahead of
the registry and the wrong channel for the registry vanishing.

### Deliberately not changed

**`cross_label_duplication`** — its own docstring says the count is unpinned because *"a new instance is a
finding, not a regression"*, and if all six duplications were repaired then **an empty table is the success
state**. A floor here would make a genuine fix fail CI.

**`magnitude_outliers`** — no floor, on an existing recorded decision: its 2,718 rows are a routine screening
total deliberately not pinned bidirectionally so that a legitimate regeneration cannot fail. I fixed only the
symptom that made it *look* broken — it printed `min ratio nan` on an empty set, which reads as a computation
that went wrong rather than as an absence. Now `min ratio n/a (no rows)`.

Both floors are **one row**, not the current count. The point is to catch a table emptying, not to freeze it.

75 gates and the full 99-case selftest pass; no tracked table changed.