### PR TITLE
Separate same-volume from cross-era resolution in constant_runs, and fix a duplicate WRITABLE key (#366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python3 scripts/validate_review_ledger.py        # a banked verdict must name a 
 python3 scripts/validate_source_conventions.py     # the conventions registry: well-formed, live patterns, corroborated, re-tested
 python3 scripts/validate_iia_label_provenance.py   # 335 raw IIA labels -> 173 countries: no equality claim on a label that mixes territories
 python3 scripts/validate_source_splices.py         # a series spliced across sources must not change scale at the seam
-python3 scripts/validate_constant_runs.py           # a value repeated for years must not outlive the resolution that refutes it
+python3 scripts/validate_constant_runs.py           # a value repeated for years must not outlive the resolution that refutes it, and a same-volume witness must not be cross-era
 python3 scripts/validate_isolated_spikes.py         # no single year may read many times its own neighbours
 python3 scripts/validate_same_polity_overlaps.py   # two labels of one source may not collide on one polity's cells
 python3 scripts/validate_era_shift_verdicts.py     # post-1933 tobacco/hops verdicts must match their own numbers

--- a/pipelines/polity-autoimprove/17_constant_runs.py
+++ b/pipelines/polity-autoimprove/17_constant_runs.py
@@ -91,6 +91,35 @@ def grid_of(v: float) -> int:
     return g
 
 
+# IIA VOLUME WINDOWS, and why this column exists at all (issue 366).
+#
+# This table only ever contains runs that HAVE finer evidence somewhere in their series -- a run fully
+# consistent with its grid is never emitted. So `n_finer_elsewhere` is positive by construction, and it
+# cannot distinguish the two cases that matter:
+#
+#   * the finer value comes from a DIFFERENT yearbook volume, whose grid was finer. Then the run is a
+#     resolution limit of its own volume and nothing is wrong with it. Issue 366's original headline was
+#     withdrawn on exactly this ground.
+#   * the finer value comes from the SAME volume. Then that volume demonstrably could express the finer
+#     figure and chose a round number for the run's years, which the grid cannot explain.
+#
+# Reading `n_finer_elsewhere` without that split produces the withdrawn claim, which is what happened.
+#
+# LAYER B CARRIES NO VOLUME PROVENANCE, so "same volume" can only be inferred from the year, and the
+# windows OVERLAP -- 1920, 1921, 1929, 1932 and 1933 each fall in two volumes, so a value there could
+# have come from either and proves nothing. Those years are excluded, which is the difference between a
+# defensible 18 and an inflated 39.
+IIA_VOLUMES = ((1909, 1921), (1920, 1925), (1926, 1929), (1929, 1933), (1932, 1938), (1939, 1945))
+IIA_AMBIGUOUS_YEARS = frozenset(
+    y for y in range(1900, 1960)
+    if sum(1 for a, b in IIA_VOLUMES if a <= y <= b) > 1
+)
+
+
+def _iia_volumes_covering(year: int) -> set:
+    return {i for i, (a, b) in enumerate(IIA_VOLUMES) if a <= year <= b}
+
+
 def find_runs(panel_path):
     import pandas as pd
     d = pd.read_parquet(panel_path)
@@ -126,6 +155,22 @@ def find_runs(panel_path):
                     finer = [x for j, x in enumerate(v)
                              if not (start <= j < k)
                              and int(round(x * SCALE)) % g != 0]
+                    # The in-volume witness: the earliest finer value that sits in a volume window the
+                    # run itself touches, at a year only ONE volume covers. Earliest rather than
+                    # closest so the choice is deterministic when the panel is rebuilt.
+                    wit_y, wit_v = "", ""
+                    if finer and source == "iia":
+                        run_vols = (_iia_volumes_covering(years[start])
+                                    | _iia_volumes_covering(years[k - 1]))
+                        for j, x in enumerate(v):
+                            if start <= j < k or int(round(x * SCALE)) % g == 0:
+                                continue
+                            yr = years[j]
+                            if yr in IIA_AMBIGUOUS_YEARS:
+                                continue
+                            if _iia_volumes_covering(yr) & run_vols:
+                                wit_y, wit_v = str(yr), f"{x:.3f}"
+                                break
                     if finer:
                         out.append({
                             "source": source, "country": country, "item": item, "unit": unit,
@@ -134,6 +179,8 @@ def find_runs(panel_path):
                             "series_n": len(v), "grid": f"{g / SCALE:g}",
                             "finest_elsewhere": f"{min(finer, key=abs):.3f}",
                             "n_finer_elsewhere": len(finer),
+                            "finer_in_volume_year": wit_y,
+                            "finer_in_volume_value": wit_v,
                         })
                 start = k
     out.sort(key=lambda r: (-r["n_values"], r["source"], r["country"], r["item"]))
@@ -176,7 +223,8 @@ def main() -> int:
 
     if args.write or args.check:
         cols = ["source", "country", "item", "unit", "constant", "n_values", "year_first",
-                "year_last", "series_n", "grid", "finest_elsewhere", "n_finer_elsewhere"]
+                "year_last", "series_n", "grid", "finest_elsewhere", "n_finer_elsewhere",
+                "finer_in_volume_year", "finer_in_volume_value"]
         if args.check:
             if not os.path.exists(OUT):
                 print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)

--- a/pipelines/polity-autoimprove/state/constant_runs.csv
+++ b/pipelines/polity-autoimprove/state/constant_runs.csv
@@ -1,247 +1,247 @@
-source,country,item,unit,constant,n_values,year_first,year_last,series_n,grid,finest_elsewhere,n_finer_elsewhere
-juan,iceland,potatoes,ha,1000.000,20,1933,1957,21,1000,400.000,1
-juan,malta,grapes,ha,1000.000,20,1933,1956,33,1000,600.000,11
-juan,luxembourg,grapes,ha,1000.000,17,1933,1959,45,1000,1200.000,28
-juan,norway,wheat,ha,5000.000,15,1900,1914,64,1000,4300.000,20
-juan,colombia,cocoa beans,tonnes,3000.000,14,1901,1914,60,1000,3670.900,21
-juan,luxembourg,grain mixed,ha,1000.000,14,1939,1953,38,1000,2400.000,11
-juan,costa rica,tobacco unmanufactured,ha,1000.000,13,1939,1955,32,1000,417.000,15
-juan,switzerland,tobacco unmanufactured,ha,1000.000,13,1933,1945,59,1000,100.000,34
-juan,malta,barley,ha,2000.000,12,1943,1956,47,1000,1700.000,22
-juan,malta,wheat,ha,2000.000,12,1944,1959,45,1000,3500.000,22
-juan,switzerland,tobacco unmanufactured,ha,1000.000,12,1948,1959,59,1000,100.000,34
-iia,australia,lemons and limes,ha,2000.000,11,1933,1944,14,1000,896.000,3
-iia,grenada,cotton lint,tonnes,100.000,11,1935,1945,31,100,16.200,18
-iia,new zealand,tobacco unmanufactured,ha,1000.000,11,1934,1945,20,1000,11.000,9
-juan,italy,sesame seed,ha,1000.000,11,1945,1955,26,1000,337.000,10
-juan,switzerland,maize,ha,1000.000,11,1930,1940,53,1000,1100.000,23
-iia,india,sesame seed,ha,1000.000,10,1934,1945,18,1000,2016349.000,8
-iia,south africa,tea,ha,1000.000,10,1933,1943,27,1000,785.000,17
-iia,viet nam,cotton lint,tonnes,100.000,10,1934,1944,14,100,20.000,4
-juan,argentina,soybeans,ha,1000.000,10,1950,1960,19,1000,2.000,9
-juan,denmark,potatoes,ha,54000.000,10,1902,1911,85,1000,54100.000,21
-iia,australia,wine,ha,20000.000,9,1935,1944,16,10000,18787.000,7
-iia,niger,tobacco unmanufactured,ha,1000.000,9,1934,1944,13,1000,200.000,4
-iia,saint lucia,lemons and limes,ha,1000.000,9,1934,1945,12,1000,1070.000,3
-iia,saint vincent and the grenadines,cacao beans,ha,400.000,9,1909,1917,18,100,305.000,2
-iia,trinidad and tobago,coffee green,ha,1700.000,9,1909,1917,20,100,320.000,7
-juan,denmark,potatoes,ha,52000.000,9,1888,1896,85,1000,54100.000,21
-juan,france,hemp tow waste,ha,4000.000,9,1936,1944,89,1000,2300.000,33
-juan,france,hempseed,ha,4000.000,9,1936,1944,89,1000,2300.000,33
-juan,mexico,cocoa beans,tonnes,1000.000,9,1901,1909,60,1000,547.200,33
-juan,switzerland,grapes,ha,11000.000,9,1940,1948,66,1000,12300.000,29
-iia,cyprus,flax fibre and tow,ha,1000.000,8,1934,1942,12,1000,349.000,4
-iia,dominica,lemons and limes,ha,1000.000,8,1936,1944,12,1000,400.000,4
-iia,fiji,tea,ha,80.000,8,1911,1918,15,10,81.000,6
-iia,guadeloupe,cacao beans,ha,3000.000,8,1930,1937,22,1000,4750.000,1
-iia,india,sesame seed,tonnes,300.000,8,1934,1943,18,100,425723.700,8
-iia,sri lanka,cacao beans,ha,14000.000,8,1930,1937,20,1000,9461.000,12
-iia,viet nam,cotton lint,ha,1000.000,8,1934,1942,14,1000,997.000,4
-iia,viet nam,cotton seed,ha,1000.000,8,1934,1942,14,1000,997.000,4
-iia,viet nam,other berries and fruits of the genus vaccinium n e c,ha,2000.000,8,1934,1942,14,1000,2611.000,4
-juan,austria,beans dry,tonnes,2000.000,8,1950,1958,25,1000,1600.000,10
-juan,ireland,rye,ha,1000.000,8,1933,1941,56,1000,900.000,32
-juan,italy,groundnuts with shell,ha,5000.000,8,1953,1960,26,1000,200.000,1
-juan,italy,oranges,ha,33000.000,8,1935,1942,27,1000,32679.000,15
-juan,malta,barley,ha,2000.000,8,1933,1940,47,1000,1700.000,22
-juan,malta,wheat,tonnes,3000.000,8,1949,1959,45,1000,270.000,34
-juan,malta,wheat,ha,4000.000,8,1933,1940,45,1000,3500.000,22
-juan,mexico,cocoa beans,tonnes,2000.000,8,1910,1917,60,1000,547.200,33
-juan,nicaragua,tobacco unmanufactured,ha,1000.000,8,1933,1959,12,1000,1048.000,3
-juan,spain,apricots,ha,3700.000,8,1939,1946,98,100,925.650,76
-iia,algeria,rye,ha,2000.000,7,1938,1944,33,1000,91.000,21
-iia,algeria,tangerines mandarins clementines satsumas,ha,5000.000,7,1937,1944,14,1000,3453.000,3
-iia,cameroon,cacao beans,ha,50000.000,7,1939,1945,15,10000,12140.000,5
-iia,guadeloupe,cotton seed,tonnes,100.000,7,1935,1941,15,100,12.000,7
-iia,guyana,coffee green,ha,1000.000,7,1939,1945,31,1000,514.000,20
-iia,ivory coast,tobacco unmanufactured,ha,2000.000,7,1934,1943,11,1000,85.000,2
-iia,malta,wine,ha,1000.000,7,1934,1945,15,1000,651.000,8
-iia,montserrat,lemons and limes,tonnes,600.000,7,1939,1945,15,100,241.900,3
-iia,new caledonia,coffee green,ha,4000.000,7,1939,1945,16,1000,700.000,2
-iia,portugal,oranges,tonnes,100.000,7,1939,1945,11,100,30.000,3
-iia,saint lucia,cacao beans,ha,2400.000,7,1910,1916,28,100,2145.000,1
-iia,viet nam,groundnuts with shell,ha,2000.000,7,1934,1941,14,1000,1270.000,4
-juan,albania,potatoes,ha,1000.000,7,1937,1951,12,1000,400.000,3
-juan,argentina,soybeans,tonnes,1000.000,7,1951,1960,15,1000,270.000,8
-juan,austria,grapes,ha,207000.000,7,1878,1884,92,1000,29600.000,28
-juan,austria,hemp tow waste,ha,1000.000,7,1940,1953,38,1000,100.000,30
-juan,austria,hempseed,ha,1000.000,7,1940,1953,38,1000,100.000,30
-juan,bolivia,tobacco unmanufactured,tonnes,1000.000,7,1954,1960,10,1000,4100.000,1
-juan,bulgaria,berries nes,ha,4000.000,7,1933,1939,24,1000,2306.000,10
-juan,canada,hops,ha,400.000,7,1953,1959,42,100,135.000,20
-juan,chile,rye,ha,8000.000,7,1954,1960,50,1000,1064.000,26
-juan,costa rica,potatoes,ha,1000.000,7,1939,1945,19,1000,692.000,8
-juan,ecuador,cotton lint,tonnes,3000.000,7,1954,1960,17,1000,1400.000,7
-juan,france,hops,ha,3000.000,7,1886,1892,86,1000,300.000,57
-juan,honduras,potatoes,ha,1000.000,7,1953,1959,13,1000,1661.000,1
-juan,hungary,hops,ha,100.000,7,1932,1938,33,100,2226.248,4
-juan,norway,barley,ha,35900.000,7,1907,1913,64,100,50433.000,4
-juan,norway,rye,ha,13000.000,7,1900,1906,64,1000,500.000,26
-juan,norway,rye,ha,15000.000,7,1907,1913,64,1000,500.000,26
-juan,sweden,wheat,ha,71000.000,7,1890,1896,96,1000,78900.000,31
-juan,switzerland,maize,ha,1000.000,7,1953,1959,53,1000,1100.000,23
-juan,switzerland,sugar beet,ha,6000.000,7,1953,1959,52,1000,400.000,29
-mitchell,dr congo,goats,heads,500000.000,7,1919,1925,26,100000,1109000.000,19
-mitchell,mozambique,sugar cane,ha,30000.000,7,1949,1955,14,10000,16000.000,7
-iia,australia,hops,ha,500.000,6,1939,1944,28,100,47.000,17
-iia,australia,oranges,ha,14000.000,6,1939,1944,14,1000,15366.000,3
-iia,bulgaria,other berries and fruits of the genus vaccinium n e c,ha,4000.000,6,1934,1939,19,1000,2306.000,8
-iia,congo,cacao beans,tonnes,1700.000,6,1940,1945,17,100,73.700,6
-iia,czech republic,hemp tow waste,ha,5000.000,6,1939,1944,10,1000,477.000,3
-iia,czech republic,hempseed,ha,5000.000,6,1939,1944,17,1000,6228.000,8
-iia,egypt,grapes,ha,3000.000,6,1934,1939,25,1000,1716.000,15
-iia,france,eggs hen in shell,tonnes,5.390,6,1939,1944,10,0.01,7.762,2
-iia,grenada,cotton lint,ha,2000.000,6,1933,1938,18,1000,1291.000,12
-iia,grenada,cotton seed,ha,2000.000,6,1933,1938,12,1000,1310.000,6
-iia,guadeloupe,coffee green,ha,7000.000,6,1918,1930,23,1000,6508.000,4
-iia,madagascar,cacao beans,ha,1000.000,6,1940,1945,9,1000,1067.000,3
-iia,montserrat,sugar raw centrifugal,tonnes,400.000,6,1939,1944,13,100,56.000,2
-iia,morocco,tobacco unmanufactured,ha,1000.000,6,1939,1944,10,1000,92.000,4
-iia,new zealand,hops,ha,200.000,6,1939,1944,27,100,144.000,17
-iia,saint lucia,cacao beans,ha,2000.000,6,1933,1939,28,1000,2145.000,17
-iia,saint lucia,cacao beans,tonnes,300.000,6,1933,1939,31,100,307.700,20
-iia,saint lucia,lemons and limes,tonnes,100.000,6,1939,1944,14,100,6988.300,3
-iia,saint vincent and the grenadines,cotton lint,ha,2000.000,6,1936,1941,33,1000,271.000,21
-iia,saint vincent and the grenadines,cotton seed,ha,2000.000,6,1936,1941,20,1000,271.000,8
-iia,suriname,oranges,ha,1000.000,6,1939,1944,9,1000,86.000,3
-iia,thailand,sesame seed,ha,1000.000,6,1933,1939,16,1000,771.000,5
-iia,zimbabwe,groundnuts with shell,ha,2000.000,6,1935,1941,18,1000,1992.000,6
-juan,albania,tobacco unmanufactured,ha,2000.000,6,1934,1939,18,1000,800.000,3
-juan,austria,hemp tow waste,tonnes,100.000,6,1933,1939,46,100,140.000,21
-juan,belgium,rapeseed,tonnes,100.000,6,1933,1941,47,100,80.000,22
-juan,brazil,tea,tonnes,700.000,6,1953,1958,21,100,236.000,11
-juan,canada,grapes,ha,9000.000,6,1951,1957,16,1000,3969.000,7
-juan,chile,hemp tow waste,ha,4000.000,6,1952,1958,32,1000,61.000,13
-juan,chile,hempseed,ha,4000.000,6,1952,1958,33,1000,61.000,14
-juan,costa rica,oranges,tonnes,1000.000,6,1946,1951,16,1000,100.000,10
-juan,czechoslovakia,hemp tow waste,ha,5000.000,6,1939,1944,37,1000,10.117,17
-juan,czechoslovakia,hempseed,ha,5000.000,6,1939,1944,37,1000,10.117,17
-juan,dominican republic,geese and guinea fowls,heads,1000.000,6,1947,1952,7,1000,3400.000,1
-juan,france,hemp tow waste,ha,2000.000,6,1954,1959,89,1000,2300.000,33
-juan,france,hempseed,ha,2000.000,6,1954,1959,89,1000,2300.000,33
-juan,france,hops,ha,1400.000,6,1953,1958,86,100,3090.000,8
-juan,france,oranges,tonnes,1000.000,6,1954,1959,32,1000,100.000,17
-juan,france,tangerines mandarins clementines satsumas,tonnes,300.000,6,1934,1940,18,100,70.000,7
-juan,haiti,cotton lint,tonnes,1000.000,6,1954,1959,40,1000,1302.000,26
-juan,ireland,rye,ha,1000.000,6,1954,1959,56,1000,900.000,32
-juan,italy,lemons and limes,ha,27750.000,6,1935,1940,27,10,30628.000,8
-juan,malta,maize,tonnes,100.000,6,1937,1943,15,100,110.000,2
-juan,mexico,broad beans horse beans dry,tonnes,19000.000,6,1946,1951,34,1000,7372.240,21
-juan,mexico,lentils,tonnes,3000.000,6,1953,1959,27,1000,399.983,16
-juan,mexico,lentils,ha,4000.000,6,1953,1959,27,1000,1262.000,16
-juan,netherlands,grapes,ha,1000.000,6,1946,1951,12,1000,400.000,6
-juan,norway,barley,ha,39500.000,6,1901,1906,64,100,50433.000,4
-juan,paraguay,potatoes,ha,1000.000,6,1940,1960,10,1000,70.000,4
-juan,spain,olives,ha,1123000.000,6,1891,1896,98,1000,869150.000,73
-juan,sweden,flax fibre and tow,tonnes,100.000,6,1933,1940,50,100,80.000,23
-juan,switzerland,barley,ha,4000.000,6,1933,1938,57,1000,5100.000,21
-juan,switzerland,cereals nes,ha,12000.000,6,1933,1938,52,1000,4500.000,32
-juan,switzerland,grain mixed,ha,7000.000,6,1933,1938,35,1000,2900.000,11
-juan,uruguay,rice paddy,ha,5000.000,6,1936,1942,28,1000,390.000,3
-juan,uruguay,sugar beet,ha,1000.000,6,1934,1941,25,1000,607.000,9
-juan,uruguay,tobacco unmanufactured,ha,1000.000,6,1934,1941,35,1000,253.000,26
-juan,yugoslav sfr,linseed,tonnes,1000.000,6,1951,1959,22,1000,300.000,12
-juan,yugoslav sfr,sesame seed,ha,1000.000,6,1934,1939,20,1000,200.000,4
-mitchell,cameroon,cattle,heads,1250000.000,6,1951,1956,35,10000,291000.000,17
-mitchell,jamaica,goats,heads,350000.000,6,1950,1955,10,10000,224000.000,4
-mitchell,sri lanka,rice paddy,ha,340000.000,6,1931,1936,99,10000,135000.000,83
-iia,angola,sesame seed,ha,2000.000,5,1937,1942,10,1000,2047.000,2
-iia,austria,n,tonnes,24000.000,5,1914,1918,12,1000,4500.000,6
-iia,chile,raisins,tonnes,2000.000,5,1939,1943,8,1000,800.000,3
-iia,cyprus,sesame seed,ha,1000.000,5,1941,1945,20,1000,562.000,8
-iia,czech republic,yarn of true hemp,ha,7000.000,5,1934,1938,13,1000,6240.000,8
-iia,egypt,oranges,ha,10000.000,5,1938,1944,13,10000,5325.000,8
-iia,grenada,cotton seed,tonnes,300.000,5,1935,1939,18,100,276.000,6
-iia,guadeloupe,cacao beans,ha,5000.000,5,1918,1925,22,1000,4750.000,1
-iia,kenya,tea,ha,6000.000,5,1939,1943,15,1000,4068.000,4
-iia,madagascar,wine,tonnes,291.000,5,1934,1941,12,1,261.900,2
-iia,malawi,tea,ha,8000.000,5,1941,1945,32,1000,210.000,21
-iia,martinique,cacao beans,tonnes,100.000,5,1941,1945,29,100,171.900,18
-iia,mauritius,tea,ha,150.000,5,1911,1915,24,10,45.000,4
-iia,mauritius,tea,tonnes,38.000,5,1911,1915,27,1,16.200,1
-iia,papua new guinea,cacao beans,ha,1000.000,5,1933,1937,15,1000,238.000,10
-iia,saint kitts and nevis,cotton lint,ha,2000.000,5,1936,1940,33,1000,154.000,20
-iia,saint kitts and nevis,cotton seed,ha,2000.000,5,1936,1940,20,1000,154.000,7
-iia,saint lucia,cacao beans,ha,2400.000,5,1922,1930,28,100,2145.000,1
-iia,saint lucia,cacao beans,ha,1000.000,5,1940,1944,28,1000,2145.000,17
-iia,saint lucia,cacao beans,tonnes,200.000,5,1940,1944,31,100,307.700,20
-iia,serbia,sesame seed,ha,1000.000,5,1934,1938,10,1000,350.000,4
-iia,sri lanka,tobacco unmanufactured,ha,6000.000,5,1934,1938,22,1000,5109.000,17
-iia,united states of america,n,tonnes,58000.000,5,1914,1918,15,1000,62131.000,4
-iia,viet nam,coffee green,ha,2000.000,5,1939,1943,13,1000,3190.000,4
-juan,argentina,cotton lint,tonnes,400.000,5,1906,1910,61,100,540.000,15
-juan,austria,grapes,ha,40000.000,5,1941,1945,92,10000,27000.000,85
-juan,belgium,cherries,tonnes,30000.000,5,1952,1956,9,10000,12000.000,1
-juan,belgium,tobacco unmanufactured,ha,3000.000,5,1933,1937,52,1000,1400.000,24
-juan,belgium,tobacco unmanufactured,ha,1000.000,5,1955,1959,52,1000,1400.000,24
-juan,bulgaria,berries nes,ha,4000.000,5,1941,1945,24,1000,2306.000,10
-juan,bulgaria,grapes,ha,146000.000,5,1947,1954,56,1000,43400.000,25
-juan,chile,grapes,ha,108000.000,5,1955,1960,54,1000,29680.000,25
-juan,colombia,cocoa beans,tonnes,4000.000,5,1919,1923,60,1000,3670.900,21
-juan,costa rica,sugar cane,tonnes,3000.000,5,1910,1914,26,1000,28240.000,8
-juan,costa rica,sugar cane,tonnes,5000.000,5,1919,1923,26,1000,28240.000,8
-juan,cuba,grapefruit inc pomelos,tonnes,7000.000,5,1954,1958,21,1000,1178.300,9
-juan,czechoslovakia,hemp tow waste,ha,7000.000,5,1934,1938,37,1000,10.117,17
-juan,czechoslovakia,hempseed,ha,7000.000,5,1934,1938,37,1000,10.117,17
-juan,czechoslovakia,tobacco unmanufactured,ha,10000.000,5,1933,1937,35,10000,1200.000,28
-juan,denmark,barley,ha,233700.000,5,1907,1911,85,100,269804.000,4
-juan,denmark,rye,ha,276000.000,5,1907,1911,85,1000,120325.000,26
-juan,dominican republic,horses,heads,242000.000,5,1955,1959,20,1000,114733.000,6
-juan,ecuador,rye,tonnes,4000.000,5,1956,1960,15,1000,3700.000,3
-juan,el salvador,tobacco unmanufactured,ha,1000.000,5,1955,1959,15,1000,400.000,5
-juan,finland,sugar beet,ha,3000.000,5,1933,1937,42,1000,600.000,9
-juan,france,hops,ha,2000.000,5,1896,1900,86,1000,300.000,57
-juan,france,lentils,ha,6000.000,5,1926,1930,51,1000,6471.000,16
-juan,france,tobacco unmanufactured,ha,16000.000,5,1895,1899,88,1000,7900.000,42
-juan,germany,grapes,ha,120000.000,5,1883,1887,78,10000,53000.000,70
-juan,germany,hemp tow waste,ha,1000.000,5,1949,1954,41,1000,200.000,17
-juan,germany,hempseed,ha,1000.000,5,1949,1954,41,1000,200.000,17
-juan,guatemala,groundnuts with shell,ha,1000.000,5,1939,1944,8,1000,5.000,3
-juan,haiti,coffee green,ha,141600.000,5,1928,1932,19,100,141690.000,1
-juan,haiti,horses,heads,400000.000,5,1932,1939,10,100000,110000.000,5
-juan,honduras,potatoes,tonnes,2000.000,5,1955,1959,12,1000,10474.200,1
-juan,ireland,flax fibre and tow,ha,2000.000,5,1935,1939,58,1000,100.000,37
-juan,ireland,linseed,ha,2000.000,5,1935,1939,58,1000,100.000,37
-juan,ireland,rye,tonnes,3000.000,5,1950,1955,56,1000,1300.000,43
-juan,italy,groundnuts with shell,ha,1000.000,5,1936,1940,26,1000,200.000,1
-juan,italy,groundnuts with shell,ha,4000.000,5,1948,1952,26,1000,200.000,1
-juan,italy,lentils,ha,26000.000,5,1950,1954,26,1000,20557.000,11
-juan,italy,linseed,tonnes,12000.000,5,1947,1951,52,1000,2200.000,34
-juan,italy,sesame seed,tonnes,300.000,5,1940,1944,26,100,373.900,1
-juan,italy,sesame seed,ha,2000.000,5,1956,1960,26,1000,337.000,10
-juan,italy,soybeans,ha,1000.000,5,1949,1953,25,1000,6.000,15
-juan,italy,soybeans,ha,300.000,5,1955,1959,25,100,6.000,9
-juan,italy,tangerines mandarins clementines satsumas,ha,10250.000,5,1941,1945,27,10,7766.000,5
-juan,luxembourg,rye,ha,4000.000,5,1955,1959,48,1000,4100.000,24
-juan,malta,potatoes,ha,4000.000,5,1936,1940,49,1000,1300.000,23
-juan,mexico,cocoa beans,tonnes,2000.000,5,1919,1923,60,1000,547.200,33
-juan,mexico,lentils,tonnes,2000.000,5,1946,1951,27,1000,399.983,16
-juan,mexico,lentils,ha,3000.000,5,1946,1951,27,1000,1262.000,16
-juan,mexico,peas dry,ha,7000.000,5,1946,1955,24,1000,3480.000,16
-juan,mexico,sweet potatoes,ha,12000.000,5,1948,1953,33,1000,5405.000,21
-juan,norway,grain mixed,ha,4000.000,5,1947,1951,48,1000,5400.000,15
-juan,norway,grain mixed,ha,2000.000,5,1956,1960,48,1000,5400.000,15
-juan,norway,rye,ha,6000.000,5,1933,1937,64,1000,500.000,26
-juan,norway,rye,ha,1000.000,5,1947,1951,64,1000,500.000,26
-juan,norway,rye,ha,1000.000,5,1953,1957,64,1000,500.000,26
-juan,paraguay,coffee green,tonnes,100.000,5,1940,1944,20,100,72.500,14
-juan,paraguay,groundnuts with shell,tonnes,10000.000,5,1954,1958,29,10000,4000.000,24
-juan,puerto rico,grapefruit inc pomelos,tonnes,19000.000,5,1948,1953,25,1000,300.000,11
-juan,puerto rico,rice paddy,tonnes,2000.000,5,1955,1959,14,1000,800.000,3
-juan,spain,carobs,ha,152000.000,5,1950,1954,98,1000,96333.495,76
-juan,spain,cherries,ha,1000.000,5,1941,1945,98,1000,271.845,93
-juan,spain,millet,ha,1000.000,5,1955,1959,101,1000,34.792,96
-juan,spain,plums and sloes,ha,2400.000,5,1948,1952,98,100,353.571,75
-juan,spain,tangerines mandarins clementines satsumas,tonnes,71900.000,5,1939,1943,98,100,23280.161,92
-juan,sweden,flax fibre and tow,ha,500.000,5,1929,1933,52,100,2722.000,1
-juan,sweden,tobacco unmanufactured,tonnes,300.000,5,1950,1955,55,100,384.000,40
-juan,switzerland,maize,tonnes,4000.000,5,1953,1957,53,1000,2100.000,35
-juan,united states of america,oil olive virgin,tonnes,700.000,5,1932,1936,46,100,192.913,16
-juan,uruguay,grapes,ha,18000.000,5,1943,1949,52,1000,3610.000,29
-juan,yugoslav sfr,rice paddy,ha,3000.000,5,1934,1938,29,1000,1100.000,8
-mitchell,australia,rice paddy,ha,10000.000,5,1937,1941,35,10000,1000.000,27
-mitchell,dr congo,sheep,heads,300000.000,5,1919,1923,26,100000,244000.000,20
-mitchell,indonesia,tea,tonnes,1000.000,5,1858,1862,104,1000,700.000,39
-mitchell,lebanon,wheat,ha,70000.000,5,1953,1957,20,10000,53000.000,11
-mitchell,senegal,rice paddy,ha,50000.000,5,1922,1926,37,10000,31000.000,24
-mitchell,sierra leone,rice paddy,tonnes,190000.000,5,1940,1944,42,10000,102000.000,30
+source,country,item,unit,constant,n_values,year_first,year_last,series_n,grid,finest_elsewhere,n_finer_elsewhere,finer_in_volume_year,finer_in_volume_value
+juan,iceland,potatoes,ha,1000.000,20,1933,1957,21,1000,400.000,1,,
+juan,malta,grapes,ha,1000.000,20,1933,1956,33,1000,600.000,11,,
+juan,luxembourg,grapes,ha,1000.000,17,1933,1959,45,1000,1200.000,28,,
+juan,norway,wheat,ha,5000.000,15,1900,1914,64,1000,4300.000,20,,
+juan,colombia,cocoa beans,tonnes,3000.000,14,1901,1914,60,1000,3670.900,21,,
+juan,luxembourg,grain mixed,ha,1000.000,14,1939,1953,38,1000,2400.000,11,,
+juan,costa rica,tobacco unmanufactured,ha,1000.000,13,1939,1955,32,1000,417.000,15,,
+juan,switzerland,tobacco unmanufactured,ha,1000.000,13,1933,1945,59,1000,100.000,34,,
+juan,malta,barley,ha,2000.000,12,1943,1956,47,1000,1700.000,22,,
+juan,malta,wheat,ha,2000.000,12,1944,1959,45,1000,3500.000,22,,
+juan,switzerland,tobacco unmanufactured,ha,1000.000,12,1948,1959,59,1000,100.000,34,,
+iia,australia,lemons and limes,ha,2000.000,11,1933,1944,14,1000,896.000,3,1930,896.000
+iia,grenada,cotton lint,tonnes,100.000,11,1935,1945,31,100,16.200,18,,
+iia,new zealand,tobacco unmanufactured,ha,1000.000,11,1934,1945,20,1000,11.000,9,,
+juan,italy,sesame seed,ha,1000.000,11,1945,1955,26,1000,337.000,10,,
+juan,switzerland,maize,ha,1000.000,11,1930,1940,53,1000,1100.000,23,,
+iia,india,sesame seed,ha,1000.000,10,1934,1945,18,1000,2016349.000,8,,
+iia,south africa,tea,ha,1000.000,10,1933,1943,27,1000,785.000,17,1930,799.000
+iia,viet nam,cotton lint,tonnes,100.000,10,1934,1944,14,100,20.000,4,,
+juan,argentina,soybeans,ha,1000.000,10,1950,1960,19,1000,2.000,9,,
+juan,denmark,potatoes,ha,54000.000,10,1902,1911,85,1000,54100.000,21,,
+iia,australia,wine,ha,20000.000,9,1935,1944,16,10000,18787.000,7,1934,19000.000
+iia,niger,tobacco unmanufactured,ha,1000.000,9,1934,1944,13,1000,200.000,4,,
+iia,saint lucia,lemons and limes,ha,1000.000,9,1934,1945,12,1000,1070.000,3,,
+iia,saint vincent and the grenadines,cacao beans,ha,400.000,9,1909,1917,18,100,305.000,2,,
+iia,trinidad and tobago,coffee green,ha,1700.000,9,1909,1917,20,100,320.000,7,1919,3593.000
+juan,denmark,potatoes,ha,52000.000,9,1888,1896,85,1000,54100.000,21,,
+juan,france,hemp tow waste,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,
+juan,france,hempseed,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,
+juan,mexico,cocoa beans,tonnes,1000.000,9,1901,1909,60,1000,547.200,33,,
+juan,switzerland,grapes,ha,11000.000,9,1940,1948,66,1000,12300.000,29,,
+iia,cyprus,flax fibre and tow,ha,1000.000,8,1934,1942,12,1000,349.000,4,,
+iia,dominica,lemons and limes,ha,1000.000,8,1936,1944,12,1000,400.000,4,,
+iia,fiji,tea,ha,80.000,8,1911,1918,15,10,81.000,6,1909,82.000
+iia,guadeloupe,cacao beans,ha,3000.000,8,1930,1937,22,1000,4750.000,1,,
+iia,india,sesame seed,tonnes,300.000,8,1934,1943,18,100,425723.700,8,,
+iia,sri lanka,cacao beans,ha,14000.000,8,1930,1937,20,1000,9461.000,12,,
+iia,viet nam,cotton lint,ha,1000.000,8,1934,1942,14,1000,997.000,4,,
+iia,viet nam,cotton seed,ha,1000.000,8,1934,1942,14,1000,997.000,4,,
+iia,viet nam,other berries and fruits of the genus vaccinium n e c,ha,2000.000,8,1934,1942,14,1000,2611.000,4,,
+juan,austria,beans dry,tonnes,2000.000,8,1950,1958,25,1000,1600.000,10,,
+juan,ireland,rye,ha,1000.000,8,1933,1941,56,1000,900.000,32,,
+juan,italy,groundnuts with shell,ha,5000.000,8,1953,1960,26,1000,200.000,1,,
+juan,italy,oranges,ha,33000.000,8,1935,1942,27,1000,32679.000,15,,
+juan,malta,barley,ha,2000.000,8,1933,1940,47,1000,1700.000,22,,
+juan,malta,wheat,tonnes,3000.000,8,1949,1959,45,1000,270.000,34,,
+juan,malta,wheat,ha,4000.000,8,1933,1940,45,1000,3500.000,22,,
+juan,mexico,cocoa beans,tonnes,2000.000,8,1910,1917,60,1000,547.200,33,,
+juan,nicaragua,tobacco unmanufactured,ha,1000.000,8,1933,1959,12,1000,1048.000,3,,
+juan,spain,apricots,ha,3700.000,8,1939,1946,98,100,925.650,76,,
+iia,algeria,rye,ha,2000.000,7,1938,1944,33,1000,91.000,21,,
+iia,algeria,tangerines mandarins clementines satsumas,ha,5000.000,7,1937,1944,14,1000,3453.000,3,,
+iia,cameroon,cacao beans,ha,50000.000,7,1939,1945,15,10000,12140.000,5,,
+iia,guadeloupe,cotton seed,tonnes,100.000,7,1935,1941,15,100,12.000,7,,
+iia,guyana,coffee green,ha,1000.000,7,1939,1945,31,1000,514.000,20,,
+iia,ivory coast,tobacco unmanufactured,ha,2000.000,7,1934,1943,11,1000,85.000,2,,
+iia,malta,wine,ha,1000.000,7,1934,1945,15,1000,651.000,8,,
+iia,montserrat,lemons and limes,tonnes,600.000,7,1939,1945,15,100,241.900,3,,
+iia,new caledonia,coffee green,ha,4000.000,7,1939,1945,16,1000,700.000,2,,
+iia,portugal,oranges,tonnes,100.000,7,1939,1945,11,100,30.000,3,,
+iia,saint lucia,cacao beans,ha,2400.000,7,1910,1916,28,100,2145.000,1,,
+iia,viet nam,groundnuts with shell,ha,2000.000,7,1934,1941,14,1000,1270.000,4,,
+juan,albania,potatoes,ha,1000.000,7,1937,1951,12,1000,400.000,3,,
+juan,argentina,soybeans,tonnes,1000.000,7,1951,1960,15,1000,270.000,8,,
+juan,austria,grapes,ha,207000.000,7,1878,1884,92,1000,29600.000,28,,
+juan,austria,hemp tow waste,ha,1000.000,7,1940,1953,38,1000,100.000,30,,
+juan,austria,hempseed,ha,1000.000,7,1940,1953,38,1000,100.000,30,,
+juan,bolivia,tobacco unmanufactured,tonnes,1000.000,7,1954,1960,10,1000,4100.000,1,,
+juan,bulgaria,berries nes,ha,4000.000,7,1933,1939,24,1000,2306.000,10,,
+juan,canada,hops,ha,400.000,7,1953,1959,42,100,135.000,20,,
+juan,chile,rye,ha,8000.000,7,1954,1960,50,1000,1064.000,26,,
+juan,costa rica,potatoes,ha,1000.000,7,1939,1945,19,1000,692.000,8,,
+juan,ecuador,cotton lint,tonnes,3000.000,7,1954,1960,17,1000,1400.000,7,,
+juan,france,hops,ha,3000.000,7,1886,1892,86,1000,300.000,57,,
+juan,honduras,potatoes,ha,1000.000,7,1953,1959,13,1000,1661.000,1,,
+juan,hungary,hops,ha,100.000,7,1932,1938,33,100,2226.248,4,,
+juan,norway,barley,ha,35900.000,7,1907,1913,64,100,50433.000,4,,
+juan,norway,rye,ha,13000.000,7,1900,1906,64,1000,500.000,26,,
+juan,norway,rye,ha,15000.000,7,1907,1913,64,1000,500.000,26,,
+juan,sweden,wheat,ha,71000.000,7,1890,1896,96,1000,78900.000,31,,
+juan,switzerland,maize,ha,1000.000,7,1953,1959,53,1000,1100.000,23,,
+juan,switzerland,sugar beet,ha,6000.000,7,1953,1959,52,1000,400.000,29,,
+mitchell,dr congo,goats,heads,500000.000,7,1919,1925,26,100000,1109000.000,19,,
+mitchell,mozambique,sugar cane,ha,30000.000,7,1949,1955,14,10000,16000.000,7,,
+iia,australia,hops,ha,500.000,6,1939,1944,28,100,47.000,17,,
+iia,australia,oranges,ha,14000.000,6,1939,1944,14,1000,15366.000,3,,
+iia,bulgaria,other berries and fruits of the genus vaccinium n e c,ha,4000.000,6,1934,1939,19,1000,2306.000,8,,
+iia,congo,cacao beans,tonnes,1700.000,6,1940,1945,17,100,73.700,6,,
+iia,czech republic,hemp tow waste,ha,5000.000,6,1939,1944,10,1000,477.000,3,,
+iia,czech republic,hempseed,ha,5000.000,6,1939,1944,17,1000,6228.000,8,,
+iia,egypt,grapes,ha,3000.000,6,1934,1939,25,1000,1716.000,15,,
+iia,france,eggs hen in shell,tonnes,5.390,6,1939,1944,10,0.01,7.762,2,,
+iia,grenada,cotton lint,ha,2000.000,6,1933,1938,18,1000,1291.000,12,1930,1600.000
+iia,grenada,cotton seed,ha,2000.000,6,1933,1938,12,1000,1310.000,6,1930,1600.000
+iia,guadeloupe,coffee green,ha,7000.000,6,1918,1930,23,1000,6508.000,4,1911,6508.000
+iia,madagascar,cacao beans,ha,1000.000,6,1940,1945,9,1000,1067.000,3,,
+iia,montserrat,sugar raw centrifugal,tonnes,400.000,6,1939,1944,13,100,56.000,2,,
+iia,morocco,tobacco unmanufactured,ha,1000.000,6,1939,1944,10,1000,92.000,4,,
+iia,new zealand,hops,ha,200.000,6,1939,1944,27,100,144.000,17,,
+iia,saint lucia,cacao beans,ha,2000.000,6,1933,1939,28,1000,2145.000,17,1930,2400.000
+iia,saint lucia,cacao beans,tonnes,300.000,6,1933,1939,31,100,307.700,20,1930,529.300
+iia,saint lucia,lemons and limes,tonnes,100.000,6,1939,1944,14,100,6988.300,3,,
+iia,saint vincent and the grenadines,cotton lint,ha,2000.000,6,1936,1941,33,1000,271.000,21,,
+iia,saint vincent and the grenadines,cotton seed,ha,2000.000,6,1936,1941,20,1000,271.000,8,,
+iia,suriname,oranges,ha,1000.000,6,1939,1944,9,1000,86.000,3,,
+iia,thailand,sesame seed,ha,1000.000,6,1933,1939,16,1000,771.000,5,1930,883.000
+iia,zimbabwe,groundnuts with shell,ha,2000.000,6,1935,1941,18,1000,1992.000,6,,
+juan,albania,tobacco unmanufactured,ha,2000.000,6,1934,1939,18,1000,800.000,3,,
+juan,austria,hemp tow waste,tonnes,100.000,6,1933,1939,46,100,140.000,21,,
+juan,belgium,rapeseed,tonnes,100.000,6,1933,1941,47,100,80.000,22,,
+juan,brazil,tea,tonnes,700.000,6,1953,1958,21,100,236.000,11,,
+juan,canada,grapes,ha,9000.000,6,1951,1957,16,1000,3969.000,7,,
+juan,chile,hemp tow waste,ha,4000.000,6,1952,1958,32,1000,61.000,13,,
+juan,chile,hempseed,ha,4000.000,6,1952,1958,33,1000,61.000,14,,
+juan,costa rica,oranges,tonnes,1000.000,6,1946,1951,16,1000,100.000,10,,
+juan,czechoslovakia,hemp tow waste,ha,5000.000,6,1939,1944,37,1000,10.117,17,,
+juan,czechoslovakia,hempseed,ha,5000.000,6,1939,1944,37,1000,10.117,17,,
+juan,dominican republic,geese and guinea fowls,heads,1000.000,6,1947,1952,7,1000,3400.000,1,,
+juan,france,hemp tow waste,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,
+juan,france,hempseed,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,
+juan,france,hops,ha,1400.000,6,1953,1958,86,100,3090.000,8,,
+juan,france,oranges,tonnes,1000.000,6,1954,1959,32,1000,100.000,17,,
+juan,france,tangerines mandarins clementines satsumas,tonnes,300.000,6,1934,1940,18,100,70.000,7,,
+juan,haiti,cotton lint,tonnes,1000.000,6,1954,1959,40,1000,1302.000,26,,
+juan,ireland,rye,ha,1000.000,6,1954,1959,56,1000,900.000,32,,
+juan,italy,lemons and limes,ha,27750.000,6,1935,1940,27,10,30628.000,8,,
+juan,malta,maize,tonnes,100.000,6,1937,1943,15,100,110.000,2,,
+juan,mexico,broad beans horse beans dry,tonnes,19000.000,6,1946,1951,34,1000,7372.240,21,,
+juan,mexico,lentils,tonnes,3000.000,6,1953,1959,27,1000,399.983,16,,
+juan,mexico,lentils,ha,4000.000,6,1953,1959,27,1000,1262.000,16,,
+juan,netherlands,grapes,ha,1000.000,6,1946,1951,12,1000,400.000,6,,
+juan,norway,barley,ha,39500.000,6,1901,1906,64,100,50433.000,4,,
+juan,paraguay,potatoes,ha,1000.000,6,1940,1960,10,1000,70.000,4,,
+juan,spain,olives,ha,1123000.000,6,1891,1896,98,1000,869150.000,73,,
+juan,sweden,flax fibre and tow,tonnes,100.000,6,1933,1940,50,100,80.000,23,,
+juan,switzerland,barley,ha,4000.000,6,1933,1938,57,1000,5100.000,21,,
+juan,switzerland,cereals nes,ha,12000.000,6,1933,1938,52,1000,4500.000,32,,
+juan,switzerland,grain mixed,ha,7000.000,6,1933,1938,35,1000,2900.000,11,,
+juan,uruguay,rice paddy,ha,5000.000,6,1936,1942,28,1000,390.000,3,,
+juan,uruguay,sugar beet,ha,1000.000,6,1934,1941,25,1000,607.000,9,,
+juan,uruguay,tobacco unmanufactured,ha,1000.000,6,1934,1941,35,1000,253.000,26,,
+juan,yugoslav sfr,linseed,tonnes,1000.000,6,1951,1959,22,1000,300.000,12,,
+juan,yugoslav sfr,sesame seed,ha,1000.000,6,1934,1939,20,1000,200.000,4,,
+mitchell,cameroon,cattle,heads,1250000.000,6,1951,1956,35,10000,291000.000,17,,
+mitchell,jamaica,goats,heads,350000.000,6,1950,1955,10,10000,224000.000,4,,
+mitchell,sri lanka,rice paddy,ha,340000.000,6,1931,1936,99,10000,135000.000,83,,
+iia,angola,sesame seed,ha,2000.000,5,1937,1942,10,1000,2047.000,2,,
+iia,austria,n,tonnes,24000.000,5,1914,1918,12,1000,4500.000,6,1912,4500.000
+iia,chile,raisins,tonnes,2000.000,5,1939,1943,8,1000,800.000,3,1944,800.000
+iia,cyprus,sesame seed,ha,1000.000,5,1941,1945,20,1000,562.000,8,,
+iia,czech republic,yarn of true hemp,ha,7000.000,5,1934,1938,13,1000,6240.000,8,,
+iia,egypt,oranges,ha,10000.000,5,1938,1944,13,10000,5325.000,8,1934,9000.000
+iia,grenada,cotton seed,tonnes,300.000,5,1935,1939,18,100,276.000,6,,
+iia,guadeloupe,cacao beans,ha,5000.000,5,1918,1925,22,1000,4750.000,1,1912,4750.000
+iia,kenya,tea,ha,6000.000,5,1939,1943,15,1000,4068.000,4,,
+iia,madagascar,wine,tonnes,291.000,5,1934,1941,12,1,261.900,2,,
+iia,malawi,tea,ha,8000.000,5,1941,1945,32,1000,210.000,21,,
+iia,martinique,cacao beans,tonnes,100.000,5,1941,1945,29,100,171.900,18,,
+iia,mauritius,tea,ha,150.000,5,1911,1915,24,10,45.000,4,1916,125.000
+iia,mauritius,tea,tonnes,38.000,5,1911,1915,27,1,16.200,1,,
+iia,papua new guinea,cacao beans,ha,1000.000,5,1933,1937,15,1000,238.000,10,1930,402.000
+iia,saint kitts and nevis,cotton lint,ha,2000.000,5,1936,1940,33,1000,154.000,20,,
+iia,saint kitts and nevis,cotton seed,ha,2000.000,5,1936,1940,20,1000,154.000,7,,
+iia,saint lucia,cacao beans,ha,2400.000,5,1922,1930,28,100,2145.000,1,,
+iia,saint lucia,cacao beans,ha,1000.000,5,1940,1944,28,1000,2145.000,17,,
+iia,saint lucia,cacao beans,tonnes,200.000,5,1940,1944,31,100,307.700,20,,
+iia,serbia,sesame seed,ha,1000.000,5,1934,1938,10,1000,350.000,4,,
+iia,sri lanka,tobacco unmanufactured,ha,6000.000,5,1934,1938,22,1000,5109.000,17,,
+iia,united states of america,n,tonnes,58000.000,5,1914,1918,15,1000,62131.000,4,,
+iia,viet nam,coffee green,ha,2000.000,5,1939,1943,13,1000,3190.000,4,,
+juan,argentina,cotton lint,tonnes,400.000,5,1906,1910,61,100,540.000,15,,
+juan,austria,grapes,ha,40000.000,5,1941,1945,92,10000,27000.000,85,,
+juan,belgium,cherries,tonnes,30000.000,5,1952,1956,9,10000,12000.000,1,,
+juan,belgium,tobacco unmanufactured,ha,3000.000,5,1933,1937,52,1000,1400.000,24,,
+juan,belgium,tobacco unmanufactured,ha,1000.000,5,1955,1959,52,1000,1400.000,24,,
+juan,bulgaria,berries nes,ha,4000.000,5,1941,1945,24,1000,2306.000,10,,
+juan,bulgaria,grapes,ha,146000.000,5,1947,1954,56,1000,43400.000,25,,
+juan,chile,grapes,ha,108000.000,5,1955,1960,54,1000,29680.000,25,,
+juan,colombia,cocoa beans,tonnes,4000.000,5,1919,1923,60,1000,3670.900,21,,
+juan,costa rica,sugar cane,tonnes,3000.000,5,1910,1914,26,1000,28240.000,8,,
+juan,costa rica,sugar cane,tonnes,5000.000,5,1919,1923,26,1000,28240.000,8,,
+juan,cuba,grapefruit inc pomelos,tonnes,7000.000,5,1954,1958,21,1000,1178.300,9,,
+juan,czechoslovakia,hemp tow waste,ha,7000.000,5,1934,1938,37,1000,10.117,17,,
+juan,czechoslovakia,hempseed,ha,7000.000,5,1934,1938,37,1000,10.117,17,,
+juan,czechoslovakia,tobacco unmanufactured,ha,10000.000,5,1933,1937,35,10000,1200.000,28,,
+juan,denmark,barley,ha,233700.000,5,1907,1911,85,100,269804.000,4,,
+juan,denmark,rye,ha,276000.000,5,1907,1911,85,1000,120325.000,26,,
+juan,dominican republic,horses,heads,242000.000,5,1955,1959,20,1000,114733.000,6,,
+juan,ecuador,rye,tonnes,4000.000,5,1956,1960,15,1000,3700.000,3,,
+juan,el salvador,tobacco unmanufactured,ha,1000.000,5,1955,1959,15,1000,400.000,5,,
+juan,finland,sugar beet,ha,3000.000,5,1933,1937,42,1000,600.000,9,,
+juan,france,hops,ha,2000.000,5,1896,1900,86,1000,300.000,57,,
+juan,france,lentils,ha,6000.000,5,1926,1930,51,1000,6471.000,16,,
+juan,france,tobacco unmanufactured,ha,16000.000,5,1895,1899,88,1000,7900.000,42,,
+juan,germany,grapes,ha,120000.000,5,1883,1887,78,10000,53000.000,70,,
+juan,germany,hemp tow waste,ha,1000.000,5,1949,1954,41,1000,200.000,17,,
+juan,germany,hempseed,ha,1000.000,5,1949,1954,41,1000,200.000,17,,
+juan,guatemala,groundnuts with shell,ha,1000.000,5,1939,1944,8,1000,5.000,3,,
+juan,haiti,coffee green,ha,141600.000,5,1928,1932,19,100,141690.000,1,,
+juan,haiti,horses,heads,400000.000,5,1932,1939,10,100000,110000.000,5,,
+juan,honduras,potatoes,tonnes,2000.000,5,1955,1959,12,1000,10474.200,1,,
+juan,ireland,flax fibre and tow,ha,2000.000,5,1935,1939,58,1000,100.000,37,,
+juan,ireland,linseed,ha,2000.000,5,1935,1939,58,1000,100.000,37,,
+juan,ireland,rye,tonnes,3000.000,5,1950,1955,56,1000,1300.000,43,,
+juan,italy,groundnuts with shell,ha,1000.000,5,1936,1940,26,1000,200.000,1,,
+juan,italy,groundnuts with shell,ha,4000.000,5,1948,1952,26,1000,200.000,1,,
+juan,italy,lentils,ha,26000.000,5,1950,1954,26,1000,20557.000,11,,
+juan,italy,linseed,tonnes,12000.000,5,1947,1951,52,1000,2200.000,34,,
+juan,italy,sesame seed,tonnes,300.000,5,1940,1944,26,100,373.900,1,,
+juan,italy,sesame seed,ha,2000.000,5,1956,1960,26,1000,337.000,10,,
+juan,italy,soybeans,ha,1000.000,5,1949,1953,25,1000,6.000,15,,
+juan,italy,soybeans,ha,300.000,5,1955,1959,25,100,6.000,9,,
+juan,italy,tangerines mandarins clementines satsumas,ha,10250.000,5,1941,1945,27,10,7766.000,5,,
+juan,luxembourg,rye,ha,4000.000,5,1955,1959,48,1000,4100.000,24,,
+juan,malta,potatoes,ha,4000.000,5,1936,1940,49,1000,1300.000,23,,
+juan,mexico,cocoa beans,tonnes,2000.000,5,1919,1923,60,1000,547.200,33,,
+juan,mexico,lentils,tonnes,2000.000,5,1946,1951,27,1000,399.983,16,,
+juan,mexico,lentils,ha,3000.000,5,1946,1951,27,1000,1262.000,16,,
+juan,mexico,peas dry,ha,7000.000,5,1946,1955,24,1000,3480.000,16,,
+juan,mexico,sweet potatoes,ha,12000.000,5,1948,1953,33,1000,5405.000,21,,
+juan,norway,grain mixed,ha,4000.000,5,1947,1951,48,1000,5400.000,15,,
+juan,norway,grain mixed,ha,2000.000,5,1956,1960,48,1000,5400.000,15,,
+juan,norway,rye,ha,6000.000,5,1933,1937,64,1000,500.000,26,,
+juan,norway,rye,ha,1000.000,5,1947,1951,64,1000,500.000,26,,
+juan,norway,rye,ha,1000.000,5,1953,1957,64,1000,500.000,26,,
+juan,paraguay,coffee green,tonnes,100.000,5,1940,1944,20,100,72.500,14,,
+juan,paraguay,groundnuts with shell,tonnes,10000.000,5,1954,1958,29,10000,4000.000,24,,
+juan,puerto rico,grapefruit inc pomelos,tonnes,19000.000,5,1948,1953,25,1000,300.000,11,,
+juan,puerto rico,rice paddy,tonnes,2000.000,5,1955,1959,14,1000,800.000,3,,
+juan,spain,carobs,ha,152000.000,5,1950,1954,98,1000,96333.495,76,,
+juan,spain,cherries,ha,1000.000,5,1941,1945,98,1000,271.845,93,,
+juan,spain,millet,ha,1000.000,5,1955,1959,101,1000,34.792,96,,
+juan,spain,plums and sloes,ha,2400.000,5,1948,1952,98,100,353.571,75,,
+juan,spain,tangerines mandarins clementines satsumas,tonnes,71900.000,5,1939,1943,98,100,23280.161,92,,
+juan,sweden,flax fibre and tow,ha,500.000,5,1929,1933,52,100,2722.000,1,,
+juan,sweden,tobacco unmanufactured,tonnes,300.000,5,1950,1955,55,100,384.000,40,,
+juan,switzerland,maize,tonnes,4000.000,5,1953,1957,53,1000,2100.000,35,,
+juan,united states of america,oil olive virgin,tonnes,700.000,5,1932,1936,46,100,192.913,16,,
+juan,uruguay,grapes,ha,18000.000,5,1943,1949,52,1000,3610.000,29,,
+juan,yugoslav sfr,rice paddy,ha,3000.000,5,1934,1938,29,1000,1100.000,8,,
+mitchell,australia,rice paddy,ha,10000.000,5,1937,1941,35,10000,1000.000,27,,
+mitchell,dr congo,sheep,heads,300000.000,5,1919,1923,26,100000,244000.000,20,,
+mitchell,indonesia,tea,tonnes,1000.000,5,1858,1862,104,1000,700.000,39,,
+mitchell,lebanon,wheat,ha,70000.000,5,1953,1957,20,10000,53000.000,11,,
+mitchell,senegal,rice paddy,ha,50000.000,5,1922,1926,37,10000,31000.000,24,,
+mitchell,sierra leone,rice paddy,tonnes,190000.000,5,1940,1944,42,10000,102000.000,30,,

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -3626,6 +3626,44 @@ def mutate_underselection_picked_is_the_maximum(root, gpd, make_valid, affinity)
     return (f"{hit['label']}/{hit['item']} picked value raised to its own same-year maximum "
             f"({float(hit['worst_max_value']):,.0f}), so it under-selects nothing")
 
+
+def mutate_constantrun_witness_is_cross_era(root, gpd, make_valid, affinity):
+    """Point a run's in-volume witness at a year from a different yearbook volume.
+
+    `constant_runs.csv` only ever contains runs that have finer evidence SOMEWHERE in their series --
+    a run consistent with its grid is never emitted -- so `n_finer_elsewhere` is positive by
+    construction and cannot distinguish the two cases that matter (issue 366). If the finer value
+    comes from a different volume, whose grid was finer, the run is its own volume's resolution limit
+    and nothing is wrong. If it comes from the SAME volume, that volume could express the finer figure
+    and printed a round number anyway.
+
+    Reading the cross-era column as though it were the same-volume one is not hypothetical: it is the
+    claim issue 366 was retitled to withdraw. `finer_in_volume_year` exists to make the distinction
+    visible, and this mutation moves a witness to 1910 -- a year in the 1909-1921 volume only, sharing
+    no window with the late-1930s runs that carry witnesses -- so the row asserts same-volume evidence
+    while holding cross-era evidence.
+
+    Nothing else moves: the constant, the grid, the run bounds and the counts are untouched, so only
+    the arm comparing the witness year's volumes against the run's can see it.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/constant_runs.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    cands = [r for r in rows if (r.get("finer_in_volume_year") or "").strip()
+             and int(r["year_first"]) >= 1932]
+    if not cands:
+        raise AssertionError("no run carries an in-volume witness with a late start, so moving one to "
+                             "1910 would not cross a volume boundary and the case would pass vacuously")
+    hit = max(cands, key=lambda r: int(r["n_values"]))
+    hit["finer_in_volume_year"] = "1910"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"{hit['country']}/{hit['item']} witness moved to 1910, which shares no volume window "
+            f"with its {hit['year_first']}-{hit['year_last']} run")
+
 CASES = (
     (
         "validate_composition_sums.py",
@@ -3789,6 +3827,14 @@ CASES = (
         "a provably-wrong cell — 0 in one yearbook volume, a real value in another — reclassified "
         "as an ordinary revision, with a revised row traded the other way so both ceilings still "
         "pass and only the class-shape check can see it",
+    ),
+    (
+        "validate_constant_runs.py",
+        mutate_constantrun_witness_is_cross_era,
+        "shares no volume window with the run",
+        "an in-volume witness moved to a year from a different yearbook volume, so the row claims "
+        "same-volume evidence while holding the cross-era kind -- the exact reading issue 366 was "
+        "retitled to withdraw, with every other field left intact",
     ),
     (
         "validate_component_underselection.py",
@@ -4442,7 +4488,8 @@ WRITABLE = {
     "validate_source_splices.py": (
         "pipelines/polity-autoimprove/state/source_splices.csv",
     ),
-    # The case rewrites constant_runs.csv in place (it edits n_values), so it must be a real copy.
+    # Two cases rewrite constant_runs.csv in place -- one edits n_values, one moves an in-volume
+    # witness year -- so it must be a real copy rather than a symlink into the tracked table.
     "validate_constant_runs.py": (
         "pipelines/polity-autoimprove/state/constant_runs.csv",
     ),
@@ -4852,7 +4899,11 @@ WRITABLE = {
     # writable because the case mutates the geojson. The master CSV must be a real copy too,
     # not stage()'s symlink: signal A compares it against site/polities.csv byte for byte, and
     # a mutation writing through the symlink would rewrite the committed database.
-    "validate_review_ledger.py": ("pipelines/polity-autoimprove/state/review_ledger.csv",),
+    # ("validate_review_ledger.py") was listed a SECOND time here with the same value until
+    # 2026-08-20. A duplicate key in a dict literal is legal Python and the later one silently wins,
+    # so the two agreeing was luck: adding a file to either entry would have had no effect. The
+    # duplicate-key self-check below now makes that impossible. Its declaration lives above, beside
+    # the case that needs it.
     "validate_site_outputs.py": (
         "polities_database.csv",
         "polities_database.gpkg",
@@ -5038,7 +5089,41 @@ def check_every_gate_runs_in_ci() -> list:
         )
     return problems
 
+def _assert_no_duplicate_registry_keys() -> None:
+    """Fail loudly if CASES or WRITABLE declares the same gate twice.
+
+    A duplicate key in a dict literal is legal Python: the later entry silently replaces the earlier
+    one. WRITABLE carried `validate_review_ledger.py` twice until 2026-08-20 and the two agreed only
+    by luck -- adding a file to the shadowed entry would have had no effect, and the case that needed
+    it would have mutated a symlink into the committed table instead of a scratch copy. That is the
+    failure this harness exists to prevent, so it should not be possible here.
+
+    CASES is a LIST and may legitimately name one gate more than once (a gate with several arms wants
+    a case per arm), so only WRITABLE is checked for uniqueness; CASES is checked for shape.
+    """
+    import ast as _ast
+    src = open(os.path.abspath(__file__), encoding="utf-8").read()
+    tree = _ast.parse(src)
+    for node in tree.body:
+        if not (isinstance(node, _ast.Assign) and isinstance(node.targets[0], _ast.Name)):
+            continue
+        if node.targets[0].id == "WRITABLE" and isinstance(node.value, _ast.Dict):
+            keys = [k.value for k in node.value.keys if isinstance(k, _ast.Constant)]
+            dupes = sorted({k for k in keys if keys.count(k) > 1})
+            if dupes:
+                raise SystemExit(
+                    f"WRITABLE declares {dupes} more than once; a duplicate key silently discards "
+                    f"the earlier entry, so one case would not get the scratch copy it asked for"
+                )
+        if node.targets[0].id == "CASES" and isinstance(node.value, (_ast.List, _ast.Tuple)):
+            bad = [(len(e.elts), e.lineno) for e in node.value.elts
+                   if isinstance(e, _ast.Tuple) and len(e.elts) != 4]
+            if bad:
+                raise SystemExit(f"CASES entries are not all 4-tuples: {bad}")
+
+
 def main() -> int:
+    _assert_no_duplicate_registry_keys()
     ap = argparse.ArgumentParser()
     ap.add_argument("--case", type=int, help="run one case by 1-based number")
     args = ap.parse_args()

--- a/scripts/validate_constant_runs.py
+++ b/scripts/validate_constant_runs.py
@@ -84,6 +84,27 @@ BASELINE_LONG = frozenset({
 })
 
 
+# THE IN-VOLUME WITNESS ARM (issue 366). `finer_in_volume_year` names the earliest year, in a volume
+# window the run itself touches, where the same series records a value OFF the constant's grid. When it
+# is set the grid cannot explain the run: that volume demonstrably could express the finer figure.
+#
+# Restated here rather than imported, so relaxing the generator and regenerating cannot quietly admit
+# weaker witnesses. The overlap years are the load-bearing part: layer B carries no volume provenance,
+# so a value at a year TWO volumes cover could have come from either and proves nothing. Allowing them
+# takes the count from 17 to 39.
+IIA_VOLUMES = ((1909, 1921), (1920, 1925), (1926, 1929), (1929, 1933), (1932, 1938), (1939, 1945))
+IIA_AMBIGUOUS_YEARS = frozenset(
+    y for y in range(1900, 1960) if sum(1 for a, b in IIA_VOLUMES if a <= y <= b) > 1
+)
+# Pinned in BOTH directions, like the row counts above: a new witness is a finding that wants reading,
+# and a lost one means something was repaired and should be said out loud.
+BASELINE_IN_VOLUME = 17
+
+
+def _volumes_covering(year: int) -> set:
+    return {i for i, (a, b) in enumerate(IIA_VOLUMES) if a <= year <= b}
+
+
 def main() -> int:
     if not os.path.exists(TABLE):
         print(f"SKIP: {os.path.relpath(TABLE, REPO)} missing — run 17_constant_runs.py --write")
@@ -115,6 +136,57 @@ def main() -> int:
         problems.append(
             f"{k[1]} / {k[2]} = {k[4]} from {k[5]} is pinned as a long constant run but is not one "
             f"any more — remove its entry, saying what was repaired")
+
+    n_wit = 0
+    for r in rows:
+        wy, wv = r.get("finer_in_volume_year", ""), r.get("finer_in_volume_value", "")
+        if not wy and not wv:
+            continue
+        who = f"{r['source']} {r['country']} / {r['item']} ({r['unit']})"
+        if bool(wy) != bool(wv):
+            problems.append(f"{who}: finer_in_volume_year and _value must be set together, "
+                            f"got {wy!r} and {wv!r}")
+            continue
+        n_wit += 1
+        if r["source"] != "iia":
+            problems.append(
+                f"{who}: carries an in-volume witness, but only `iia` has known volume windows — "
+                f"for any other source this column cannot mean anything and must be empty")
+            continue
+        try:
+            y = int(wy)
+            wval = float(wv)
+            y0, y1 = int(r["year_first"]), int(r["year_last"])
+            grid = float(r["grid"])
+        except (TypeError, ValueError) as e:
+            problems.append(f"{who}: unparseable witness ({e})")
+            continue
+        if y0 <= y <= y1:
+            problems.append(
+                f"{who}: witness year {y} lies INSIDE the run {y0}-{y1}, where every value equals "
+                f"the constant by definition, so it cannot be evidence against the grid")
+        if y in IIA_AMBIGUOUS_YEARS:
+            problems.append(
+                f"{who}: witness year {y} is covered by two IIA volumes, so the value could have "
+                f"come from either and proves nothing about the run's own volume. Layer B carries no "
+                f"volume provenance, which is why these years are excluded")
+        if not (_volumes_covering(y) & (_volumes_covering(y0) | _volumes_covering(y1))):
+            problems.append(
+                f"{who}: witness year {y} shares no volume window with the run {y0}-{y1}, so it is "
+                f"cross-era evidence — exactly the reading issue 366 withdrew")
+        if grid > 0:
+            q = wval / grid
+            if abs(q - round(q)) < 1e-9:
+                problems.append(
+                    f"{who}: witness value {wval} sits ON the constant's grid of {grid}, so it shows "
+                    f"a different multiple rather than finer precision. `algeria rye` is the trap: a "
+                    f"2,000 constant beside 1,000, both on a 1,000 grid, is no evidence at all")
+    print(f"  with an in-volume witness: {n_wit} (pinned {BASELINE_IN_VOLUME})")
+    if n_wit != BASELINE_IN_VOLUME:
+        problems.append(
+            f"{n_wit} runs carry an in-volume witness against the pinned {BASELINE_IN_VOLUME}. More "
+            f"means a volume was shown to resolve finer for a series it flat-lines, which wants "
+            f"reading; fewer means one was repaired, which wants saying")
 
     if problems:
         print(f"\nFAIL: {len(problems)} problem(s)\n")


### PR DESCRIPTION
*PR by Claude.* All 80 gates green, 104 selftest cases pass, every `--check` mode clean.

`constant_runs.csv` only ever holds runs that have finer evidence **somewhere** in their series — a run
consistent with its grid is never emitted — so `n_finer_elsewhere` is positive by construction and
cannot separate:

- finer value from a **different** volume, whose grid was finer → the run is its own volume's resolution
  limit, nothing wrong. **This is the reading #366 was retitled to withdraw.**
- finer value from the **same** volume → that volume could express the finer figure and printed a round
  number anyway.

A reader meeting `n_finer_elsewhere` reaches the withdrawn conclusion. `finer_in_volume_year` /
`finer_in_volume_value` now name the earliest witness in a volume window the run touches. **17 of 79 iia
runs** carry one:

```
australia    lemons and limes ha 1933-1944 const  2,000   witness 1930: 896
south africa tea              ha 1933-1943 const  1,000   witness 1930: 799
papua new g. cacao beans      ha 1933-1937 const  1,000   witness 1930: 402
australia    wine             ha 1935-1944 const 20,000   witness 1934: 19,000
```

**The overlap years are load-bearing.** Layer B carries no volume provenance, so "same volume" is
inferred from the year — and the windows overlap, so 1920, 1921, 1929, 1932 and 1933 each fall in two
volumes and prove nothing. Excluding them is the difference between **17** and an inflated **39**.

## Why this belongs in the generator: I got the number wrong three times by hand

- `value % constant != 0` counts a *different multiple of the same grid* as evidence. `algeria rye` has a
  2,000 constant beside 1,000 — both on a 1,000 grid, no evidence at all. Six apparent hits were that.
- A crude power-of-ten test mishandles decimals. `france / eggs hen in shell` has a constant of **5.390**
  on a 0.01 grid, and 10.8 sits exactly on it; my test returned `None` for sub-unit values and called it
  finer. **That is the 18th case I published on the issue, and it is wrong — the answer is 17.**
- Joining raw item strings loses 31 of 79 rows, because this generator normalises item names before
  writing (`groundnuts with shell` vs `groundnuts, with shell`).

The gate arm restates the volume windows rather than importing them, and rejects a witness that is
inside its own run, at an overlap year, in no shared window, or on the constant's grid. Pinned **both
ways** at 17.

## Also fixes a latent harness bug

`WRITABLE` declared `validate_review_ledger.py` **twice**, with the same value — so the two agreed only
by luck. A duplicate key in a dict literal silently discards the earlier entry, so adding a file to the
shadowed one would have had no effect, leaving that case to mutate a **symlink into the committed table**
instead of a scratch copy. I found it by introducing a second duplicate myself while wiring this case.

Both duplicates are gone, and `selftest_gates.py` now AST-checks its own registries on every run —
verified to fire by re-introducing one. `CASES` is deliberately *not* uniqueness-checked, since a gate
with several arms wants a case per arm; it is shape-checked instead.