### PR TITLE
Key the area-revision screen on the unit, not the label string (#503)

### DIFF
--- a/pipelines/polity-autoimprove/34_area_revision_boundaries.py
+++ b/pipelines/polity-autoimprove/34_area_revision_boundaries.py
@@ -67,7 +67,7 @@ POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
 # plainly surveys (`TRANSJORDANIE` 40,000 -> 89,975 as its desert frontier was fixed).
 MIN_STEP = 0.50
 
-FIELDS = ("label", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
+FIELDS = ("label", "footnote", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
           "polity_code", "polity_start", "polity_end", "verdict")
 
 
@@ -99,8 +99,19 @@ def build() -> list[dict]:
     st = pd.read_csv(STATED)
     st = st[st.stated_area_km2 > 0]
 
+    # KEY ON THE FOOTNOTE TOO, because the label alone does not always identify a reporting unit.
+    # `INDE BRITANNIQUE:` carries TWO areas at the same data year -- 2,646,259 footnoted `british` and
+    # 2,012,967 footnoted `india indigenous states` -- which are the directly administered provinces and
+    # the princely states, summing exactly to the 4,659,226 total. Grouped on the label alone they read
+    # as two estimates of one territory and the 31% gap between them as a revision.
+    #
+    # That label is the only one in the file with a same-year collision, and at 1.31x it sits under
+    # MIN_STEP, so nothing false was published -- but the protection was a threshold coincidence, not a
+    # design. Only 10 of 2,225 statements carry a footnote at all (4 distinct values), so this changes
+    # no current row: the table is byte-identical before and after.
+    st = st.assign(_fn=st.footnote.fillna("").astype(str).str.strip())
     rows = []
-    for (source, label), g in st.groupby(["source", "label"], sort=True):
+    for (source, label, footnote), g in st.groupby(["source", "label", "_fn"], sort=True):
         if g.stated_area_km2.nunique() < 2:
             continue
         seq = [(int(r.data_year), float(r.stated_area_km2))
@@ -129,7 +140,7 @@ def build() -> list[dict]:
             continue                      # a diagnosed source defect leaves by being diagnosed
         a, b = int(db.at[code, "start_year"]), int(db.at[code, "end_year"])
         rows.append({
-            "label": label, "source": source, "step_pct": _n(round(step * 100, 1)),
+            "label": label, "footnote": footnote, "source": source, "step_pct": _n(round(step * 100, 1)),
             "year_before": y0, "year_after": y1,
             "area_before": _n(a0), "area_after": _n(a1),
             "polity_code": code, "polity_start": a, "polity_end": b,

--- a/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
+++ b/pipelines/polity-autoimprove/state/area_revision_boundaries.csv
@@ -1,13 +1,13 @@
-label,source,step_pct,year_before,year_after,area_before,area_after,polity_code,polity_start,polity_end,verdict
-ALGÉRIE,iia,281.8,1921,1932,575289,2196294,DZA-1919-1962,1919,1962,one_polity_spans_the_revision
-algérie,iia,281.1,1913,1929,576000,2195097,DZA-1919-1962,1919,1962,our_boundary_falls_between
-yougoslavie,iia,183.1,1913,1929,87776,248494,F248-1920-1947,1920,1947,our_boundary_falls_between
-ETAT SERBE-CROATE-SLOVENE,iia,182.4,1913,1921,87776,247916,F248-1920-1947,1920,1947,our_boundary_falls_between
-GRÈCE,iia,127.2,1911,1921,63211,143641,GRC-1919-1947,1919,1947,our_boundary_falls_between
-roumanie,iia,113.8,1913,1929,137903,294892,ROU-1920-1940,1920,1940,our_boundary_falls_between
-ROUMANIE,iia,113.7,1913,1921,137903,294695,ROU-1920-1940,1920,1940,our_boundary_falls_between
-AUTRICHE,iia,74,1913,1921,300004,78061,AUT-1919-2025,1919,2025,our_boundary_falls_between
-autriche,iia,72.1,1913,1929,300004,83833,AUT-1919-2025,1919,2025,our_boundary_falls_between
-hongrie,iia,71.4,1913,1929,325411,93005,HUN-1920-1938,1920,1938,our_boundary_falls_between
-HONGRIE,iia,70.5,1913,1921,325411,96114,HUN-1920-1938,1920,1938,our_boundary_falls_between
-MONTÉNÉGRO,iia,59.8,1911,1913,9080,14512,MNE-1913-1918,1913,1918,our_boundary_falls_between
+label,footnote,source,step_pct,year_before,year_after,area_before,area_after,polity_code,polity_start,polity_end,verdict
+ALGÉRIE,,iia,281.8,1921,1932,575289,2196294,DZA-1919-1962,1919,1962,one_polity_spans_the_revision
+algérie,,iia,281.1,1913,1929,576000,2195097,DZA-1919-1962,1919,1962,our_boundary_falls_between
+yougoslavie,,iia,183.1,1913,1929,87776,248494,F248-1920-1947,1920,1947,our_boundary_falls_between
+ETAT SERBE-CROATE-SLOVENE,,iia,182.4,1913,1921,87776,247916,F248-1920-1947,1920,1947,our_boundary_falls_between
+GRÈCE,,iia,127.2,1911,1921,63211,143641,GRC-1919-1947,1919,1947,our_boundary_falls_between
+roumanie,,iia,113.8,1913,1929,137903,294892,ROU-1920-1940,1920,1940,our_boundary_falls_between
+ROUMANIE,,iia,113.7,1913,1921,137903,294695,ROU-1920-1940,1920,1940,our_boundary_falls_between
+AUTRICHE,,iia,74,1913,1921,300004,78061,AUT-1919-2025,1919,2025,our_boundary_falls_between
+autriche,,iia,72.1,1913,1929,300004,83833,AUT-1919-2025,1919,2025,our_boundary_falls_between
+hongrie,,iia,71.4,1913,1929,325411,93005,HUN-1920-1938,1920,1938,our_boundary_falls_between
+HONGRIE,,iia,70.5,1913,1921,325411,96114,HUN-1920-1938,1920,1938,our_boundary_falls_between
+MONTÉNÉGRO,,iia,59.8,1911,1913,9080,14512,MNE-1913-1918,1913,1918,our_boundary_falls_between

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -3733,6 +3733,41 @@ def mutate_atomicwrite_mkstemp_loses_cleanup(root, gpd, make_valid, affinity):
         fh.write(src.replace(needle, "        except BaseException:\n            raise", 1))
     return "17_constant_runs.py's atomic writer can now leak its temp file on any write error"
 
+
+def mutate_arearevision_footnote_split_collapsed(root, gpd, make_valid, affinity):
+    """Add a second row for the same label and years, differing only by footnote.
+
+    A label string does not always identify a reporting unit. `INDE BRITANNIQUE:` carries 2,646,259 km2
+    footnoted `british` and 2,012,967 footnoted `india indigenous states` at the SAME data year -- the
+    directly administered provinces and the princely states, summing exactly to the 4,659,226 total.
+    Keyed on the label alone they read as two estimates of one territory and the 31% gap between them as
+    a revision, reported against whatever polity the label routes to (issue 503).
+
+    That label is the only same-year collision in the file today and its spread is under the screen's
+    50% floor, so nothing false was ever published -- the protection was a threshold coincidence rather
+    than a design, which is why the generator keys on the footnote and this arm exists.
+
+    The mutation duplicates a row with a different footnote, which is exactly the shape the generator
+    would produce if it went back to keying on the label. Every other field is a copy, so the
+    arithmetic, verdict, exclusion and corroboration arms all stay quiet.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/area_revision_boundaries.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    if "footnote" not in fields:
+        raise AssertionError("the table has no footnote column, so the unit cannot be keyed on it and "
+                             "this case would pass vacuously")
+    dup = dict(rows[0])
+    dup["footnote"] = "british"
+    rows.append(dup)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"added a second {rows[0]['label']} row differing only by footnote, as keying on the label "
+            f"alone would produce")
+
 CASES = (
     (
         "validate_composition_sums.py",
@@ -3904,6 +3939,14 @@ CASES = (
         "an atomic writer stripped of its unlink handler, so a DictWriter error leaves a half-written "
         ".tmp in a tracked state directory -- the try and the raise are left in place, so the module "
         "still parses and still re-raises and only the mkstemp arm can see it",
+    ),
+    (
+        "validate_area_revision_boundaries.py",
+        mutate_arearevision_footnote_split_collapsed,
+        "differing only by footnote",
+        "two rows for one label and year pair separated only by footnote -- the shape a generator keyed "
+        "on the label alone produces, where the princely states and the directly administered provinces "
+        "read as two estimates of one territory",
     ),
     (
         "validate_area_revision_boundaries.py",

--- a/scripts/validate_area_revision_boundaries.py
+++ b/scripts/validate_area_revision_boundaries.py
@@ -21,7 +21,14 @@ halves and BOTH are load-bearing:
      worklist: a diagnosed source defect leaves the table by being diagnosed. Without it, 4 of the
      spanning rows are MONACO's dropped decimal, GREENLAND's re-estimates and TIEN-TSIN, and the table
      reads as a false-positive generator.
-  D  THE CORROBORATION HALF MUST NOT VANISH. At least MIN_AGREEING rows must agree. If that number
+  D  THE UNIT MUST BE UNIQUE, NOT THE LABEL. A label string does not always identify a reporting unit:
+     `INDE BRITANNIQUE:` carries 2,646,259 km2 footnoted `british` and 2,012,967 footnoted
+     `india indigenous states` at the SAME data year, which are the directly administered provinces and
+     the princely states, summing exactly to the 4,659,226 total. Grouped on the label alone they read
+     as two estimates of one territory and the gap between them as a revision. So rows must be unique
+     on (label, footnote, source, year_before, year_after), and two rows sharing everything but the
+     footnote is the shape that says the generator went back to keying on the label.
+  E  THE CORROBORATION HALF MUST NOT VANISH. At least MIN_AGREEING rows must agree. If that number
      goes to zero the periodisation did not suddenly stop matching the source -- the label resolution
      broke, which is the failure mode this whole area is prone to (issue 195: 1,190 of 2,225
      statements resolved to nothing until the lexicon was retargeted).
@@ -43,7 +50,7 @@ TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/area_revision_bou
 POLITIES = os.path.join(REPO, "data/final/polities_database.csv")
 BASIS = os.path.join(REPO, "data/final/source_stated_area_basis.csv")
 
-FIELDS = ["label", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
+FIELDS = ["label", "footnote", "source", "step_pct", "year_before", "year_after", "area_before", "area_after",
           "polity_code", "polity_start", "polity_end", "verdict"]
 
 VERDICTS = {"one_polity_spans_the_revision", "our_boundary_falls_between"}
@@ -133,12 +140,32 @@ def main() -> int:
         print(f"  {r['label'][:26]:28}{float(r['step_pct']):>6.0f}%  {r['year_before']}->"
               f"{r['year_after']:<6}{r['polity_code']:20} {m}")
 
-    if n_agree < MIN_AGREEING:                                                     # D
+    seen = {}
+    for r in rows:
+        k = (r["label"], r["footnote"], r["source"], r["year_before"], r["year_after"])
+        if k in seen:
+            problems.append(
+                f"{r['label']} / {r['source']}: two rows share (label, footnote, source, years), so "
+                f"the same unit is reported twice")
+        seen[k] = True
+    by_label = {}
+    for r in rows:
+        by_label.setdefault((r["label"], r["source"], r["year_before"], r["year_after"]), set()).add(
+            r["footnote"])
+    for k, fns in by_label.items():
+        if len(fns) > 1:                                                            # D
+            problems.append(
+                f"{k[0]} / {k[1]}: rows differing only by footnote ({sorted(fns)}) over the same "
+                f"years. A footnote can carry the unit's identity — `INDE BRITANNIQUE:` splits into "
+                f"the directly administered provinces and the princely states that way — so two such "
+                f"rows are one unit reported twice or two units compared against each other")
+
+    if n_agree < MIN_AGREEING:                                                     # E
         problems.append(
             f"only {n_agree} revision(s) agree with a span boundary, below the floor of "
             f"{MIN_AGREEING}. The periodisation did not stop matching the source — far more likely the "
             f"label resolution broke, which is exactly what issue 195 found when 1,190 of 2,225 "
-            f"statements resolved to nothing")
+            f"statements resolved to nothing")   # E
 
     if problems:
         print(f"FAIL: {len(problems)} area-revision problem(s)", file=sys.stderr)


### PR DESCRIPTION
*PR by Claude.* All 81 gates green, 107 selftest cases pass, `--check` regenerates clean.

Auditing the screen merged in #504 found a case where its **label string does not identify a reporting
unit**:

```
INDE BRITANNIQUE:  1911  2,646,259  footnote "british"
INDE BRITANNIQUE:  1911  2,012,967  footnote "india indigenous states"
```

Those are the directly administered provinces and the princely states, summing exactly to the 4,659,226
total. Grouped on the label alone they read as two estimates of one territory, and the 31% gap between
them as a revision reported against whatever polity the label routes to.

## Nothing false was published, and that is the problem

The protection is a **threshold coincidence**: 1.31× sits under the screen's 50% floor. Swept the file —
this is the only same-year collision, and only **10 of 2,225** statements carry a footnote at all across
4 distinct values (the others, `british` on the Solomons and `former british east africa` on `kénia`,
are clarifying rather than identity-bearing).

So the generator groups on `(source, label, footnote)`, and the table is **byte-identical apart from the
new column** — 12 rows, 11 corroborating, 1 spanning, and **0 rows differ on any pre-existing field**.
That is the property worth having when refactoring a screen merged an hour earlier.

## Arm D

Rows must be unique on the **unit** rather than the label, and two rows differing only by footnote over
the same years is rejected — that being the shape a generator keyed on the label alone produces.
Verified by duplicating a row with a different footnote; every other arm stays quiet because all the
other fields are copies, so only the new arm can see it.

## A correction carried into the code

I had listed `INDE BRITANNIQUE:` on the issue among three labels where "two editions disagree
materially" at 1.31×. Wrong for the same reason — two territories, not two opinions about one. `BOLIVIE`
(1.38×) and `GUATÉMALA` (1.14×) stand.