### PR TITLE
Diagnose the 6 area outliers (spanning 7 → 1), and stop 9 writers leaking temp files into a tracked directory (#503)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ __pycache__/
 data/external/before_1961.csv
 data/external/federico_tena_polities.xlsx
 data/external/federico_tena/
+
+# Leaked atomic-write temp files. The writers unlink these on failure (2026-08-20), but the
+# state directory is tracked and a stray .tmp is one `git add -A` away from being committed.
+pipelines/polity-autoimprove/state/*.tmp
+data/final/*.tmp

--- a/data/final/source_stated_area_basis.csv
+++ b/data/final/source_stated_area_basis.csv
@@ -6,7 +6,7 @@ AFG-1893-1919,Afghanistan (1893-1919),iia,635000,3,1909;1925;1929,AFGHANISTAN;af
 AFG-1919-2025,Afghanistan,fao,600000,1,1952,Afghanistan,641971,1.070,agrees,
 AFG-1919-2025,Afghanistan,iia,650000,6,1909;1925;1929;1932;1933;1938,AFGHANISTAN;afghanistan,641971,0.988,agrees,
 ALB-1913-2025,Albania (1913-2025),fao,28750,1,1952,Albania,28624,0.996,agrees,
-ALB-1913-2025,Albania (1913-2025),iia,36750,8,1909;1925;1929;1932;1933;1938,ALBANIE;albanie,28624,0.779,agrees,
+ALB-1913-2025,Albania (1913-2025),iia,36750,8,1909;1925;1929;1932;1933;1938,ALBANIE;albanie,28624,0.779,agrees,"TWO EDITIONS CARRY A FIGURE 60% TOO LARGE, and they are not consecutive. `ALBANIE` reads 45,000 km2 at 1913, 28,500 at 1921, 45,000 again at 1925, then 27,538 for 1932/1933/1937; our polygon is 28,624. Albania is about 28,750 km2, so the ~28,000 figures are right and 45,000 is wrong -- appearing, disappearing and reappearing, which is the product-switch shape (21_item_product_switches.py) applied to an area column rather than a single bad edition."
 ALK-1867-1959,Territory of Alaska,fao,1519000,1,1952,Alaska,1505805,0.991,agrees,
 ALK-1867-1959,Territory of Alaska,iia,1530399,9,1909;1925;1929;1932;1933;1938,ALASKA;alaska,1505805,0.984,agrees,
 AND-1800-2025,Andorra,fao,460,1,1952,Andorra,498,1.083,agrees,
@@ -38,7 +38,7 @@ BOL-1938-2025,Bolivia,fao,1069100,1,1952,Bolivia,1086608,1.016,agrees,
 BRA-1909-2025,Brazil,fao,8516040,1,1952,Brazil,8471741,0.995,agrees,
 BRA-1909-2025,Brazil,iia,8511189,9,1909;1925;1929;1932;1933;1938,BRESIL;BRÉSIL;brésil,8471741,0.995,agrees,
 BRN-1888-2025,Brunei Darussalam,fao,5770,1,1952,British Borneo Brunei,5685,0.985,agrees,
-BSS-1884-1960,British Somaliland Protectorate (1884-1960),iia,176000,9,1909;1925;1929;1932;1933;1938,SOMALIE BRITANNIQUE;SOMALIE BRITANNIQUE british;somalie britannique,171627,0.975,agrees,
+BSS-1884-1960,British Somaliland Protectorate (1884-1960),iia,176000,9,1909;1925;1929;1932;1933;1938,SOMALIE BRITANNIQUE;SOMALIE BRITANNIQUE british;somalie britannique,171627,0.975,agrees,"A SINGLE-EDITION OUTLIER, in the other direction. `SOMALIE BRITANNIQUE` reads 176,000 km2 in 1913 and 86,000 in 1925; our polygon is 171,627, which is 2% from the EARLIER figure and 100% from the later. British Somaliland was about 176,000 km2, so here it is the 1925 edition that is wrong -- which is why this class cannot be handled by preferring later editions."
 BSW-1841-1963,Sarawak (Brooke Raj / Crown Colony),fao,121910,1,1952,British Borneo Sarawak,124230,1.019,agrees,
 BTL-1920-1957,British Togoland (1920-1957),iia,34200,1,1925,TOGOLAND british,26545,0.776,agrees,
 BTN-1800-2025,Bhutan,fao,46600,1,1952,Bhutan,39799,0.854,agrees,
@@ -77,7 +77,7 @@ DOM-1800-2025,Dominican Republic,iia,50070,9,1909;1925;1929;1932;1933;1938,REPUB
 DZA-1902-1919,Algeria (1902-1919),iia,575511,3,1909;1925;1929,ALGÉRIE;ALGÉRIE french;algérie,2442683,4.244,review,"SCOPE, and the more interesting direction. IIA states 575,511 km2 -- NORTHERN Algeria, the three civil departments -- while our polygon is 2,442,844 including the Southern Territories. Both are 'Algeria'; only one is the basis French agricultural statistics were collected on. A per-km2 denominator using our polygon understates by 4.2x for any series the yearbook drew from the civil departments."
 DZA-1919-1962,Algeria (1919-1962),fao,2204860,1,1952,Algeria,2318386,1.051,agrees,
 DZA-1919-1962,Algeria (1919-1962),iia,2195696,6,1909;1925;1929;1932;1933;1938,ALGÉRIE;ALGÉRIE french;algérie,2318386,1.056,agrees,
-ECU-1800-1942,Ecuador (to 1942),iia,307243,9,1909;1925;1929;1932;1933;1938,EQUATEUR;equateur,341715,1.112,agrees,
+ECU-1800-1942,Ecuador (to 1942),iia,307243,9,1909;1925;1929;1932;1933;1938,EQUATEUR;equateur,341715,1.112,agrees,"A CLAIM, NOT A DEFECT AND NOT A BOUNDARY CHANGE. `EQUATEUR` reads 307,243 km2 in four editions, 451,180 in 1932, 306,644 in 1933 and 714,860 in 1937; our polygon is 341,715, closest to the 307,243 cluster. 714,860 km2 is Ecuador's CLAIMED Amazon territory before the 1942 Rio Protocol, and 451,180 is an intermediate claim -- so the source is tracking what Ecuador asserted rather than what it administered. Neither figure is an error in the source and neither implies a missing period boundary; the polity's own span ends at 1942, which is the year the claim was settled."
 ECU-1942-2025,Ecuador,fao,275000,1,1952,Ecuador,255241,0.928,agrees,
 EGY-1899-1925,Egypt (1899-1925),iia,1027996,4,1909;1925;1929,EGYPTE;egypte,1517113,1.476,agrees,"SCOPE, verified by containment rather than assumed. Our polygon is 1,517,144 km2 against IIA's 1,027,996 and a modern Egypt of 1,001,450 -- but Cairo, Aswan and Sinai are inside it while Wadi Halfa, Khartoum and Port Sudan are OUTSIDE, so it is not silently carrying Sudan. The extra ~500,000 km2 is the Libyan Desert: Egypt's western boundary with Cyrenaica was undefined until 1925 and CShapes encodes the maximal claim. IIA states the administered territory, which is the basis its agricultural figures were collected on."
 EGY-1925-1967,Egypt (1925-1967),fao,1000000,1,1952,Egypt,998328,0.998,agrees,
@@ -86,7 +86,7 @@ ERI-1889-1952,"Eritrea (colony/administration, 1889-1952)",fao,124320,1,1952,Eri
 ERI-1889-1952,"Eritrea (colony/administration, 1889-1952)",iia,119000,8,1909;1925;1929;1932;1933,ERYTHREE;ERYTHREE italian;ERYTHRÉE;erythrée,120803,1.015,agrees,
 ESP-1800-2025,Spain,fao,503060,1,1952,Spain,506132,1.006,agrees,
 ESP-1800-2025,Spain,iia,505208,9,1909;1925;1929;1932;1933;1938,ESPAGNE;espagne,506132,1.002,agrees,
-EST-1918-1940,Estonia (interwar republic),iia,47549,6,1909;1925;1929;1932;1933;1938,ESTHONIE;ESTONIE;estonie,49303,1.037,agrees,
+EST-1918-1940,Estonia (interwar republic),iia,47549,6,1909;1925;1929;1932;1933;1938,ESTHONIE;ESTONIE;estonie,49303,1.037,agrees,"A SINGLE-EDITION OUTLIER. The 1909 edition states 6,775 km2 for `ESTHONIE`; the 1925 edition states 47,549, and our polygon is 49,303 -- 4% from the later figure and 628% from the earlier. 47,549 km2 is interwar Estonia including Petserimaa and Narva-taguse, so the 1925 figure is right and the 1909 one is wrong by a factor of seven. Not a periodisation gap."
 ETH-1907-1936,Ethiopia (1907-1936),iia,900000,8,1909;1925;1929;1932;1933,ETHIOPIE;FTHIOPIE;ethiopie,1127539,1.253,agrees,"OURS IS RIGHT. Ethiopia is ~1,104,300 km2 and our polygon is 1,127,533. IIA's 900,000 is a pre-survey estimate from before the interior was mapped."
 ETH-1941-1952,Ethiopia (1941-1952),fao,1060000,1,1952,Ethiopia,1127539,1.064,agrees,
 F228-1945-1991,USSR (1945-1991),fao,22270000,1,1952,USSR,22065490,0.991,agrees,
@@ -108,7 +108,7 @@ FRA-1919-2025,France,fao,551600,1,1952,France,548058,0.994,agrees,
 FRA-1919-2025,France,iia,550986,6,1909;1925;1929;1932;1933;1938,FRANCE;france,548058,0.995,agrees,
 FRIN-1816-1954,French India (Établissements français dans l'Inde),fao,510,1,1952,French India,547,1.072,agrees,
 FRS-1884-1977,French Somaliland,fao,23000,1,1952,French Somaliland,21481,0.934,agrees,
-FRS-1884-1977,French Somaliland,iia,22000,9,1909;1925;1929;1932;1933;1938,COTE DES SOMALIS;COTE DES SOMALIS french;CÔTE DES SOMALIS;côte des somalis,21481,0.976,agrees,
+FRS-1884-1977,French Somaliland,iia,22000,9,1909;1925;1929;1932;1933;1938,COTE DES SOMALIS;COTE DES SOMALIS french;CÔTE DES SOMALIS;côte des somalis,21481,0.976,agrees,"A SINGLE-EDITION OUTLIER. `CÔTE DES SOMALIS` reads 120,000 km2 in the 1909 edition (applied to 1911 and 1921) and 21,963 in 1937; our polygon is 21,481, i.e. 2% from the later figure and 82% from the earlier. French Somaliland was about 23,000 km2, so 120,000 is the error."
 FTO-1920-1960,French Togoland (1920-1960),fao,55000,1,1952,French Togoland,57137,1.039,agrees,
 GBR-1800-1921,United Kingdom (to 1921),iia,230616,3,1909;1925;1929,GRANDE-BRETAGNE;grande-bretagne,313550,1.360,agrees,"THE LABEL IS NARROWER THAN THE POLITY. IIA's `royaume uni` states 230,616 km2, which is GREAT BRITAIN without Ireland. Our 313,550 includes all of Ireland, which is correct for the United Kingdom of 1800-1921. Ours is right; the label needs a separate GB row if any data actually arrives under it."
 GBR-1921-2025,United Kingdom,fao,244010,1,1952,United Kingdom,243964,1.000,agrees,
@@ -188,7 +188,7 @@ LIE-1800-2025,Liechtenstein,fao,160,1,1952,Liechtenstein,177,1.106,agrees,
 LIE-1800-2025,Liechtenstein,iia,159,9,1909;1925;1929;1932;1933;1938,LIECHTENSTEIN;liechtenstein,177,1.113,agrees,
 LKA-1800-2025,Sri Lanka,iia,65608,9,1909;1925;1929;1932;1933;1938,CEYLAN;ceylan,65955,1.005,agrees,
 LSO-1886-1966,Lesotho (1886-1966),iia,30344,5,1929;1932;1933;1938,BASOUTOLAND;basoutoland,30503,1.005,agrees,
-LTU-1918-1940,Lithuania (interwar republic),iia,55670,6,1909;1925;1929;1932;1933;1938,LITHUANIE;lithuanie,55904,1.004,agrees,
+LTU-1918-1940,Lithuania (interwar republic),iia,55670,6,1909;1925;1929;1932;1933;1938,LITHUANIE;lithuanie,55904,1.004,agrees,"A SINGLE-EDITION OUTLIER, and the later editions are unanimous. `LITHUANIE` reads 150,000 km2 in the 1909 edition and then 55,658 / 55,670 / 55,670 / 55,670 across 1925-1937; our polygon is 55,904, within 0% of those. Interwar Lithuania was about 55,700 km2 without Vilnius, so 150,000 is the error and four editions agree against it."
 LUX-1839-2025,Luxembourg,fao,2590,1,1952,Luxembourg,2591,1.000,agrees,
 LUX-1839-2025,Luxembourg,iia,2586,9,1909;1925;1929;1932;1933;1938,LUXEMBOURG;luxembourg,2591,1.002,agrees,
 LVA-1918-1940,Latvia (interwar republic),iia,65791,6,1909;1925;1929;1932;1933;1938,LETTONIE;lettonie,65978,1.003,agrees,

--- a/pipelines/polity-autoimprove/16_source_splices.py
+++ b/pipelines/polity-autoimprove/16_source_splices.py
@@ -150,11 +150,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} seams to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/17_constant_runs.py
+++ b/pipelines/polity-autoimprove/17_constant_runs.py
@@ -241,11 +241,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} runs to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/18_isolated_spikes.py
+++ b/pipelines/polity-autoimprove/18_isolated_spikes.py
@@ -171,11 +171,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} spikes to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/19_composition_overlaps.py
+++ b/pipelines/polity-autoimprove/19_composition_overlaps.py
@@ -211,11 +211,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} overlaps to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/20_item_provenance.py
+++ b/pipelines/polity-autoimprove/20_item_provenance.py
@@ -322,11 +322,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} series to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/21_item_product_switches.py
+++ b/pipelines/polity-autoimprove/21_item_product_switches.py
@@ -206,11 +206,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=cols)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=cols)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} series to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/22_item_equivalences.py
+++ b/pipelines/polity-autoimprove/22_item_equivalences.py
@@ -180,11 +180,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=COLS)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=COLS)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} pairs to {os.path.relpath(OUT, REPO)} "
               f"({len(new_pairs)} new, {len(gone)} dropped)")
     return 0

--- a/pipelines/polity-autoimprove/23_verdict_carryover.py
+++ b/pipelines/polity-autoimprove/23_verdict_carryover.py
@@ -216,11 +216,20 @@ def main() -> int:
     if args.write:
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=COLS)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=COLS)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} carry rows to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/24_item_axis_aggregates.py
+++ b/pipelines/polity-autoimprove/24_item_axis_aggregates.py
@@ -158,11 +158,20 @@ def main() -> int:
             return 0
         fd, tmp = tempfile.mkstemp(dir=os.path.dirname(OUT), suffix=".tmp")
         os.close(fd)
-        with open(tmp, "w", newline="", encoding="utf-8") as fh:
-            w = csv.DictWriter(fh, fieldnames=COLS)
-            w.writeheader()
-            w.writerows(rows)
-        os.replace(tmp, OUT)
+        # The unlink matters: a DictWriter raises on an unexpected key, and without this the
+        # half-written .tmp is left behind in a TRACKED state directory where `git add -A`
+        # can commit it. That happened on 2026-08-20 when a column was added to the rows but
+        # not to the fieldnames.
+        try:
+            with open(tmp, "w", newline="", encoding="utf-8") as fh:
+                w = csv.DictWriter(fh, fieldnames=COLS)
+                w.writeheader()
+                w.writerows(rows)
+            os.replace(tmp, OUT)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
         print(f"\nwrote {len(rows)} groups to {os.path.relpath(OUT, REPO)}")
     return 0
 

--- a/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
+++ b/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
@@ -1,19 +1,13 @@
 label,source,step_pct,year_before,year_after,area_before,area_after,polity_code,polity_start,polity_end,verdict
-ESTHONIE,iia,601.8,1921,1925,6775,47549,EST-1918-1940,1918,1940,one_polity_spans_the_revision
 ALGÉRIE,iia,281.8,1921,1932,575289,2196294,DZA-1919-1962,1919,1962,one_polity_spans_the_revision
 algérie,iia,281.1,1913,1929,576000,2195097,DZA-1919-1962,1919,1962,our_boundary_falls_between
 yougoslavie,iia,183.1,1913,1929,87776,248494,F248-1920-1947,1920,1947,our_boundary_falls_between
 ETAT SERBE-CROATE-SLOVENE,iia,182.4,1913,1921,87776,247916,F248-1920-1947,1920,1947,our_boundary_falls_between
-EQUATEUR,iia,133.1,1933,1937,306644,714860,ECU-1800-1942,1800,1942,one_polity_spans_the_revision
 GRÈCE,iia,127.2,1911,1921,63211,143641,GRC-1919-1947,1919,1947,our_boundary_falls_between
 roumanie,iia,113.8,1913,1929,137903,294892,ROU-1920-1940,1920,1940,our_boundary_falls_between
 ROUMANIE,iia,113.7,1913,1921,137903,294695,ROU-1920-1940,1920,1940,our_boundary_falls_between
-CÔTE DES SOMALIS,iia,81.7,1921,1937,120000,21963,FRS-1884-1977,1884,1977,one_polity_spans_the_revision
 AUTRICHE,iia,74,1913,1921,300004,78061,AUT-1919-2025,1919,2025,our_boundary_falls_between
 autriche,iia,72.1,1913,1929,300004,83833,AUT-1919-2025,1919,2025,our_boundary_falls_between
 hongrie,iia,71.4,1913,1929,325411,93005,HUN-1920-1938,1920,1938,our_boundary_falls_between
 HONGRIE,iia,70.5,1913,1921,325411,96114,HUN-1920-1938,1920,1938,our_boundary_falls_between
-LITHUANIE,iia,62.9,1921,1925,150000,55658,LTU-1918-1940,1918,1940,one_polity_spans_the_revision
 MONTÉNÉGRO,iia,59.8,1911,1913,9080,14512,MNE-1913-1918,1913,1918,our_boundary_falls_between
-ALBANIE,iia,57.9,1921,1925,28500,45000,ALB-1913-2025,1913,2025,one_polity_spans_the_revision
-SOMALIE BRITANNIQUE british,iia,51.1,1913,1925,176000,86000,BSS-1884-1960,1884,1960,one_polity_spans_the_revision

--- a/scripts/validate_stated_areas.py
+++ b/scripts/validate_stated_areas.py
@@ -301,6 +301,46 @@ SOURCE_NOTES = {
     # source_stated_area_basis.csv with NO published reason, so a reader met a 10x ratio and an
     # empty note. That is the shape this file warns about elsewhere: an unexplained flag reads as
     # either an error or an oversight, and there is no way to tell which.
+    # SIX SINGLE-EDITION AREA OUTLIERS, added 2026-08-20. Each was surfaced by
+    # 34_area_revision_boundaries.py as a >=50% revision that ONE POLITY SPANS -- i.e. a candidate
+    # missing period boundary. Each is instead a bad figure in one edition, and the test is the one
+    # this file's own failure message prescribes: check which side is wrong first. In every case the
+    # polygon sits within 0-11% of one stated figure and 36-628% from the other, and the remaining
+    # editions agree with the figure the polygon backs. Recording them here removes them from that
+    # screen, which is the point of its exclusion: a diagnosed source defect leaves by being diagnosed.
+    ("EST-1918-1940", "iia"):
+        "A SINGLE-EDITION OUTLIER. The 1909 edition states 6,775 km2 for `ESTHONIE`; the 1925 edition "
+        "states 47,549, and our polygon is 49,303 -- 4% from the later figure and 628% from the "
+        "earlier. 47,549 km2 is interwar Estonia including Petserimaa and Narva-taguse, so the 1925 "
+        "figure is right and the 1909 one is wrong by a factor of seven. Not a periodisation gap.",
+    ("FRS-1884-1977", "iia"):
+        "A SINGLE-EDITION OUTLIER. `CÔTE DES SOMALIS` reads 120,000 km2 in the 1909 edition (applied to "
+        "1911 and 1921) and 21,963 in 1937; our polygon is 21,481, i.e. 2% from the later figure and "
+        "82% from the earlier. French Somaliland was about 23,000 km2, so 120,000 is the error.",
+    ("LTU-1918-1940", "iia"):
+        "A SINGLE-EDITION OUTLIER, and the later editions are unanimous. `LITHUANIE` reads 150,000 km2 "
+        "in the 1909 edition and then 55,658 / 55,670 / 55,670 / 55,670 across 1925-1937; our polygon "
+        "is 55,904, within 0% of those. Interwar Lithuania was about 55,700 km2 without Vilnius, so "
+        "150,000 is the error and four editions agree against it.",
+    ("BSS-1884-1960", "iia"):
+        "A SINGLE-EDITION OUTLIER, in the other direction. `SOMALIE BRITANNIQUE` reads 176,000 km2 in "
+        "1913 and 86,000 in 1925; our polygon is 171,627, which is 2% from the EARLIER figure and 100% "
+        "from the later. British Somaliland was about 176,000 km2, so here it is the 1925 edition that "
+        "is wrong -- which is why this class cannot be handled by preferring later editions.",
+    ("ALB-1913-2025", "iia"):
+        "TWO EDITIONS CARRY A FIGURE 60% TOO LARGE, and they are not consecutive. `ALBANIE` reads "
+        "45,000 km2 at 1913, 28,500 at 1921, 45,000 again at 1925, then 27,538 for 1932/1933/1937; our "
+        "polygon is 28,624. Albania is about 28,750 km2, so the ~28,000 figures are right and 45,000 is "
+        "wrong -- appearing, disappearing and reappearing, which is the product-switch shape "
+        "(21_item_product_switches.py) applied to an area column rather than a single bad edition.",
+    ("ECU-1800-1942", "iia"):
+        "A CLAIM, NOT A DEFECT AND NOT A BOUNDARY CHANGE. `EQUATEUR` reads 307,243 km2 in four "
+        "editions, 451,180 in 1932, 306,644 in 1933 and 714,860 in 1937; our polygon is 341,715, "
+        "closest to the 307,243 cluster. 714,860 km2 is Ecuador's CLAIMED Amazon territory before the "
+        "1942 Rio Protocol, and 451,180 is an intermediate claim -- so the source is tracking what "
+        "Ecuador asserted rather than what it administered. Neither figure is an error in the source "
+        "and neither implies a missing period boundary; the polity's own span ends at 1942, which is "
+        "the year the claim was settled.",
     ("MCO-1800-2025", "iia"):
         "A LOST DECIMAL SEPARATOR, TWICE, AT TWO DIFFERENT MAGNITUDES. IIA states 21 km2 for "
         "Monaco in 1911-1932 and 149 km2 in 1933/1937; Monaco is about 2.0 km2 today and was "


### PR DESCRIPTION
*PR by Claude.* All 81 gates green, 105 selftest cases pass, all 12 `--check` modes clean.

## Part 1 — the six outliers, which is what #504's screen was built to enable

It flagged 7 revisions of ≥50% that **one polity spans** — candidates for a missing period boundary. Six
are instead a bad figure in a single edition, and the polygon says which:

```
ESTHONIE             6,775 vs  47,549   polygon  49,303   AFTER   by  4% vs 628%
CÔTE DES SOMALIS   120,000 vs  21,963   polygon  21,481   AFTER   by  2% vs  82%
LITHUANIE          150,000 vs  55,658   polygon  55,904   AFTER   by  0% vs  63%
SOMALIE BRITANN.   176,000 vs  86,000   polygon 171,627   BEFORE  by  2% vs 100%
ALBANIE             28,500 vs  45,000   polygon  28,624   BEFORE  by  0% vs  36%
EQUATEUR           306,644 vs 714,860   polygon 341,715   BEFORE  by 11% vs  52%
```

`SOMALIE BRITANNIQUE` runs the **other way** from the rest, so this class cannot be handled by preferring
later editions. `ALBANIE`'s 45,000 appears at 1913 *and* 1925 with 28,500 between them — the
product-switch shape applied to an area column. `EQUATEUR` is a third category: 714,860 km² is Ecuador's
*claimed* Amazon before the 1942 Rio Protocol, so the source tracks an assertion rather than making an
error, and the polity's span already ends at 1942.

Recorded in `SOURCE_NOTES`, which warns without suppressing. The screen's exclusion then does its job:

```
18 rows -> 12     spanning 7 -> 1     corroboration unchanged at 11
```

The one remaining spanning case is **`ALGÉRIE`** — #400's case 2, and a genuine periodisation question.

## Part 2 — nine writers leaked their temp file, and this one nearly got committed

Tools 16–24 wrote `mkstemp` → `os.close` → `open(tmp,"w")` → `os.replace` with **no try/except**, so any
exception in between leaves a half-written `.tmp` behind. Not hypothetical: adding a column to
`17_constant_runs.py`'s rows without adding it to `fieldnames` made `DictWriter` raise, and I found the
orphan in `git status` while staging this PR — in a **tracked** directory, with `.tmp` not gitignored, one
`git add -A` from being committed.

All nine now unlink on failure, matching tools 25+; `*.tmp` under `state/` and `data/final/` is gitignored
as defence in depth; and each of the nine still regenerates **byte-identically** under `--check`, which is
what says the refactor changed only the failure path.