### PR TITLE
raw_label is a canonical name, not the raw extract's label — say so where readers meet it

### DIFF
--- a/scripts/lookup_known_defect.py
+++ b/scripts/lookup_known_defect.py
@@ -189,14 +189,17 @@ def main() -> int:
     if prov:
         print(f"\nLABEL PROVENANCE -- this label already carries a recorded classification ({len(prov)}):")
         for field, r in prov[:6]:
-            print(f"  matched on {field}: raw={r.get('raw_label')!r} -> layer_b={r.get('layer_b_label')!r}"
-                  f" (assigned {r.get('assigned_modern')!r})")
+            print(f"  matched on {field}: raw_label={r.get('raw_label')!r} -> "
+                  f"layer_b={r.get('layer_b_label')!r} (assigned {r.get('assigned_modern')!r})")
             print(f"    kind={r.get('kind')!r} territory_signal={r.get('territory_signal')!r} "
                   f"mixing_observed={r.get('mixing_observed')!r}")
             print(f"    fingerprint: {r.get('fingerprint_note')!r} "
                   f"dominant={r.get('dominant_raw_label')!r} @ {r.get('dominant_share')!r}")
         print("  A classification here means the ROUTING is known. It does NOT quantify how many cells")
         print("  are affected, so a measured count can still be new -- but say what was already recorded.")
+        print("  NOTE `raw_label` is a CANONICAL territory name, not the raw extract's label (it matches")
+        print("  the extract in only 32% of rows). `dominant` IS the extract's label -- 100% of rows --")
+        print("  so join on that: e.g. canonical `cyprus` is `british cyprus` in the extract.")
 
     if not matches and not indet:
         print("no entry can cover this query on the dimensions given.")

--- a/scripts/validate_iia_label_provenance.py
+++ b/scripts/validate_iia_label_provenance.py
@@ -230,7 +230,19 @@ def main() -> int:
     # on its layer-B target are Kwantung's and `territory_signal` reads `redirected`. Printing the
     # distribution without saying the column is unmaintained invites exactly that reading, so the
     # report now says it.
-    UNMAINTAINED = {"mixing_observed"}
+    # `raw_label` IS A CANONICAL TERRITORY NAME, NOT THE RAW EXTRACT'S LABEL, and the name says the
+    # opposite. Measured: of 335 rows, `raw_label` matches a label in the raw extract in 106 (32%),
+    # while `dominant_raw_label` matches in 302 of 302 (100%). `cyprus` is the canonical name whose
+    # raw label is `british cyprus`; `new hebrides` is `british-french new hebrides`.
+    #
+    # That cost two false alarms in one session: reading `raw_label` as the extract's label, I flagged
+    # 784 layer-B series as having no raw production for their item, and then 229 of 335 rows as naming
+    # a nonexistent raw label. Both were the same misreading. `raw_label` is also not refreshed by
+    # `15_label_provenance.py --write`, which updates only the four columns named below, so like
+    # `mixing_observed` it is whatever the base table carries.
+    #
+    # Use `dominant_raw_label` for anything that must join against the raw extract.
+    UNMAINTAINED = {"mixing_observed", "raw_label"}
     for col in ("kind", "mixing_observed", "territory_signal"):
         if not prov or col not in prov[0]:
             continue


### PR DESCRIPTION
`iia_label_provenance.csv` has two label columns, and the names point the wrong way:

```
raw_label           matches a label in the raw extract in  106 of 335 rows    32%
dominant_raw_label  matches                                302 of 302 rows   100%
```

`raw_label` is a **canonical territory name** — canonical `cyprus` is `british cyprus` in the extract,
`new hebrides` is `british-french new hebrides`. Nothing documented this, and the column name says the
opposite of what it holds.

### It cost two false alarms in one session

Reading `raw_label` as the extract's label, I flagged **784** layer-B series as having no raw production for
their item, then **229 of 335** rows as naming a nonexistent raw label. Both were the same misreading, and
both looked alarming enough to file.

`raw_label` is also **not refreshed** by `15_label_provenance.py --write`, which updates only
`territory_signal`, `fingerprint_note`, `dominant_raw_label` and `dominant_share`. So it joins
`mixing_observed` (#485) as a column the tooling reads but never maintains, and the gate now marks both.

### Recorded in the two places a reader meets the table

- **`validate_iia_label_provenance`'s docstring** — the measurement, and the instruction to join on
  `dominant_raw_label` for anything that must reach the raw extract.
- **`lookup_known_defect`'s provenance output** — because it prints `raw_label` and `dominant` side by side,
  which invites exactly the conflation:

```
NOTE `raw_label` is a CANONICAL territory name, not the raw extract's label (it matches
the extract in only 32% of rows). `dominant` IS the extract's label -- 100% of rows --
so join on that: e.g. canonical `cyprus` is `british cyprus` in the extract.
```

Comments and report text only; no logic, no threshold, no table changed. 76 gates and the full 100-case
selftest pass.