### PR TITLE
Screen stated-area revisions against our period boundaries: 11 corroborate, 7 have one polity spanning a change the source records (#503)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -482,6 +482,15 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_era_shift_verdicts.py
 
+      # Where a source REVISES its own stated area by >=50%, does our periodisation have a boundary
+      # there? 11 of 18 agree — Serbia -> Yugoslavia 87,776 -> 247,916, Romania's Transylvania gains,
+      # Trianon — which corroborates the spans from data rather than from historical reading, and no
+      # other check here does that. 7 have one polity spanning the revision. Rows whose cause is
+      # already recorded in validate_stated_areas' BASELINE/SOURCE_NOTES are excluded, so a diagnosed
+      # source defect leaves the table by being diagnosed and this stays a worklist.
+      - name: Sources — stated-area revisions must agree with their own verdict and our spans
+        if: '!cancelled()'
+        run: python3 scripts/validate_area_revision_boundaries.py
       # A layer-B nutrient series that consistently publishes the SMALLEST of several raw materials
       # the source prints side by side. Issue 379 gates raw-product switching on OSCILLATION, which a
       # series that never switches cannot trigger — so 7 of these 8 are invisible to it. spain/p reads

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ python3 scripts/validate_constant_runs.py           # a value repeated for years
 python3 scripts/validate_isolated_spikes.py         # no single year may read many times its own neighbours
 python3 scripts/validate_same_polity_overlaps.py   # two labels of one source may not collide on one polity's cells
 python3 scripts/validate_era_shift_verdicts.py     # post-1933 tobacco/hops verdicts must match their own numbers
+python3 scripts/validate_area_revision_boundaries.py # stated-area revisions must agree with their own verdict and our spans
 python3 scripts/validate_component_underselection.py # recorded component under-selections must still pick a minor material
 python3 scripts/validate_grid_ambiguous_zeros.py  # recorded grid-ambiguous zeros must live at their grid's resolution floor
 python3 scripts/validate_cross_label_duplication.py # recorded cross-label duplications must still clear their own conditions

--- a/pipelines/polity-autoimprove/34_area_revision_boundaries.py
+++ b/pipelines/polity-autoimprove/34_area_revision_boundaries.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Where the SOURCE revises its own stated area, does our periodisation have a boundary? (issue 503)
+
+THE SIGNAL, AND WHY IT IS INDEPENDENT OF EVERYTHING ELSE HERE. `data/final/source_stated_areas.csv`
+carries what each yearbook edition said its own reporting units measured. 210 of 1,008 labels revise
+that figure at least once, and a LARGE revision marks a year the source itself treated as a
+territorial change. Our span boundaries and those revisions should coincide -- and where they do, that
+is corroboration of the periodisation from the data rather than from historical reading, which nothing
+else in this repo supplies. Where they do not, one polity is asserting a constant territory that the
+source contradicts in its own area column.
+
+This depends on no polygon, no wiki page, no magnitude profile and no second source, which is what
+makes it worth having: every other check on periodisation here shares inputs with the thing it checks.
+
+WHAT AGREEMENT LOOKS LIKE. 87,776 -> 247,916 km2 for `ETAT SERBE-CROATE-SLOVENE` between the 1913 and
+1921 statements, with `F248-1920-1947` beginning in 1920. 137,903 -> 294,695 for `ROUMANIE`, boundary
+at 1920. `HONGRIE` 70% at Trianon, `GRÈCE` 127% across the Balkan Wars, `AUTRICHE` 74% at the
+dissolution. The source watched the same events.
+
+THE FILTER IS WHAT MAKES THIS A WORKLIST RATHER THAN A FIXED LIST, and it is the whole design. A large
+revision has two possible causes and only one of them is ours:
+
+    a real territorial or scope change  -> our span may be missing a boundary
+    a defect in the source              -> nothing to do here
+
+`validate_stated_areas.py` already curates the second class, in BASELINE (a divergence that suppresses
+a failure) and SOURCE_NOTES (a one-source note that does not). MONACO's dropped decimal separator,
+GREENLAND's three estimates, GIBRALTAR's 1000-hectare unit error are all recorded there. So this file
+EXCLUDES any (polity, source) pair those dicts already explain, which means:
+
+  * a diagnosed source error leaves the table by being diagnosed, not by being hard-coded here;
+  * an UNEXPLAINED large revision stays, whichever cause it turns out to have, which is correct --
+    `ESTHONIE` stating 6,775 km2 against Estonia's 45,339 is worth looking at either way.
+
+Without the filter, 4 of the 9 spanning cases are known source defects and the table reads as a
+false-positive generator.
+
+WHAT THIS DOES NOT DO. It does not propose moving any polity. `ALGÉRIE` is the clearest case -- 575,289
+km2 (the three civil departments) to 2,196,294 (the colony including the Southern Territories), with
+`DZA-1919-1962` carrying one polygon across it -- and that is issue 400's case 2, whose remedy is a
+polity-creation decision. `EQUATEUR`'s 306,644 -> 714,860 tracks Ecuador's CLAIMED Amazon before the
+1942 Rio Protocol, so it is a claim rather than control and probably not ours at all. The table records
+the disagreement and its size; whose it is, is a judgement.
+
+Usage:
+  python3 pipelines/polity-autoimprove/34_area_revision_boundaries.py            # report only
+  python3 pipelines/polity-autoimprove/34_area_revision_boundaries.py --write    # refresh the table
+  python3 pipelines/polity-autoimprove/34_area_revision_boundaries.py --check    # fail if stale
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+STATE = os.path.join(HERE, "state")
+OUT = os.path.join(STATE, "area_revision_boundaries.csv")
+STATED = os.path.join(REPO, "data/final/source_stated_areas.csv")
+POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
+
+# A revision below this is re-measurement, rounding or a boundary survey, not an event. 50% is not
+# tuned: every agreement case below sits at 60% or more, and the largest sub-50% revisions are
+# plainly surveys (`TRANSJORDANIE` 40,000 -> 89,975 as its desert frontier was fixed).
+MIN_STEP = 0.50
+
+FIELDS = ("label", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
+          "polity_code", "polity_start", "polity_end", "verdict")
+
+
+def _n(x, nd=4):
+    f = float(x)
+    return str(int(f)) if f == int(f) and abs(f) < 1e15 else repr(round(f, nd))
+
+
+def build() -> list[dict]:
+    import pandas as pd
+    sys.path.insert(0, os.path.join(REPO, "scripts"))
+    sys.path.insert(0, HERE)
+    import io
+    _o = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        import validate_stated_areas as V
+        res = V.analyse()
+        import matchlib
+        matcher = matchlib.Matcher(
+            V.CSV_PATH, os.path.join(HERE, "state/applied_aliases.csv"), verbose=False)
+    finally:
+        sys.stdout = _o
+    lex, ours = res["lexicon"], res["ours"]
+    # (polity, source) pairs whose divergence is already explained by curation
+    explained = set(V.BASELINE) | set(V.SOURCE_NOTES)
+
+    db = pd.read_csv(POLITIES).set_index("polity_code")
+    st = pd.read_csv(STATED)
+    st = st[st.stated_area_km2 > 0]
+
+    rows = []
+    for (source, label), g in st.groupby(["source", "label"], sort=True):
+        if g.stated_area_km2.nunique() < 2:
+            continue
+        seq = [(int(r.data_year), float(r.stated_area_km2))
+               for r in g.sort_values("data_year").itertuples()]
+        steps = [(abs(seq[i + 1][1] / seq[i][1] - 1), i) for i in range(len(seq) - 1) if seq[i][1] > 0]
+        if not steps:
+            continue
+        step, i = max(steps)
+        if step < MIN_STEP:
+            continue
+        y0, a0 = seq[i]
+        y1, a1 = seq[i + 1]
+        code = None
+        for cand in (label, lex.get(V.normalise_label(label))):
+            if not cand:
+                continue
+            try:
+                code = matcher.assign(cand, None, source, y1)[0]
+            except Exception:
+                code = None
+            if code:
+                break
+        if not code or code not in ours or code not in db.index:
+            continue
+        if (code, source) in explained:
+            continue                      # a diagnosed source defect leaves by being diagnosed
+        a, b = int(db.at[code, "start_year"]), int(db.at[code, "end_year"])
+        rows.append({
+            "label": label, "source": source, "step_pct": _n(round(step * 100, 1)),
+            "year_before": y0, "year_after": y1,
+            "area_before": _n(a0), "area_after": _n(a1),
+            "polity_code": code, "polity_start": a, "polity_end": b,
+            "verdict": "one_polity_spans_the_revision" if (a <= y0 and y1 <= b)
+                       else "our_boundary_falls_between",
+        })
+    rows.sort(key=lambda r: (-float(r["step_pct"]), r["label"]))
+    return rows
+
+
+def write(rows: list[dict], path: str) -> None:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=FIELDS)
+            w.writeheader()
+            for r in rows:
+                w.writerow(r)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--check", action="store_true")
+    a = ap.parse_args()
+
+    for p in (STATED, POLITIES):
+        if not os.path.exists(p):
+            print(f"input absent ({p}); nothing to do", file=sys.stderr)
+            return 0
+    rows = build()
+    spans = [r for r in rows if r["verdict"] == "one_polity_spans_the_revision"]
+    agree = [r for r in rows if r["verdict"] == "our_boundary_falls_between"]
+    print(f"{len(rows)} stated-area revision(s) of at least {MIN_STEP:.0%} whose label resolves to a "
+          f"polity, excluding those already explained in BASELINE/SOURCE_NOTES")
+    print(f"  our boundary falls between the two figures: {len(agree)}   (corroboration)")
+    print(f"  ONE POLITY SPANS THE REVISION:              {len(spans)}   (a constant territory the "
+          f"source contradicts)")
+    for r in rows:
+        m = "SPANS" if r["verdict"] == "one_polity_spans_the_revision" else "boundary"
+        print(f"  {r['label'][:28]:30}{float(r['step_pct']):>6.0f}%  {r['year_before']}->"
+              f"{r['year_after']:<6}{float(r['area_before']):>11,.0f} -> "
+              f"{float(r['area_after']):>11,.0f}  {r['polity_code']:20} {m}")
+
+    if a.check:
+        if not os.path.exists(OUT):
+            print(f"MISSING {OUT}; run with --write", file=sys.stderr)
+            return 1
+        with open(OUT, newline="") as fh:
+            have = list(csv.DictReader(fh))
+        want = [{k: str(v) for k, v in r.items()} for r in rows]
+        if have != want:
+            print(f"STALE {OUT}: {len(have)} row(s) on disk, {len(want)} rebuilt", file=sys.stderr)
+            for h, w in zip(have, want):
+                if h != w:
+                    print(f"  first difference:\n    disk {h}\n    built {w}", file=sys.stderr)
+                    break
+            return 1
+        print(f"OK {os.path.basename(OUT)} matches a fresh rebuild ({len(have)} rows)")
+    if a.write:
+        write(rows, OUT)
+        print(f"wrote {OUT} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
+++ b/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
@@ -1,0 +1,19 @@
+label,source,step_pct,year_before,year_after,area_before,area_after,polity_code,polity_start,polity_end,verdict
+ESTHONIE,iia,601.8,1921,1925,6775,47549,EST-1918-1940,1918,1940,one_polity_spans_the_revision
+ALGÉRIE,iia,281.8,1921,1932,575289,2196294,DZA-1919-1962,1919,1962,one_polity_spans_the_revision
+algérie,iia,281.1,1913,1929,576000,2195097,DZA-1919-1962,1919,1962,our_boundary_falls_between
+yougoslavie,iia,183.1,1913,1929,87776,248494,F248-1920-1947,1920,1947,our_boundary_falls_between
+ETAT SERBE-CROATE-SLOVENE,iia,182.4,1913,1921,87776,247916,F248-1920-1947,1920,1947,our_boundary_falls_between
+EQUATEUR,iia,133.1,1933,1937,306644,714860,ECU-1800-1942,1800,1942,one_polity_spans_the_revision
+GRÈCE,iia,127.2,1911,1921,63211,143641,GRC-1919-1947,1919,1947,our_boundary_falls_between
+roumanie,iia,113.8,1913,1929,137903,294892,ROU-1920-1940,1920,1940,our_boundary_falls_between
+ROUMANIE,iia,113.7,1913,1921,137903,294695,ROU-1920-1940,1920,1940,our_boundary_falls_between
+CÔTE DES SOMALIS,iia,81.7,1921,1937,120000,21963,FRS-1884-1977,1884,1977,one_polity_spans_the_revision
+AUTRICHE,iia,74,1913,1921,300004,78061,AUT-1919-2025,1919,2025,our_boundary_falls_between
+autriche,iia,72.1,1913,1929,300004,83833,AUT-1919-2025,1919,2025,our_boundary_falls_between
+hongrie,iia,71.4,1913,1929,325411,93005,HUN-1920-1938,1920,1938,our_boundary_falls_between
+HONGRIE,iia,70.5,1913,1921,325411,96114,HUN-1920-1938,1920,1938,our_boundary_falls_between
+LITHUANIE,iia,62.9,1921,1925,150000,55658,LTU-1918-1940,1918,1940,one_polity_spans_the_revision
+MONTÉNÉGRO,iia,59.8,1911,1913,9080,14512,MNE-1913-1918,1913,1918,our_boundary_falls_between
+ALBANIE,iia,57.9,1921,1925,28500,45000,ALB-1913-2025,1913,2025,one_polity_spans_the_revision
+SOMALIE BRITANNIQUE british,iia,51.1,1913,1925,176000,86000,BSS-1884-1960,1884,1960,one_polity_spans_the_revision

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -3664,6 +3664,42 @@ def mutate_constantrun_witness_is_cross_era(root, gpd, make_valid, affinity):
     return (f"{hit['country']}/{hit['item']} witness moved to 1910, which shares no volume window "
             f"with its {hit['year_first']}-{hit['year_last']} run")
 
+
+def mutate_arearevision_verdict_contradicts_span(root, gpd, make_valid, affinity):
+    """Flip a revision's verdict so it contradicts its own polity span.
+
+    `area_revision_boundaries.csv` has two halves and the verdict IS the finding (issue 503): either our
+    period boundary falls between the source's two figures, which corroborates the periodisation from
+    data rather than from historical reading, or one polity spans the revision and is asserting a
+    constant territory the source contradicts in its own area column.
+
+    Because the verdict is a written field beside the span it describes, nothing but a gate stops the two
+    disagreeing -- and a row claiming `our_boundary_falls_between` while one polity covers both figures
+    would hide exactly the case the table exists to surface. The mutation takes an agreeing row and
+    relabels it as spanning, leaving the years, the areas, the step and the polity bounds untouched, so
+    only the arm deriving the verdict from the span can see it.
+
+    It picks the agreeing row with the largest step, so the case does not depend on which labels happen
+    to resolve when the lexicon changes.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/area_revision_boundaries.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    cands = [r for r in rows if r["verdict"] == "our_boundary_falls_between"]
+    if not cands:
+        raise AssertionError("no revision currently agrees with a period boundary, so there is nothing "
+                             "to relabel and the case would pass vacuously")
+    hit = max(cands, key=lambda r: float(r["step_pct"]))
+    hit["verdict"] = "one_polity_spans_the_revision"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"{hit['label']} relabelled as spanning, though {hit['polity_code']} "
+            f"({hit['polity_start']}-{hit['polity_end']}) has a boundary inside "
+            f"{hit['year_before']}-{hit['year_after']}")
+
 CASES = (
     (
         "validate_composition_sums.py",
@@ -3827,6 +3863,14 @@ CASES = (
         "a provably-wrong cell — 0 in one yearbook volume, a real value in another — reclassified "
         "as an ordinary revision, with a revised row traded the other way so both ceilings still "
         "pass and only the class-shape check can see it",
+    ),
+    (
+        "validate_area_revision_boundaries.py",
+        mutate_arearevision_verdict_contradicts_span,
+        "must follow from the span",
+        "a revision whose verdict claims one polity spans it while that polity's own bounds put a "
+        "boundary between the source's two figures -- hiding the case the table exists to surface, "
+        "with the years, areas, step and bounds all left intact",
     ),
     (
         "validate_constant_runs.py",
@@ -4487,6 +4531,12 @@ WRITABLE = {
     # to tell a retracted verdict from a live one.
     "validate_source_splices.py": (
         "pipelines/polity-autoimprove/state/source_splices.csv",
+    ),
+    # The case rewrites area_revision_boundaries.csv in place (it flips one verdict).
+    "validate_area_revision_boundaries.py": (
+        "pipelines/polity-autoimprove/state/area_revision_boundaries.csv",
+        # arm C reads the published note column here, so the scratch tree needs it materialised
+        "data/final/source_stated_area_basis.csv",
     ),
     # Two cases rewrite constant_runs.csv in place -- one edits n_values, one moves an in-volume
     # witness year -- so it must be a real copy rather than a symlink into the tracked table.

--- a/scripts/validate_area_revision_boundaries.py
+++ b/scripts/validate_area_revision_boundaries.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Do the recorded stated-area revisions still line up (or fail to) with our period boundaries?
+
+`pipelines/polity-autoimprove/34_area_revision_boundaries.py` records every case where a source revises
+its own stated area by at least 50% and the label resolves to a polity (issue 503). The table has two
+halves and BOTH are load-bearing:
+
+  * `our_boundary_falls_between` -- the source revised and we already have a span boundary there. This
+    is CORROBORATION of the periodisation from data rather than from historical reading, which nothing
+    else in this repo supplies. 87,776 -> 247,916 km2 for Serbia becoming Yugoslavia against
+    F248-1920-1947; Romania's Transylvania gains against ROU-1920-1940; Trianon against HUN-1920-1938.
+  * `one_polity_spans_the_revision` -- one row carries a constant territory across a change the source
+    records in its own area column.
+
+  A  ARITHMETIC. `step_pct` must equal |area_after/area_before - 1| x 100, and clear the 50% floor.
+     A row whose stated step disagrees with its own two areas is not measuring anything.
+  B  THE VERDICT MUST FOLLOW FROM THE SPAN. `one_polity_spans_the_revision` exactly when the polity's
+     span contains both data years. This is the finding, so it cannot be a free-text field.
+  C  THE EXCLUSION MUST HOLD. No row may name a (polity, source) pair that `validate_stated_areas.py`
+     already explains in BASELINE or SOURCE_NOTES. That filter is what makes this a self-clearing
+     worklist: a diagnosed source defect leaves the table by being diagnosed. Without it, 4 of the
+     spanning rows are MONACO's dropped decimal, GREENLAND's re-estimates and TIEN-TSIN, and the table
+     reads as a false-positive generator.
+  D  THE CORROBORATION HALF MUST NOT VANISH. At least MIN_AGREEING rows must agree. If that number
+     goes to zero the periodisation did not suddenly stop matching the source -- the label resolution
+     broke, which is the failure mode this whole area is prone to (issue 195: 1,190 of 2,225
+     statements resolved to nothing until the lexicon was retargeted).
+
+WHAT IS NOT ASSERTED. That any polity should move. `ALGÉRIE` is the clear case -- 575,289 km2 for the
+three civil departments against 2,196,294 for the colony including the Southern Territories, with
+DZA-1919-1962 spanning it -- and that is issue 400's case 2, a polity-creation decision. `EQUATEUR`
+tracks Ecuador's CLAIMED Amazon before the 1942 Rio Protocol, so it is probably not ours at all. Of the
+rest, one of the two figures is simply wrong (`LITHUANIE` 150,000 against a real 65,300;
+`CÔTE DES SOMALIS` 120,000 against 23,000), and they belong in SOURCE_NOTES once diagnosed -- at which
+point they leave here on their own.
+"""
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/area_revision_boundaries.csv")
+POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
+BASIS = os.path.join(REPO, "data/final/source_stated_area_basis.csv")
+
+FIELDS = ["label", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
+          "polity_code", "polity_start", "polity_end", "verdict"]
+
+VERDICTS = {"one_polity_spans_the_revision", "our_boundary_falls_between"}
+MIN_STEP_PCT = 50.0     # restated, not imported
+MIN_AGREEING = 6        # arm D: 11 today; a floor well below it, so a real change is a finding
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} missing — run "
+              f"34_area_revision_boundaries.py --write", file=sys.stderr)
+        return 1
+    with open(TABLE, newline="", encoding="utf-8") as fh:
+        rdr = csv.DictReader(fh)
+        if rdr.fieldnames != FIELDS:
+            print(f"FAIL: {TABLE} header is {rdr.fieldnames}, expected {FIELDS}", file=sys.stderr)
+            return 1
+        rows = list(rdr)
+
+    # The excluded set is read from the PUBLISHED artifact of that curation, not by importing
+    # validate_stated_areas: write_stated_area_basis.py already copies every BASELINE/SOURCE_NOTES
+    # explanation into the `note` column of source_stated_area_basis.csv. Reading the table keeps this
+    # gate a data check with one input instead of a code import that drags in matchlib, the lexicon and
+    # the polities CSV -- which is exactly what stopped it running in the selftest's scratch tree.
+    explained = set()
+    if os.path.exists(BASIS):
+        with open(BASIS, newline="", encoding="utf-8") as fh:
+            for b in csv.DictReader(fh):
+                if (b.get("note") or "").strip():
+                    explained.add((b["polity_code"], b["source"]))
+
+    problems = []
+    if not os.path.exists(BASIS):
+        # Arm C cannot run without it, and a gate arm that silently skips is the failure mode this
+        # repo has shipped three times (issues 407, 412, 420), so absence is a failure.
+        print(f"FAIL: {os.path.relpath(BASIS, REPO)} missing — arm C cannot check the exclusion",
+              file=sys.stderr)
+        return 1
+    n_span = n_agree = 0
+    for r in rows:
+        who = f"{r['label']} / {r['source']}"
+        try:
+            step = float(r["step_pct"])
+            y0, y1 = int(r["year_before"]), int(r["year_after"])
+            a0, a1 = float(r["area_before"]), float(r["area_after"])
+            ps, pe = int(r["polity_start"]), int(r["polity_end"])
+        except (TypeError, ValueError) as e:
+            problems.append(f"{who}: unparseable field ({e})")
+            continue
+        if r["verdict"] not in VERDICTS:                                          # vocabulary
+            problems.append(f"{who}: verdict {r['verdict']!r} not in {sorted(VERDICTS)}")
+            continue
+        n_span += r["verdict"] == "one_polity_spans_the_revision"
+        n_agree += r["verdict"] == "our_boundary_falls_between"
+
+        if not (a0 > 0 and a1 > 0):
+            problems.append(f"{who}: non-positive stated area ({a0}, {a1})")
+        else:
+            exp = abs(a1 / a0 - 1) * 100
+            if abs(step - exp) > 0.15:                                            # A
+                problems.append(f"{who}: step_pct {step} != |{a1}/{a0} - 1| x 100 = {exp:.1f}")
+            elif step < MIN_STEP_PCT:                                             # A
+                problems.append(
+                    f"{who}: a {step:.0f}% revision is below the {MIN_STEP_PCT:.0f}% floor. Below it a "
+                    f"revision is re-measurement or a boundary survey, not an event")
+        if y1 <= y0:
+            problems.append(f"{who}: year_after {y1} does not follow year_before {y0}")
+        spans = ps <= y0 and y1 <= pe
+        want = "one_polity_spans_the_revision" if spans else "our_boundary_falls_between"
+        if r["verdict"] != want:                                                  # B
+            problems.append(
+                f"{who}: verdict says {r['verdict']!r} but {r['polity_code']} spans {ps}-{pe} and the "
+                f"revision runs {y0}->{y1}, so it should be {want!r}. The verdict is the finding and "
+                f"must follow from the span, not be asserted beside it")
+        if (r["polity_code"], r["source"]) in explained:                           # C
+            problems.append(
+                f"{who}: ({r['polity_code']}, {r['source']}) is already explained in "
+                f"validate_stated_areas' BASELINE/SOURCE_NOTES, so this revision has a recorded cause "
+                f"and must not be re-reported here — that exclusion is what keeps this a worklist "
+                f"rather than a false-positive generator")
+
+    print(f"{len(rows)} stated-area revision(s) of at least {MIN_STEP_PCT:.0f}% with a resolved polity")
+    print(f"  our boundary falls between the figures: {n_agree} (corroboration, floor {MIN_AGREEING})")
+    print(f"  ONE POLITY SPANS THE REVISION:          {n_span}")
+    for r in rows[:8]:
+        m = "SPANS" if r["verdict"] == "one_polity_spans_the_revision" else "boundary"
+        print(f"  {r['label'][:26]:28}{float(r['step_pct']):>6.0f}%  {r['year_before']}->"
+              f"{r['year_after']:<6}{r['polity_code']:20} {m}")
+
+    if n_agree < MIN_AGREEING:                                                     # D
+        problems.append(
+            f"only {n_agree} revision(s) agree with a span boundary, below the floor of "
+            f"{MIN_AGREEING}. The periodisation did not stop matching the source — far more likely the "
+            f"label resolution broke, which is exactly what issue 195 found when 1,190 of 2,225 "
+            f"statements resolved to nothing")
+
+    if problems:
+        print(f"FAIL: {len(problems)} area-revision problem(s)", file=sys.stderr)
+        for p in problems[:25]:
+            print("  - " + p, file=sys.stderr)
+        return 1
+    print(f"PASS: every revision's step matches its own two areas, every verdict follows from its "
+          f"polity's span, none duplicates a recorded source-defect note, and {n_agree} still "
+          f"corroborate a period boundary")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
*PR by Claude.* All 81 gates green, 105 selftest cases pass, every `--check` mode clean.

The source revises its own stated area for **210 of 1,008 labels**, and a large revision marks a year the
source itself treated as a territorial change. Our spans and those revisions should coincide — making
this an independent test of the periodisation that depends on **no polygon, no wiki page, no magnitude
profile and no second source**. Every other check on periodisation here shares inputs with the thing it
checks.

```
18 revisions of >=50% whose label resolves to a polity
  our boundary falls between the two figures   11   corroboration
  ONE POLITY SPANS THE REVISION                 7
```

## The corroborating half is the novel part

```
ETAT SERBE-CROATE-SLOVENE  182%  1913->1921   87,776 ->  247,916   F248-1920-1947
ROUMANIE                   114%  1913->1921  137,903 ->  294,695   ROU-1920-1940
GRÈCE                      127%  1911->1921   63,211 ->  143,641   GRC-1919-1947
HONGRIE                     70%  1913->1921  325,411 ->   96,114   HUN-1920-1938
```

Serbia becoming Yugoslavia, Romania's Transylvania and Bessarabia gains, the Balkan Wars, Trianon. **The
source watched the same events our spans encode, and said so in its own area column** — which is
corroboration from data rather than from historical reading.

## The exclusion is the design

A large revision is either a real change (possibly ours) or a source defect (not ours).
`validate_stated_areas.py` already curates the second class in `BASELINE`/`SOURCE_NOTES` — Monaco's
dropped decimal, Greenland's three estimates, Gibraltar's 1000-hectare unit error. Excluding those pairs
makes this **self-clearing**: a diagnosed defect leaves by being *diagnosed*, not by being hard-coded
here, and an unexplained revision stays whichever cause it has — `ESTHONIE` stating 6,775 km² against
Estonia's 45,339 is worth looking at either way. Without the filter, **4 of the 7** spanning rows are
known defects and the table reads as a false-positive generator.

Arm C reads the **published** artifact of that curation (the `note` column of
`source_stated_area_basis.csv`) rather than importing `validate_stated_areas`. The import version could
not run in the selftest's scratch tree at all — it drags in matchlib, the lexicon and the polities CSV.
Absence of that table is a **failure**, not a skipped arm, since a silently skipped arm is the failure
mode this repo has shipped three times (#407, #412, #420).

## No polity is proposed to move

`ALGÉRIE` is the clear case — 575,289 km² (three civil departments) against 2,196,294 (the colony with
the Southern Territories), `DZA-1919-1962` spanning it — and that is **#400's case 2**, a
polity-creation decision. `EQUATEUR`'s 306,644 → 714,860 tracks Ecuador's *claimed* Amazon before the
1942 Rio Protocol, so it is a claim rather than control. For `LITHUANIE` (150,000 vs a real 65,300) and
`CÔTE DES SOMALIS` (120,000 vs 23,000) one of the two figures is simply wrong.

All five arms verified to fire by mutation, and arm C **re-verified after** the import was replaced.