### PR TITLE
76 of #414's 83 contradicted zeros are correctly rounded, not misread blanks (#414, #446)

### DIFF
--- a/pipelines/polity-autoimprove/26_edition_conflicts.py
+++ b/pipelines/polity-autoimprove/26_edition_conflicts.py
@@ -73,7 +73,7 @@ EPS = 1e-9
 # x100 cases cluster tightly, while ordinary revisions have a median ratio of 1.032.
 POW10_WINDOW = 0.05
 
-FIELDS = ["label", "product", "variable", "unit", "year", "kind",
+FIELDS = ["label", "product", "variable", "unit", "year", "kind", "zero_grid_verdict",
           "volume_a", "value_a", "volume_b", "value_b", "ratio"]
 
 
@@ -91,6 +91,46 @@ def power_of_ten(ratio: float) -> int | None:
     if p == 0 or abs(p) > 3:
         return None
     return p if abs(ratio / (10.0 ** p) - 1.0) <= POW10_WINDOW else None
+
+
+
+# THE LATE VOLUMES' REPORTING GRID, from state/source_value_precision.csv (issue 446, PR 528): `iia` from
+# 1934 sits at 96.3% on a 1000-grid for `ha` and 86.4% on a 100-grid for `tonnes`. These are the windows
+# iia_1938_39 and iia_1939_45 cover.
+LATE_GRID = {"area": 1000.0, "production": 100.0}
+
+
+def zero_grid_verdict(variable: str, contradicting_value: float, zero_volume: str) -> str:
+    """Is a contradicted zero a MISREAD BLANK, or a value correctly rounded to zero?
+
+    THE DISCRIMINATING PREDICTION, which is why this column exists rather than a note on the issue. A
+    blank read as 0 has no reason to correlate with the magnitude of the value the other volume prints.
+    Rounding to a coarse grid does: it can only produce 0 when the true value is below HALF the grid. So
+    the two explanations are separable per cell, and on the 83 rows here they separate sharply --
+    57 of 62 area cells sit under 500 against a 1000-hectare step (median 178), and 19 of 21 production
+    cells under 50 against a 100-tonne step (median 21.5). `belgium` hemp fibre is 17 ha; against a
+    1000-hectare grid, 17 IS zero.
+
+    This does not weaken issue 414's asymmetry (83 contradicted zeros one way, 0 the other) -- it
+    explains it, since the coarseness is one-way too. What it changes is the reading of the cells: most
+    are a resolution floor, which issue 446 owns and which needs no repair, not an extraction fault
+    needing recovery.
+
+    `grid_explains` requires the zero to be in a LATE volume, because the grid claim is about those
+    windows; a zero in an early volume gets `not_applicable` rather than being waved through.
+    """
+    if zero_volume not in ("iia_1938_39", "iia_1939_45"):
+        return "not_applicable"
+    grid = LATE_GRID.get(variable)
+    if grid is None:
+        return "unknown_variable"
+    if abs(contradicting_value) < grid / 2:
+        return "grid_explains"
+    if abs(contradicting_value) == grid / 2:
+        # Exactly at the boundary the rounding direction is a convention, not arithmetic -- three of
+        # these 83 sit at 500-535 ha and are undecidable in principle rather than in practice.
+        return "at_grid_boundary"
+    return "grid_cannot_explain"
 
 
 def build(raw_path: str) -> tuple[list[dict], dict]:
@@ -148,6 +188,9 @@ def build(raw_path: str) -> tuple[list[dict], dict]:
                 rows.append({
                     "label": k[0], "product": k[1], "variable": k[2], "unit": k[3],
                     "year": int(k[4]), "kind": kind,
+                    "zero_grid_verdict": (
+                        zero_grid_verdict(k[2], xa if xb == 0 else xb, vb if xb == 0 else va)
+                        if kind == "zero_contradicted" else ""),
                     # .12g, not .6g: the volumes differ by rounding as well as by revision --
                     # french algeria wine 1933 is 1,522,516.996 in iia_1933_34 and 1,522,521.0 in
                     # iia_1938_39 -- and at six significant figures both print identically, so the

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -470,6 +470,14 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        products and 16 of them reach layer B with the wrong value (issue 424) —
                        iia/japan/soybeans/ha 1933 reads 32,367 between 341,753 and 336,000, a 10.5x
                        collapse that sits BELOW 27_series_collapses.py's 20x floor.
+                       ZERO_GRID_VERDICT splits the 83 contradicted zeros by whether the LATE
+                       volume's own grid can produce the zero: a blank read as 0 does not correlate
+                       with the magnitude of the other volume's value, while rounding to a coarse
+                       grid can only give 0 BELOW HALF the grid, so the two explanations separate per
+                       cell. 76 grid_explains, 6 grid_cannot_explain, 1 at_grid_boundary — `belgium`
+                       hemp fibre is 17 ha against a 1,000-hectare step, i.e. correctly rounded,
+                       while `austria` meslin at 8,588 ha cannot be. Grids from
+                       state/source_value_precision.csv (issue 446).
                        Issue 414. --write refreshes state/edition_conflicts.csv
 27_series_collapses.py where does a series COLLAPSE — a year many times BELOW its neighbours, or
                        below its own start/end? 18_isolated_spikes.py is one-directional and skips

--- a/pipelines/polity-autoimprove/state/edition_conflicts.csv
+++ b/pipelines/polity-autoimprove/state/edition_conflicts.csv
@@ -1,1142 +1,1142 @@
-label,product,variable,unit,year,kind,volume_a,value_a,volume_b,value_b,ratio
-albania,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1087.3,iia_1938_39,108700,99.9724
-australia,sugar: cane,production,tonnes,1933,power_of_ten,iia_1933_34,65128.6,iia_1938_39,636200,9.7684
-austria,hops,production,tonnes,1933,power_of_ten,iia_1933_34,67.2,iia_1938_39,6700,99.7024
-belgian ruanda-urundi,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,525,iia_1938_39,52500,100.0000
-belgium,hops,area,hectares,1933,power_of_ten,iia_1933_34,597,iia_1938_39,6000,10.0503
-belgium,hops,production,tonnes,1933,power_of_ten,iia_1933_34,716.7,iia_1938_39,71700,100.0419
-belgium,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,6385.1,iia_1938_39,638500,99.9984
-british antigua,sugar: cane,production,tonnes,1933,power_of_ten,iia_1933_34,2100,iia_1938_39,21000,10.0000
-british borneo,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,179.2,iia_1938_39,17900,99.8884
-british cyprus,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,207.6,iia_1938_39,20800,100.1927
-british jamaica,cacao: raw,area,hectares,1933,power_of_ten,iia_1933_34,390,iia_1938_39,4000,10.2564
-british nyasaland,cottonseed,production,tonnes,1933,power_of_ten,iia_1933_34,1133.5,iia_1938_39,11250,9.9250
-british palestine,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,420.6,iia_1938_39,42100,100.0951
-british transjordan,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,19.9,iia_1938_39,2000,100.5025
-british uganda,groundnut,area,hectares,1933,power_of_ten,iia_1933_34,5103,iia_1938_39,51000,9.9941
-bulgaria,meslin,production,tonnes,1933,power_of_ten,iia_1933_34,115096.1,iia_1938_39,11900,9.6719
-bulgaria,spelt,production,tonnes,1933,power_of_ten,iia_1933_34,11889.9,iia_1938_39,115100,9.6805
-bulgaria,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,24455.6,iia_1938_39,2445600,100.0016
-canada,hops,area,hectares,1933,power_of_ten,iia_1933_34,398,iia_1938_39,4000,10.0503
-canada,hops,production,tonnes,1933,power_of_ten,iia_1933_34,670.1,iia_1938_39,67000,99.9851
-canada,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,20354,iia_1938_39,2036800,100.0688
-cuba,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,16488.9,iia_1938_39,1672200,101.4137
-czechoslovakia,hops,area,hectares,1933,power_of_ten,iia_1933_34,10267,iia_1938_39,103000,10.0321
-czechoslovakia,hops,production,tonnes,1933,power_of_ten,iia_1933_34,6267.7,iia_1938_39,626800,100.0048
-czechoslovakia,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,11777.6,iia_1938_39,1177800,100.0034
-denmark,rye,area,hectares,1933,power_of_ten,iia_1933_34,14302,iia_1938_39,143000,9.9986
-dutch east indies,sesame,area,hectares,1933,power_of_ten,iia_1933_34,1580,iia_1938_39,16000,10.1266
-france,hops,area,hectares,1933,power_of_ten,iia_1933_34,1708,iia_1938_39,17000,9.9532
-france,hops,production,tonnes,1933,power_of_ten,iia_1933_34,1441.7,iia_1938_39,144200,100.0208
-france,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,28429.4,iia_1938_39,2842900,99.9986
-french algeria,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,13086,iia_1938_39,1307500,99.9159
-french annam,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,2800,iia_1938_39,280000,100.0000
-french cambodia,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,7000,iia_1938_39,700000,100.0000
-french dahomey,cacao: raw,production,tonnes,1933,power_of_ten,iia_1933_34,30,iia_1938_39,300,10.0000
-french dahomey,eggs,production,tonnes,1932,power_of_ten,iia_1933_34,129.36,iia_1938_39,1293.6,10.0000
-french equatorial africa,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1220,iia_1938_39,122000,100.0000
-french guadeloupe,sugar: cane,production,tonnes,1933,power_of_ten,iia_1933_34,4179.7,iia_1938_39,41800,10.0007
-french guinea,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,530,iia_1938_39,53000,100.0000
-french indochine,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,13450,iia_1938_39,1401000,104.1636
-french ivory coast,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,334,iia_1938_39,3300,9.8802
-french laos,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,410,iia_1938_39,41000,100.0000
-french madagascar,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,7700,iia_1938_39,770000,100.0000
-french mauritania,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,4,iia_1938_39,400,100.0000
-french morocco,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,160.9,iia_1938_39,16100,100.0622
-french syria and lebanon,cottonseed,area,hectares,1933,power_of_ten,iia_1933_34,780,iia_1938_39,8000,10.2564
-french syria and lebanon,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,3044.5,iia_1938_39,304400,99.9836
-french tonkin,tea,area,hectares,1933,power_of_ten,iia_1933_34,406,iia_1938_39,4000,9.8522
-french tonkin,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1100,iia_1938_39,110000,100.0000
-french tunisia,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,510.5,iia_1938_39,51000,99.9021
-german south west africa,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,26.3,iia_1938_39,2600,98.8593
-germany,hops,area,hectares,1933,power_of_ten,iia_1933_34,9566,iia_1938_39,96000,10.0355
-germany,hops,production,tonnes,1933,power_of_ten,iia_1933_34,6793.6,iia_1938_39,679400,100.0059
-germany,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,29433.4,iia_1938_39,2943300,99.9986
-greece,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,54878.4,iia_1938_39,5487800,99.9993
-guatemala,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,120.4,iia_1938_39,12000,99.6678
-hungary,hops,production,tonnes,1933,power_of_ten,iia_1933_34,59.1,iia_1938_39,5900,99.8308
-hungary,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,23851.2,iia_1938_39,2385100,99.9992
-italian dodecanese islands,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,74.3,iia_1938_39,7400,99.5962
-italian eritrea,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,20,iia_1938_39,2000,100.0000
-italian libya: tripolitania,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,336.5,iia_1938_39,33600,99.8514
-italy,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,44380.3,iia_1938_39,4438000,99.9993
-japan,soybean,area,hectares,1933,power_of_ten,iia_1933_34,32367,iia_1938_39,324000,10.0102
-japan,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,66540.1,iia_1938_39,6654000,99.9998
-japanese korea,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,16553.5,iia_1938_39,1655300,99.9970
-japanese taiwan,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1536.7,iia_1938_39,153700,100.0195
-mexico,sesame,area,hectares,1933,power_of_ten,iia_1933_34,3187,iia_1938_39,32000,10.0408
-mexico,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,9524.2,iia_1938_39,975300,102.4023
-new zealand,hops,area,hectares,1933,power_of_ten,iia_1933_34,206,iia_1938_39,2000,9.7087
-new zealand,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,562.4,iia_1938_39,56200,99.9289
-nicaragua,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,550,iia_1938_39,55000,100.0000
-peru,cottonseed,area,hectares,1933,power_of_ten,iia_1933_34,13048,iia_1938_39,130000,9.9632
-poland,hops,area,hectares,1933,power_of_ten,iia_1933_34,2195,iia_1938_39,22000,10.0228
-poland,hops,production,tonnes,1933,power_of_ten,iia_1933_34,1152.7,iia_1938_39,115300,100.0260
-poland,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,7226.7,iia_1938_39,722700,100.0042
-romania,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,6279.7,iia_1938_39,628000,100.0048
-spain,rye,area,hectares,1933,power_of_ten,iia_1933_34,59073,iia_1938_39,591000,10.0046
-spain,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,7257.7,iia_1938_39,725900,100.0179
-spanish spanish guinea,cacao: raw,area,hectares,1933,power_of_ten,iia_1933_34,600,iia_1938_39,6000,10.0000
-sweden,rye,area,hectares,1933,power_of_ten,iia_1933_34,22103,iia_1938_39,226000,10.2249
-sweden,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,545,iia_1938_39,54500,100.0000
-switzerland,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1105,iia_1938_39,110500,100.0000
-total general,hops,area,hectares,1933,power_of_ten,iia_1933_34,45000,iia_1938_39,470000,10.4444
-total general,hops,production,tonnes,1933,power_of_ten,iia_1933_34,47600,iia_1938_39,4920000,103.3613
-total general excluding the ussr,rye,area,hectares,1933,power_of_ten,iia_1933_34,18750,iia_1938_39,18760000,1000.5333
-total general including the ussr,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,2200000,iia_1938_39,217000000,98.6364
-total north hemisphere aggregated,hops,area,hectares,1933,power_of_ten,iia_1933_34,44000,iia_1938_39,460000,10.4545
-total north hemisphere aggregated,hops,production,tonnes,1933,power_of_ten,iia_1933_34,46600,iia_1938_39,4770000,102.3605
-total north hemisphere aggregated excluding the ussr,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,1782000,iia_1938_39,180700000,101.4029
-uk,hops,area,hectares,1933,power_of_ten,iia_1933_34,6837,iia_1938_39,68000,9.9459
-uk,hops,production,tonnes,1933,power_of_ten,iia_1933_34,10973.2,iia_1938_39,1097300,99.9982
-us philippines,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,41750.3,iia_1938_39,4175000,99.9993
-us puerto rico,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,7711,iia_1938_39,761300,98.7291
-us samoa,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,34,iia_1938_39,3400,100.0000
-usa,hops,area,hectares,1933,power_of_ten,iia_1933_34,12262,iia_1938_39,123000,10.0310
-usa,hops,production,tonnes,1933,power_of_ten,iia_1933_34,18127.7,iia_1938_39,1812800,100.0017
-usa,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,624883.3,iia_1938_39,62193100,99.5275
-yugoslavia,hops,area,hectares,1933,power_of_ten,iia_1933_34,1694,iia_1938_39,17000,10.0354
-yugoslavia,hops,production,tonnes,1933,power_of_ten,iia_1933_34,1464.3,iia_1938_39,146400,99.9795
-yugoslavia,tobacco,production,tonnes,1933,power_of_ten,iia_1933_34,8750.7,iia_1938_39,875100,100.0034
-albania,rye,area,hectares,1933,revised,iia_1933_34,3482,iia_1938_39,3000,1.1607
-albania,rye,production,tonnes,1933,revised,iia_1933_34,4580.4,iia_1938_39,4800,1.0479
-albania,tobacco,area,hectares,1933,revised,iia_1933_34,1042,iia_1938_39,1000,1.0420
-argentina,cottonseed,area,hectares,1933,revised,iia_1933_34,194258,iia_1938_39,195000,1.0038
-argentina,cottonseed,production,tonnes,1933,revised,iia_1933_34,113000,iia_1938_39,106800,1.0581
-argentina,groundnut,area,hectares,1933,revised,iia_1933_34,83193,iia_1938_39,83000,1.0023
-argentina,linseed,production,tonnes,1933,revised,iia_1933_34,1440000,iia_1938_39,1590000,1.1042
-argentina,rye,area,hectares,1933,revised,iia_1933_34,366,iia_1938_39,290000,792.3497
-argentina,rye,production,tonnes,1933,revised,iia_1933_34,237000,iia_1938_39,184100,1.2873
-argentina,sugar: beet,production,tonnes,1933,revised,iia_1933_34,3167,iia_1938_39,3200,1.0104
-argentina,sugar: cane,production,tonnes,1933,revised,iia_1933_34,315744,iia_1938_39,315700,1.0001
-argentina,wine,production,tonnes,1933,revised,iia_1933_34,728000,iia_1938_39,682500,1.0667
-australia,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,12818,iia_1938_39,12800,1.0014
-australia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,649237,iia_1938_39,759000,1.1691
-australia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,369516,iia_1938_39,100,3695.1600
-australia,sugar: beet,production,tonnes,1933,revised,iia_1933_34,5388.1,iia_1938_39,5400,1.0022
-australia,wine,production,tonnes,1933,revised,iia_1933_34,56420,iia_1938_39,57876,1.0258
-austria,eggs,production,tonnes,1932,revised,iia_1933_34,23716,iia_1938_39,25872,1.0909
-austria,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,6497,iia_1938_39,6500,1.0005
-austria,flax: fibre,area,hectares,1933,revised,iia_1933_34,1812,iia_1938_39,2000,1.1038
-austria,flax: fibre,production,tonnes,1933,revised,iia_1933_34,2839.5,iia_1938_39,600,4.7325
-austria,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,598.8,iia_1938_39,100,5.9880
-austria,hops,area,hectares,1933,revised,iia_1933_34,56,iia_1938_39,1000,17.8571
-austria,hops,production,tonnes,1920,revised,iia_1909_21,39.3,iia_1925_26,38.9,1.0103
-austria,linseed,area,hectares,1933,revised,iia_1933_34,1127,iia_1938_39,1000,1.1270
-austria,linseed,production,tonnes,1933,revised,iia_1933_34,437.2,iia_1938_39,400,1.0930
-austria,rapeseed,area,hectares,1933,revised,iia_1933_34,1804,iia_1938_39,2000,1.1086
-austria,rapeseed,production,tonnes,1920,revised,iia_1909_21,780.1,iia_1925_26,1109.5,1.4223
-austria,rapeseed,production,tonnes,1933,revised,iia_1933_34,2114.1,iia_1938_39,2100,1.0067
-austria,rye,area,hectares,1933,revised,iia_1933_34,387545,iia_1938_39,388000,1.0012
-austria,rye,production,tonnes,1933,revised,iia_1933_34,686960.9,iia_1938_39,687000,1.0001
-austria,soybean,production,tonnes,1933,revised,iia_1933_34,327.9,iia_1938_39,300,1.0930
-austria,spelt,area,hectares,1933,revised,iia_1933_34,6,iia_1938_39,9000,1500.0000
-austria,spelt,production,tonnes,1933,revised,iia_1933_34,13.3,iia_1938_39,11600,872.1805
-austria,sugar: beet,production,tonnes,1933,revised,iia_1933_34,170459.2,iia_1938_39,150000,1.1364
-austria,wine,production,tonnes,1933,revised,iia_1933_34,84623.175,iia_1938_39,84630,1.0001
-belgian congo,coffee: raw,production,tonnes,1933,revised,iia_1933_34,7566,iia_1938_39,10000,1.3217
-belgian congo,sugar: cane,production,tonnes,1933,revised,iia_1933_34,7850,iia_1938_39,7800,1.0064
-belgian ruanda-urundi,cottonseed,area,hectares,1933,revised,iia_1933_34,3077,iia_1938_39,3000,1.0257
-belgian ruanda-urundi,cottonseed,production,tonnes,1933,revised,iia_1933_34,1190,iia_1938_39,1200,1.0084
-belgian ruanda-urundi,groundnut,area,hectares,1933,revised,iia_1933_34,2330,iia_1938_39,2000,1.1650
-belgian ruanda-urundi,groundnut,production,tonnes,1933,revised,iia_1933_34,1599,iia_1938_39,1600,1.0006
-belgium,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,38386,iia_1938_39,38400,1.0004
-belgium,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,25130,iia_1938_39,25100,1.0012
-belgium,flax: fibre,area,hectares,1933,revised,iia_1933_34,10812,iia_1938_39,11000,1.0174
-belgium,flax: fibre,production,tonnes,1933,revised,iia_1933_34,16864.7,iia_1938_39,7800,2.1621
-belgium,hops,production,tonnes,1920,revised,iia_1909_21,2285.3,iia_1925_26,1516.7,1.5068
-belgium,linseed,area,hectares,1933,revised,iia_1933_34,10812,iia_1938_39,11000,1.0174
-belgium,linseed,production,tonnes,1933,revised,iia_1933_34,6080.7,iia_1938_39,6900,1.1347
-belgium,meslin,area,hectares,1933,revised,iia_1933_34,3400,iia_1938_39,14000,4.1176
-belgium,meslin,production,tonnes,1933,revised,iia_1933_34,5715.3,iia_1938_39,30700,5.3715
-belgium,rapeseed,production,tonnes,1920,revised,iia_1909_21,2379.3,iia_1925_26,687.9,3.4588
-belgium,rapeseed,production,tonnes,1933,revised,iia_1933_34,100.9,iia_1938_39,100,1.0090
-belgium,rye,area,hectares,1933,revised,iia_1933_34,224164,iia_1938_39,224000,1.0007
-belgium,rye,production,tonnes,1933,revised,iia_1933_34,566693.5,iia_1938_39,566700,1.0000
-belgium,spelt,area,hectares,1933,revised,iia_1933_34,14376,iia_1938_39,3000,4.7920
-belgium,spelt,production,tonnes,1933,revised,iia_1933_34,30736.9,iia_1938_39,5700,5.3924
-belgium,sugar: beet,production,tonnes,1933,revised,iia_1933_34,243107.5,iia_1938_39,221000,1.1000
-belgium,tobacco,area,hectares,1933,revised,iia_1933_34,2688,iia_1938_39,3000,1.1161
-brazil,cacao: raw,production,tonnes,1933,revised,iia_1933_34,90000,iia_1938_39,107900,1.1989
-brazil,coffee: raw,production,tonnes,1933,revised,iia_1933_34,860000,iia_1938_39,1776600,2.0658
-brazil,cottonseed,area,hectares,1933,revised,iia_1933_34,790000,iia_1938_39,1154000,1.4608
-brazil,cottonseed,production,tonnes,1933,revised,iia_1933_34,634000,iia_1938_39,512100,1.2380
-brazil,rye,production,tonnes,1933,revised,iia_1933_34,17.5,iia_1938_39,16000,914.2857
-brazil,sugar: cane,production,tonnes,1933,revised,iia_1933_34,650000,iia_1938_39,1084600,1.6686
-brazil,tobacco,production,tonnes,1933,revised,iia_1933_34,110000,iia_1938_39,9954000,90.4909
-brazil,wine,production,tonnes,1933,revised,iia_1933_34,182000,iia_1938_39,47866,3.8023
-british aden,coffee: raw,production,tonnes,1933,revised,iia_1933_34,4485.3,iia_1938_39,4500,1.0033
-british barbados,sugar: cane,production,tonnes,1933,revised,iia_1933_34,18693.4,iia_1938_39,56650,3.0305
-british bermuda,eggs,production,tonnes,1932,revised,iia_1933_34,81.4968,iia_1938_39,107.8,1.3228
-british bermuda,eggs,production,tonnes,1933,revised,iia_1933_34,81.4968,iia_1938_39,107.8,1.3228
-british brunei,eggs,production,tonnes,1932,revised,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
-british brunei,eggs,production,tonnes,1933,revised,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
-british ceylon,cacao: raw,production,tonnes,1933,revised,iia_1933_34,4001,iia_1938_39,4100,1.0247
-british ceylon,cottonseed,area,hectares,1933,revised,iia_1933_34,800,iia_1938_39,1000,1.2500
-british ceylon,tea,production,tonnes,1933,revised,iia_1933_34,97922.118,iia_1938_39,97922,1.0000
-british ceylon,tobacco,area,hectares,1933,revised,iia_1933_34,5700,iia_1938_39,6000,1.0526
-british cyprus,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,1277,iia_1938_39,1300,1.0180
-british cyprus,citrus fruits: oranges,production,tonnes,1933,revised,iia_1933_34,5275,iia_1938_39,5300,1.0047
-british cyprus,cottonseed,area,hectares,1933,revised,iia_1933_34,1925,iia_1938_39,2000,1.0390
-british cyprus,cottonseed,production,tonnes,1933,revised,iia_1933_34,390,iia_1938_39,400,1.0256
-british cyprus,flax: fibre,area,hectares,1933,revised,iia_1933_34,816,iia_1938_39,1000,1.2255
-british cyprus,flax: fibre,production,tonnes,1933,revised,iia_1933_34,234.3,iia_1938_39,200,1.1715
-british cyprus,linseed,production,tonnes,1933,revised,iia_1933_34,388.7,iia_1938_39,400,1.0291
-british cyprus,olive grove,production,tonnes,1933,revised,iia_1933_34,1626.6,iia_1938_39,1800,1.1066
-british cyprus,olive: oil,production,tonnes,1933,revised,iia_1933_34,191.7,iia_1938_39,200,1.0433
-british cyprus,sesame,area,hectares,1933,revised,iia_1933_34,562,iia_1938_39,1000,1.7794
-british cyprus,wine,production,tonnes,1933,revised,iia_1933_34,11425.141,iia_1938_39,9737,1.1734
-british dominica,citrus fruits: limes,production,tonnes,1933,revised,iia_1933_34,2610,iia_1938_39,2600,1.0038
-british fiji islands,sugar: cane,production,tonnes,1933,revised,iia_1933_34,117000,iia_1938_39,106700,1.0965
-british gambia,groundnut,production,tonnes,1933,revised,iia_1933_34,68451.1,iia_1938_39,68500,1.0007
-british gold coast,cacao: raw,production,tonnes,1933,revised,iia_1933_34,210800,iia_1938_39,212600,1.0085
-british grenada,cacao: raw,production,tonnes,1933,revised,iia_1933_34,4360,iia_1938_39,4400,1.0092
-british guiana,cacao: raw,area,hectares,1933,revised,iia_1933_34,323,iia_1938_39,3000,9.2879
-british guiana,coffee: raw,area,hectares,1933,revised,iia_1933_34,1874,iia_1938_39,2000,1.0672
-british guiana,sugar: cane,production,tonnes,1933,revised,iia_1933_34,132000,iia_1938_39,134400,1.0182
-british india,rapeseed,production,tonnes,1920,revised,iia_1909_21,585751.05,iia_1925_26,593350,1.0130
-british iraq,cottonseed,production,tonnes,1933,revised,iia_1933_34,216,iia_1938_39,200,1.0800
-british jamaica,coffee: raw,area,hectares,1933,revised,iia_1933_34,2535,iia_1938_39,3000,1.1834
-british jamaica,sugar: cane,production,tonnes,1933,revised,iia_1933_34,73000,iia_1938_39,73600,1.0082
-british kenya,coffee: raw,area,hectares,1933,revised,iia_1933_34,41374,iia_1938_39,38500,1.0746
-british kenya,coffee: raw,production,tonnes,1933,revised,iia_1933_34,13631.9,iia_1938_39,13600,1.0023
-british kenya,cottonseed,production,tonnes,1933,revised,iia_1933_34,2850,iia_1938_39,2900,1.0175
-british kenya,eggs,production,tonnes,1932,revised,iia_1933_34,57.3496,iia_1938_39,53.9,1.0640
-british kenya,eggs,production,tonnes,1933,revised,iia_1933_34,64.7339,iia_1938_39,53.9,1.2010
-british kenya,groundnut,production,tonnes,1933,revised,iia_1933_34,403.4,iia_1938_39,400,1.0085
-british kenya,sesame,production,tonnes,1933,revised,iia_1933_34,3294,iia_1938_39,3300,1.0018
-british kenya,sugar: cane,production,tonnes,1933,revised,iia_1933_34,5808.7,iia_1938_39,5800,1.0015
-british kenya,tea,area,hectares,1933,revised,iia_1933_34,5047,iia_1938_39,5000,1.0094
-british kenya,tea,production,tonnes,1933,revised,iia_1933_34,1389.658,iia_1938_39,1390,1.0002
-british malaya,coffee: raw,area,hectares,1933,revised,iia_1933_34,7517,iia_1938_39,8000,1.0643
-british malaya,tea,area,hectares,1933,revised,iia_1933_34,1016,iia_1938_39,1000,1.0160
-british mauritius,sugar: cane,production,tonnes,1933,revised,iia_1933_34,261459,iia_1938_39,261500,1.0002
-british montserrat,citrus fruits: limes,production,tonnes,1933,revised,iia_1933_34,617.9,iia_1938_39,600,1.0298
-british montserrat,cottonseed,area,hectares,1933,revised,iia_1933_34,883,iia_1938_39,1000,1.1325
-british nauru,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,97,iia_1938_39,369500,3809.2784
-british newfoundland,eggs,production,tonnes,1933,revised,iia_1933_34,857.6568,iia_1938_39,862.4,1.0055
-british nigeria,cacao: raw,production,tonnes,1933,revised,iia_1933_34,69481,iia_1938_39,68500,1.0143
-british nigeria,cottonseed,production,tonnes,1933,revised,iia_1933_34,10990,iia_1938_39,11000,1.0009
-british nigeria,groundnut,production,tonnes,1933,revised,iia_1933_34,296984.8,iia_1938_39,297000,1.0001
-british nigeria,sesame,production,tonnes,1933,revised,iia_1933_34,9813,iia_1938_39,9800,1.0013
-british nyasaland,coffee: raw,production,tonnes,1933,revised,iia_1933_34,57.3,iia_1938_39,100,1.7452
-british nyasaland,cottonseed,area,hectares,1933,revised,iia_1933_34,6119,iia_1938_39,6000,1.0198
-british nyasaland,tea,area,hectares,1933,revised,iia_1933_34,5597,iia_1938_39,6000,1.0720
-british nyasaland,tea,production,tonnes,1933,revised,iia_1933_34,1383.338,iia_1938_39,1383,1.0002
-british nyasaland,tobacco,area,hectares,1933,revised,iia_1933_34,3182,iia_1938_39,6500,2.0427
-british nyasaland,tobacco,production,tonnes,1933,revised,iia_1933_34,1582.1,iia_1938_39,286200,180.8988
-british ocean island,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,191779,iia_1938_39,191800,1.0001
-british palestine,olive grove,production,tonnes,1933,revised,iia_1933_34,3599,iia_1938_39,3600,1.0003
-british palestine,sesame,production,tonnes,1933,revised,iia_1933_34,214,iia_1938_39,200,1.0700
-british palestine,tobacco,area,hectares,1933,revised,iia_1933_34,933,iia_1938_39,1000,1.0718
-british palestine,wine,production,tonnes,1933,revised,iia_1933_34,2711.254,iia_1938_39,1456,1.8621
-british saint christopher and nevis,cottonseed,production,tonnes,1933,revised,iia_1933_34,60,iia_1938_39,200,3.3333
-british saint christopher and nevis,sugar: cane,production,tonnes,1933,revised,iia_1933_34,28715.5,iia_1938_39,28800,1.0029
-british saint lucia,sugar: cane,production,tonnes,1933,revised,iia_1933_34,5700,iia_1938_39,5600,1.0179
-british seychelles,"fertilizers: guano, natural",production,tonnes,1933,revised,iia_1933_34,12307,iia_1938_39,12300,1.0006
-british southern rhodesia,eggs,production,tonnes,1932,revised,iia_1933_34,523.8541,iia_1938_39,539,1.0289
-british southern rhodesia,eggs,production,tonnes,1933,revised,iia_1933_34,474.8051,iia_1938_39,485.1,1.0217
-british tanganyika,coffee: raw,production,tonnes,1933,revised,iia_1933_34,12922,iia_1938_39,12900,1.0017
-british tanganyika,cottonseed,production,tonnes,1933,revised,iia_1933_34,12060,iia_1938_39,13000,1.0779
-british tanganyika,groundnut,production,tonnes,1933,revised,iia_1933_34,27840,iia_1938_39,27800,1.0014
-british tanganyika,sesame,production,tonnes,1933,revised,iia_1933_34,4512.2,iia_1938_39,4500,1.0027
-british transjordan,eggs,production,tonnes,1932,revised,iia_1933_34,1585.3068,iia_1938_39,1563.1,1.0142
-british transjordan,eggs,production,tonnes,1933,revised,iia_1933_34,1619.9645,iia_1938_39,1617,1.0018
-british trinidad and tobago,cacao: raw,production,tonnes,1933,revised,iia_1933_34,13180,iia_1938_39,12200,1.0803
-british trinidad and tobago,coffee: raw,production,tonnes,1933,revised,iia_1933_34,153.9,iia_1938_39,200,1.2995
-british trinidad and tobago,sugar: cane,production,tonnes,1933,revised,iia_1933_34,107032,iia_1938_39,107000,1.0003
-british uganda,coffee: raw,area,hectares,1933,revised,iia_1933_34,17029,iia_1938_39,17000,1.0017
-british uganda,coffee: raw,production,tonnes,1933,revised,iia_1933_34,5102.8,iia_1938_39,5100,1.0005
-british uganda,cottonseed,area,hectares,1933,revised,iia_1933_34,441364,iia_1938_39,441000,1.0008
-british uganda,cottonseed,production,tonnes,1933,revised,iia_1933_34,118370,iia_1938_39,120800,1.0205
-british uganda,sesame,area,hectares,1933,revised,iia_1933_34,81643,iia_1938_39,82000,1.0044
-british uganda,tobacco,area,hectares,1933,revised,iia_1933_34,1644,iia_1938_39,2000,1.2165
-british‑egyptian sudan,cottonseed,area,hectares,1933,revised,iia_1933_34,134818,iia_1938_39,135000,1.0013
-british‑egyptian sudan,cottonseed,production,tonnes,1933,revised,iia_1933_34,68230,iia_1938_39,66100,1.0322
-british‑egyptian sudan,groundnut,area,hectares,1933,revised,iia_1933_34,12369,iia_1938_39,12000,1.0308
-british‑egyptian sudan,groundnut,production,tonnes,1933,revised,iia_1933_34,5988,iia_1938_39,6000,1.0020
-british‑egyptian sudan,sesame,area,hectares,1933,revised,iia_1933_34,58169,iia_1938_39,58000,1.0029
-british‑egyptian sudan,sesame,production,tonnes,1933,revised,iia_1933_34,15675,iia_1938_39,15700,1.0016
-british‑french cameroon,cacao: raw,production,tonnes,1933,revised,iia_1933_34,3800,iia_1938_39,11600,3.0526
-british‑french cameroon,groundnut,production,tonnes,1933,revised,iia_1933_34,24510,iia_1938_39,24500,1.0004
-british‑french cameroon,sesame,area,hectares,1933,revised,iia_1933_34,10650,iia_1938_39,2000,5.3250
-british‑french cameroon,sesame,production,tonnes,1933,revised,iia_1933_34,3205,iia_1938_39,700,4.5786
-british‑french new hebrides,coffee: raw,production,tonnes,1933,revised,iia_1933_34,439.9,iia_1938_39,400,1.0998
-bulgaria,blackberries,area,hectares,1933,revised,iia_1933_34,4402,iia_1938_39,4000,1.1005
-bulgaria,blackberries,production,tonnes,1933,revised,iia_1933_34,33108.8,iia_1938_39,33100,1.0003
-bulgaria,cottonseed,area,hectares,1933,revised,iia_1933_34,20533,iia_1938_39,21000,1.0227
-bulgaria,cottonseed,production,tonnes,1933,revised,iia_1933_34,6350,iia_1938_39,6400,1.0079
-bulgaria,flax: fibre,production,tonnes,1933,revised,iia_1933_34,106.6,iia_1938_39,100,1.0660
-bulgaria,groundnut,production,tonnes,1933,revised,iia_1933_34,302.8,iia_1938_39,300,1.0093
-bulgaria,hemp: fibre,area,hectares,1933,revised,iia_1933_34,5272,iia_1938_39,5000,1.0544
-bulgaria,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,2128.7,iia_1938_39,2100,1.0137
-bulgaria,hempseed,area,hectares,1933,revised,iia_1933_34,5272,iia_1938_39,5000,1.0544
-bulgaria,hempseed,production,tonnes,1933,revised,iia_1933_34,1703.9,iia_1938_39,1700,1.0023
-bulgaria,linseed,production,tonnes,1933,revised,iia_1933_34,203.7,iia_1938_39,200,1.0185
-bulgaria,meslin,area,hectares,1933,revised,iia_1933_34,92168,iia_1938_39,12000,7.6807
-bulgaria,rapeseed,area,hectares,1933,revised,iia_1933_34,69,iia_1938_39,1000,14.4928
-bulgaria,rapeseed,production,tonnes,1920,revised,iia_1909_21,1391.6,iia_1925_26,434.7,3.2013
-bulgaria,rapeseed,production,tonnes,1933,revised,iia_1933_34,897.3,iia_1938_39,900,1.0030
-bulgaria,rye,area,hectares,1933,revised,iia_1933_34,208627,iia_1938_39,209000,1.0018
-bulgaria,rye,production,tonnes,1933,revised,iia_1933_34,245956.7,iia_1938_39,246000,1.0002
-bulgaria,sesame,area,hectares,1933,revised,iia_1933_34,10393,iia_1938_39,10000,1.0393
-bulgaria,sesame,production,tonnes,1933,revised,iia_1933_34,3395.5,iia_1938_39,3400,1.0013
-bulgaria,spelt,area,hectares,1933,revised,iia_1933_34,11784,iia_1938_39,92000,7.8072
-bulgaria,sugar: beet,production,tonnes,1933,revised,iia_1933_34,41545.7,iia_1938_39,40400,1.0284
-bulgaria,tobacco,area,hectares,1933,revised,iia_1933_34,27209,iia_1938_39,27000,1.0077
-bulgaria,wine,production,tonnes,1933,revised,iia_1933_34,217345.492,iia_1938_39,138593,1.5682
-canada,eggs,production,tonnes,1929,revised,iia_1929_30,179872.8701,iia_1933_34,146658.666,1.2265
-canada,eggs,production,tonnes,1932,revised,iia_1933_34,148415.3748,iia_1938_39,148440.6,1.0002
-canada,eggs,production,tonnes,1933,revised,iia_1933_34,136206.378,iia_1938_39,143751.3,1.0554
-canada,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,74874,iia_1938_39,74900,1.0003
-canada,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,31425,iia_1938_39,31400,1.0008
-canada,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,2008,iia_1938_39,2000,1.0040
-canada,flax: fibre,area,hectares,1933,revised,iia_1933_34,2060,iia_1938_39,2000,1.0300
-canada,flax: fibre,production,tonnes,1933,revised,iia_1933_34,1385.75,iia_1938_39,2800,2.0206
-canada,hops,production,tonnes,1920,revised,iia_1909_21,391.3,iia_1925_26,308.8,1.2672
-canada,linseed,area,hectares,1933,revised,iia_1933_34,50330,iia_1938_39,50500,1.0034
-canada,linseed,production,tonnes,1933,revised,iia_1933_34,16050,iia_1938_39,8450,1.8994
-canada,rye,area,hectares,1933,revised,iia_1933_34,235969,iia_1938_39,236000,1.0001
-canada,sugar: beet,production,tonnes,1933,revised,iia_1933_34,67730,iia_1938_39,59600,1.1364
-canada,tobacco,area,hectares,1933,revised,iia_1933_34,18596,iia_1938_39,19000,1.0217
-chile,fertilizers: sodium nitrate,production,tonnes,1933,revised,iia_1933_34,443000,iia_1938_39,437700,1.0121
-china,cottonseed,area,hectares,1933,revised,iia_1933_34,2485500,iia_1938_39,2485000,1.0002
-china,cottonseed,production,tonnes,1933,revised,iia_1933_34,1376750,iia_1938_39,1359200,1.0129
-china,groundnut,production,tonnes,1933,revised,iia_1933_34,191860,iia_1938_39,2980600,15.5353
-china,rapeseed,production,tonnes,1933,revised,iia_1933_34,16540.6,iia_1938_39,2106600,127.3593
-china,sesame,production,tonnes,1933,revised,iia_1933_34,33442.3,iia_1938_39,963400,28.8078
-china,tea,production,tonnes,1933,revised,iia_1933_34,41939.7,iia_1938_39,40957,1.0240
-colombia,coffee: raw,production,tonnes,1933,revised,iia_1933_34,203000,iia_1938_39,230400,1.1350
-costa rica,coffee: raw,production,tonnes,1933,revised,iia_1933_34,18000,iia_1938_39,19100,1.0611
-cuba,coffee: raw,area,hectares,1933,revised,iia_1933_34,42576,iia_1938_39,56000,1.3153
-cuba,coffee: raw,production,tonnes,1933,revised,iia_1933_34,23680.8,iia_1938_39,26400,1.1148
-cuba,sugar: cane,production,tonnes,1933,revised,iia_1933_34,2310798.7,iia_1938_39,2210000,1.0456
-cuba,tobacco,area,hectares,1933,revised,iia_1933_34,45474,iia_1938_39,45000,1.0105
-czechoslovakia,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,31950,iia_1938_39,32000,1.0016
-czechoslovakia,fertilizers: bone superphosphate,production,tonnes,1933,revised,iia_1933_34,3067,iia_1938_39,3100,1.0108
-czechoslovakia,fertilizers: calcium cyanamide,production,tonnes,1933,revised,iia_1933_34,18330,iia_1938_39,16800,1.0911
-czechoslovakia,fertilizers: calcium nitrate,production,tonnes,1933,revised,iia_1933_34,16762,iia_1938_39,18300,1.0918
-czechoslovakia,"fertilizers: mineral, calcium superphosphate",production,tonnes,1933,revised,iia_1933_34,102512,iia_1938_39,102500,1.0001
-czechoslovakia,flax: fibre,area,hectares,1933,revised,iia_1933_34,7098,iia_1938_39,7000,1.0140
-czechoslovakia,flax: fibre,production,tonnes,1933,revised,iia_1933_34,3597.3,iia_1938_39,3600,1.0008
-czechoslovakia,hemp: fibre,area,hectares,1933,revised,iia_1933_34,7627,iia_1938_39,8000,1.0489
-czechoslovakia,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,5337.8,iia_1938_39,5300,1.0071
-czechoslovakia,hempseed,area,hectares,1933,revised,iia_1933_34,7627,iia_1938_39,8000,1.0489
-czechoslovakia,hempseed,production,tonnes,1933,revised,iia_1933_34,3469,iia_1938_39,3500,1.0089
-czechoslovakia,hops,production,tonnes,1920,revised,iia_1909_21,5265.6,iia_1925_26,5642.1,1.0715
-czechoslovakia,linseed,area,hectares,1933,revised,iia_1933_34,7098,iia_1938_39,7000,1.0140
-czechoslovakia,linseed,production,tonnes,1933,revised,iia_1933_34,2676.7,iia_1938_39,2700,1.0087
-czechoslovakia,meslin,production,tonnes,1933,revised,iia_1933_34,12438.1,iia_1938_39,700,17.7687
-czechoslovakia,rapeseed,area,hectares,1933,revised,iia_1933_34,970,iia_1938_39,1000,1.0309
-czechoslovakia,rapeseed,production,tonnes,1920,revised,iia_1909_21,7203.5,iia_1925_26,4251.6,1.6943
-czechoslovakia,rapeseed,production,tonnes,1933,revised,iia_1933_34,1033.5,iia_1938_39,1000,1.0335
-czechoslovakia,rye,area,hectares,1933,revised,iia_1933_34,1045658,iia_1938_39,1046000,1.0003
-czechoslovakia,rye,production,tonnes,1933,revised,iia_1933_34,2085537.2,iia_1938_39,2085500,1.0000
-czechoslovakia,slag: basic,production,tonnes,1933,revised,iia_1933_34,71383,iia_1938_39,71400,1.0002
-czechoslovakia,spelt,area,hectares,1933,revised,iia_1933_34,440,iia_1938_39,7000,15.9091
-czechoslovakia,spelt,production,tonnes,1933,revised,iia_1933_34,700.2,iia_1938_39,12400,17.7092
-czechoslovakia,sugar: beet,production,tonnes,1933,revised,iia_1933_34,515766,iia_1938_39,455300,1.1328
-czechoslovakia,tobacco,area,hectares,1933,revised,iia_1933_34,10030,iia_1938_39,10000,1.0030
-czechoslovakia,wine,production,tonnes,1933,revised,iia_1933_34,30727.242,iia_1938_39,30758,1.0010
-denmark,eggs,production,tonnes,1929,revised,iia_1929_30,59424.75,iia_1933_34,62516.6157,1.0520
-denmark,eggs,production,tonnes,1933,revised,iia_1933_34,73074.7094,iia_1938_39,79664.2,1.0902
-denmark,rye,production,tonnes,1933,revised,iia_1933_34,251441,iia_1938_39,251400,1.0002
-denmark,sugar: beet,production,tonnes,1933,revised,iia_1933_34,243800,iia_1938_39,229200,1.0637
-dominican republic,cacao: raw,production,tonnes,1933,revised,iia_1933_34,22461,iia_1938_39,22900,1.0195
-dominican republic,sugar: cane,production,tonnes,1933,revised,iia_1933_34,388510,iia_1938_39,362000,1.0732
-dutch east indies,cacao: raw,production,tonnes,1933,revised,iia_1933_34,1903,iia_1938_39,1600,1.1894
-dutch east indies,coffee: raw,area,hectares,1933,revised,iia_1933_34,116897,iia_1938_39,117000,1.0009
-dutch east indies,coffee: raw,production,tonnes,1933,revised,iia_1933_34,53222.1,iia_1938_39,53200,1.0004
-dutch east indies,cottonseed,area,hectares,1933,revised,iia_1933_34,8094,iia_1938_39,8000,1.0117
-dutch east indies,cottonseed,production,tonnes,1933,revised,iia_1933_34,2850,iia_1938_39,2900,1.0175
-dutch east indies,sesame,production,tonnes,1933,revised,iia_1933_34,3143.5,iia_1938_39,3100,1.0140
-dutch east indies,sulphur,production,tonnes,1933,revised,iia_1933_34,11213,iia_1938_39,11200,1.0012
-dutch east indies,tea,area,hectares,1933,revised,iia_1933_34,128078,iia_1938_39,128000,1.0006
-dutch east indies,tea,production,tonnes,1933,revised,iia_1933_34,63977.2,iia_1938_39,63986,1.0001
-dutch east indies,tobacco,area,hectares,1933,revised,iia_1933_34,84153.5,iia_1938_39,39000,2.1578
-dutch east indies,tobacco,production,tonnes,1933,revised,iia_1933_34,27828.9,iia_1938_39,3255800,116.9935
-dutch guiana,coffee: raw,area,hectares,1933,revised,iia_1933_34,10825,iia_1938_39,9000,1.2028
-dutch guiana,coffee: raw,production,tonnes,1933,revised,iia_1933_34,2624.8,iia_1938_39,2600,1.0095
-dutch guiana,sugar: cane,production,tonnes,1933,revised,iia_1933_34,16454.9,iia_1938_39,16500,1.0027
-dutch java and madura,groundnut,area,hectares,1933,revised,iia_1933_34,218054,iia_1938_39,218000,1.0002
-dutch java and madura,soybean,area,hectares,1933,revised,iia_1933_34,280494,iia_1938_39,280000,1.0018
-dutch java and madura,sugar: cane,production,tonnes,1933,revised,iia_1933_34,617059,iia_1938_39,636100,1.0309
-ecuador,cacao: raw,production,tonnes,1933,revised,iia_1933_34,16909,iia_1938_39,19000,1.1237
-ecuador,sugar: cane,production,tonnes,1933,revised,iia_1933_34,20000,iia_1938_39,20700,1.0350
-egypt,cottonseed,area,hectares,1933,revised,iia_1933_34,757912,iia_1938_39,758000,1.0001
-egypt,cottonseed,production,tonnes,1933,revised,iia_1933_34,798850,iia_1938_39,783400,1.0197
-egypt,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,440632,iia_1938_39,440600,1.0001
-egypt,flax: fibre,area,hectares,1933,revised,iia_1933_34,1405,iia_1938_39,1000,1.4050
-egypt,flax: fibre,production,tonnes,1933,revised,iia_1933_34,1131.3,iia_1938_39,1100,1.0285
-egypt,groundnut,area,hectares,1933,revised,iia_1933_34,8707,iia_1938_39,9000,1.0337
-egypt,groundnut,production,tonnes,1933,revised,iia_1933_34,11392.4,iia_1938_39,11400,1.0007
-egypt,linseed,area,hectares,1933,revised,iia_1933_34,1405,iia_1938_39,1000,1.4050
-egypt,linseed,production,tonnes,1933,revised,iia_1933_34,1245.1,iia_1938_39,1200,1.0376
-egypt,sesame,area,hectares,1933,revised,iia_1933_34,8161,iia_1938_39,8000,1.0201
-egypt,sesame,production,tonnes,1933,revised,iia_1933_34,5741.9,iia_1938_39,5700,1.0074
-egypt,sugar: cane,production,tonnes,1933,revised,iia_1933_34,154358,iia_1938_39,154500,1.0009
-el salvador,coffee: raw,area,hectares,1933,revised,iia_1933_34,100000,iia_1938_39,102000,1.0200
-el salvador,coffee: raw,production,tonnes,1933,revised,iia_1933_34,45000,iia_1938_39,58000,1.2889
-estonia,eggs,production,tonnes,1932,revised,iia_1933_34,5296.3218,iia_1938_39,90390.3,17.0666
-estonia,eggs,production,tonnes,1933,revised,iia_1933_34,5345.5325,iia_1938_39,90444.2,16.9196
-estonia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,8949,iia_1938_39,8900,1.0055
-estonia,flax: fibre,area,hectares,1933,revised,iia_1933_34,16610,iia_1938_39,17000,1.0235
-estonia,flax: fibre,production,tonnes,1933,revised,iia_1933_34,5157.1,iia_1938_39,5200,1.0083
-estonia,linseed,area,hectares,1933,revised,iia_1933_34,16610,iia_1938_39,17000,1.0235
-estonia,linseed,production,tonnes,1933,revised,iia_1933_34,6187.6,iia_1938_39,6200,1.0020
-estonia,rye,area,hectares,1933,revised,iia_1933_34,151103,iia_1938_39,151000,1.0007
-estonia,rye,production,tonnes,1933,revised,iia_1933_34,221890.2,iia_1938_39,221900,1.0000
-finland,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,45302,iia_1938_39,45300,1.0000
-finland,flax: fibre,area,hectares,1933,revised,iia_1933_34,4540,iia_1938_39,5000,1.1013
-finland,flax: fibre,production,tonnes,1933,revised,iia_1933_34,1796,iia_1938_39,1800,1.0022
-finland,rye,area,hectares,1933,revised,iia_1933_34,232742,iia_1938_39,233000,1.0011
-finland,rye,production,tonnes,1933,revised,iia_1933_34,371694.2,iia_1938_39,372700,1.0027
-finland,sugar: beet,production,tonnes,1933,revised,iia_1933_34,7287,iia_1938_39,5900,1.2351
-france,blackberries,production,tonnes,1933,revised,iia_1933_34,55427,iia_1938_39,55400,1.0005
-france,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,231,iia_1938_39,200,1.1550
-france,citrus fruits: mandarins,production,tonnes,1933,revised,iia_1933_34,279,iia_1938_39,300,1.0753
-france,citrus fruits: oranges,production,tonnes,1933,revised,iia_1933_34,1132,iia_1938_39,1100,1.0291
-france,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,343000,iia_1938_39,351000,1.0233
-france,fertilizers: calcium cyanamide,production,tonnes,1933,revised,iia_1933_34,45000,iia_1938_39,130200,2.8933
-france,fertilizers: calcium nitrate,production,tonnes,1933,revised,iia_1933_34,130000,iia_1938_39,47000,2.7660
-france,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,71100,iia_1938_39,75700,1.0647
-france,flax: fibre,area,hectares,1933,revised,iia_1933_34,14944,iia_1938_39,15000,1.0037
-france,flax: fibre,production,tonnes,1933,revised,iia_1933_34,9201.2,iia_1938_39,9200,1.0001
-france,hemp: fibre,area,hectares,1933,revised,iia_1933_34,2470,iia_1938_39,2000,1.2350
-france,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,2626.8,iia_1938_39,2600,1.0103
-france,hempseed,area,hectares,1933,revised,iia_1933_34,2470,iia_1938_39,2000,1.2350
-france,hempseed,production,tonnes,1933,revised,iia_1933_34,626.4,iia_1938_39,600,1.0440
-france,hops,production,tonnes,1920,revised,iia_1909_21,4711.5,iia_1925_26,4055,1.1619
-france,linseed,area,hectares,1933,revised,iia_1933_34,14944,iia_1938_39,15000,1.0037
-france,linseed,production,tonnes,1933,revised,iia_1933_34,4650.3,iia_1938_39,4700,1.0107
-france,olive grove,production,tonnes,1933,revised,iia_1933_34,26705,iia_1938_39,26700,1.0002
-france,olive: oil,production,tonnes,1933,revised,iia_1933_34,4810,iia_1938_39,4000,1.2025
-france,rapeseed,area,hectares,1933,revised,iia_1933_34,11340,iia_1938_39,14000,1.2346
-france,rapeseed,production,tonnes,1920,revised,iia_1909_21,41155,iia_1925_26,23767,1.7316
-france,rapeseed,production,tonnes,1933,revised,iia_1933_34,13510,iia_1938_39,15900,1.1769
-france,rye,area,hectares,1933,revised,iia_1933_34,690410,iia_1938_39,690000,1.0006
-france,rye,production,tonnes,1933,revised,iia_1933_34,897612,iia_1938_39,897600,1.0000
-france,slag: basic,production,tonnes,1933,revised,iia_1933_34,988000,iia_1938_39,988500,1.0005
-france,sugar: beet,production,tonnes,1933,revised,iia_1933_34,942901.7,iia_1938_39,851600,1.1072
-france,tobacco,area,hectares,1933,revised,iia_1933_34,17687,iia_1938_39,18000,1.0177
-france,wine,production,tonnes,1933,revised,iia_1933_34,4710693.26,iia_1938_39,4710706,1.0000
-french algeria,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,587750,iia_1938_39,587800,1.0001
-french algeria,olive grove,area,hectares,1933,revised,iia_1933_34,67984,iia_1938_39,68000,1.0002
-french algeria,olive grove,production,tonnes,1933,revised,iia_1933_34,40833.25,iia_1938_39,40850,1.0004
-french algeria,olive: oil,production,tonnes,1933,revised,iia_1933_34,8311.1,iia_1938_39,8300,1.0013
-french algeria,rye,area,hectares,1933,revised,iia_1933_34,1228,iia_1938_39,1000,1.2280
-french algeria,rye,production,tonnes,1933,revised,iia_1933_34,731.5,iia_1938_39,700,1.0450
-french algeria,tobacco,area,hectares,1933,revised,iia_1933_34,16918,iia_1938_39,17000,1.0048
-french algeria,wine,production,tonnes,1933,revised,iia_1933_34,1522516.996,iia_1938_39,1522521,1.0000
-french annam,blackberries,area,hectares,1933,revised,iia_1933_34,3500,iia_1938_39,3000,1.1667
-french annam,coffee: raw,area,hectares,1933,revised,iia_1933_34,6500,iia_1938_39,6000,1.0833
-french annam,cottonseed,area,hectares,1933,revised,iia_1933_34,7600,iia_1938_39,8000,1.0526
-french annam,cottonseed,production,tonnes,1933,revised,iia_1933_34,1550,iia_1938_39,1500,1.0333
-french annam,sesame,area,hectares,1933,revised,iia_1933_34,2500,iia_1938_39,2000,1.2500
-french cambodia,blackberries,area,hectares,1933,revised,iia_1933_34,1500,iia_1938_39,1000,1.5000
-french cambodia,cottonseed,production,tonnes,1933,revised,iia_1933_34,1290,iia_1938_39,1000,1.2900
-french cochinchina,blackberries,area,hectares,1933,revised,iia_1933_34,625,iia_1938_39,1000,1.6000
-french cochinchina,blackberries,production,tonnes,1933,revised,iia_1933_34,1203,iia_1938_39,1200,1.0025
-french cochinchina,coffee: raw,area,hectares,1933,revised,iia_1933_34,600,iia_1938_39,1000,1.6667
-french cochinchina,groundnut,area,hectares,1933,revised,iia_1933_34,3020,iia_1938_39,3000,1.0067
-french cochinchina,sugar: cane,production,tonnes,1933,revised,iia_1933_34,19400,iia_1938_39,5400,3.5926
-french cochinchina,tea,production,tonnes,1933,revised,iia_1933_34,880,iia_1938_39,236,3.7288
-french cochinchina,tobacco,area,hectares,1933,revised,iia_1933_34,3060,iia_1938_39,3000,1.0200
-french cochinchina,tobacco,production,tonnes,1933,revised,iia_1933_34,2140,iia_1938_39,270000,126.1682
-french equatorial africa,coffee: raw,production,tonnes,1933,revised,iia_1933_34,179.9,iia_1938_39,200,1.1117
-french equatorial africa,cottonseed,production,tonnes,1933,revised,iia_1933_34,9530,iia_1938_39,9500,1.0032
-french equatorial africa,groundnut,area,hectares,1933,revised,iia_1933_34,12700,iia_1938_39,13000,1.0236
-french equatorial africa,sesame,area,hectares,1933,revised,iia_1933_34,8520,iia_1938_39,8000,1.0650
-french equatorial africa,sesame,production,tonnes,1933,revised,iia_1933_34,1260,iia_1938_39,1300,1.0317
-french equatorial africa,tobacco,area,hectares,1933,revised,iia_1933_34,9250,iia_1938_39,9000,1.0278
-french guadeloupe,coffee: raw,area,hectares,1933,revised,iia_1933_34,7600,iia_1938_39,6000,1.2667
-french guadeloupe,coffee: raw,production,tonnes,1933,revised,iia_1933_34,293.5,iia_1938_39,300,1.0221
-french guinea,groundnut,area,hectares,1933,revised,iia_1933_34,20500,iia_1938_39,20000,1.0250
-french guinea,groundnut,production,tonnes,1933,revised,iia_1933_34,12274,iia_1938_39,12300,1.0021
-french india,groundnut,area,hectares,1933,revised,iia_1933_34,3026,iia_1938_39,3000,1.0087
-french india,groundnut,production,tonnes,1933,revised,iia_1933_34,1201.1,iia_1938_39,1200,1.0009
-french india,sesame,area,hectares,1933,revised,iia_1933_34,677,iia_1938_39,1000,1.4771
-french india,sesame,production,tonnes,1933,revised,iia_1933_34,227.4,iia_1938_39,200,1.1370
-french indochine,tobacco,area,hectares,1933,revised,iia_1933_34,15013,iia_1938_39,15000,1.0009
-french ivory coast,cacao: raw,production,tonnes,1933,revised,iia_1933_34,31789,iia_1938_39,41600,1.3086
-french ivory coast,coffee: raw,area,hectares,1933,revised,iia_1933_34,24812,iia_1938_39,25000,1.0076
-french ivory coast,coffee: raw,production,tonnes,1933,revised,iia_1933_34,1697.8,iia_1938_39,1700,1.0013
-french ivory coast,eggs,production,tonnes,1929,revised,iia_1929_30,381.612,iia_1933_34,217.9716,1.7507
-french ivory coast,groundnut,area,hectares,1933,revised,iia_1933_34,105540,iia_1938_39,106000,1.0044
-french ivory coast,groundnut,production,tonnes,1933,revised,iia_1933_34,49714,iia_1938_39,49700,1.0003
-french ivory coast,tobacco,area,hectares,1933,revised,iia_1933_34,1640,iia_1938_39,2000,1.2195
-french laos,cottonseed,area,hectares,1933,revised,iia_1933_34,1400,iia_1938_39,1000,1.4000
-french laos,cottonseed,production,tonnes,1933,revised,iia_1933_34,225,iia_1938_39,200,1.1250
-french laos,groundnut,production,tonnes,1933,revised,iia_1933_34,180,iia_1938_39,200,1.1111
-french laos,tobacco,area,hectares,1933,revised,iia_1933_34,500,iia_1938_39,1000,2.0000
-french madagascar,coffee: raw,area,hectares,1933,revised,iia_1933_34,69500,iia_1938_39,69000,1.0072
-french madagascar,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,13110,iia_1938_39,13100,1.0008
-french madagascar,groundnut,area,hectares,1933,revised,iia_1933_34,4601,iia_1938_39,3000,1.5337
-french madagascar,groundnut,production,tonnes,1933,revised,iia_1933_34,6440,iia_1938_39,2600,2.4769
-french martinique,sugar: cane,production,tonnes,1933,revised,iia_1933_34,48220,iia_1938_39,50700,1.0514
-french morocco,cottonseed,production,tonnes,1933,revised,iia_1933_34,60,iia_1938_39,100,1.6667
-french morocco,eggs,production,tonnes,1933,revised,iia_1933_34,32340,iia_1938_39,53900,1.6667
-french morocco,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,39000,iia_1938_39,28000,1.3929
-french morocco,linseed,area,hectares,1933,revised,iia_1933_34,12115,iia_1938_39,12000,1.0096
-french morocco,linseed,production,tonnes,1933,revised,iia_1933_34,3185,iia_1938_39,3200,1.0047
-french morocco,rye,area,hectares,1933,revised,iia_1933_34,1130,iia_1938_39,1000,1.1300
-french morocco,rye,production,tonnes,1933,revised,iia_1933_34,565,iia_1938_39,600,1.0619
-french morocco,wine,production,tonnes,1933,revised,iia_1933_34,40677,iia_1938_39,40040,1.0159
-french new caledonia,coffee: raw,area,hectares,1933,revised,iia_1933_34,2696,iia_1938_39,3000,1.1128
-french new caledonia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,6698,iia_1938_39,6700,1.0003
-french niger,tobacco,production,tonnes,1933,revised,iia_1933_34,250,iia_1938_39,22000,88.0000
-french oceania,tobacco,production,tonnes,1933,revised,iia_1933_34,22,iia_1938_39,300,13.6364
-french oceania: makatea island,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,78000,iia_1938_39,78400,1.0051
-french reunion,sugar: cane,production,tonnes,1933,revised,iia_1933_34,77430,iia_1938_39,77400,1.0004
-french sudan,tobacco,area,hectares,1933,revised,iia_1933_34,2235,iia_1938_39,3000,1.3423
-french sudan,tobacco,production,tonnes,1933,revised,iia_1933_34,1245,iia_1938_39,138500,111.2450
-french syria,hemp: fibre,area,hectares,1933,revised,iia_1933_34,960,iia_1938_39,1000,1.0417
-french syria,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,780,iia_1938_39,800,1.0256
-french syria and lebanon,blackberries,area,hectares,1933,revised,iia_1933_34,24500,iia_1938_39,21000,1.1667
-french syria and lebanon,blackberries,production,tonnes,1933,revised,iia_1933_34,220000,iia_1938_39,210000,1.0476
-french syria and lebanon,"citrus fruits: oranges, other",area,hectares,1933,revised,iia_1933_34,2504,iia_1938_39,3000,1.1981
-french syria and lebanon,"citrus fruits: oranges, other",production,tonnes,1933,revised,iia_1933_34,32810,iia_1938_39,32800,1.0003
-french syria and lebanon,cottonseed,production,tonnes,1933,revised,iia_1933_34,1940,iia_1938_39,1900,1.0211
-french syria and lebanon,olive grove,area,hectares,1933,revised,iia_1933_34,77620,iia_1938_39,78000,1.0049
-french syria and lebanon,olive grove,production,tonnes,1933,revised,iia_1933_34,24764.75,iia_1938_39,24750,1.0006
-french syria and lebanon,olive: oil,production,tonnes,1933,revised,iia_1933_34,15824.5,iia_1938_39,15800,1.0016
-french syria and lebanon,sesame,area,hectares,1933,revised,iia_1933_34,3520,iia_1938_39,4000,1.1364
-french syria and lebanon,sesame,production,tonnes,1933,revised,iia_1933_34,1107,iia_1938_39,1100,1.0064
-french syria and lebanon,tobacco,area,hectares,1933,revised,iia_1933_34,6920,iia_1938_39,7000,1.0116
-french tonkin,blackberries,area,hectares,1933,revised,iia_1933_34,2670,iia_1938_39,3000,1.1236
-french tonkin,coffee: raw,area,hectares,1933,revised,iia_1933_34,3190,iia_1938_39,3000,1.0633
-french tonkin,coffee: raw,production,tonnes,1933,revised,iia_1933_34,1250,iia_1938_39,1200,1.0417
-french tonkin,cottonseed,area,hectares,1933,revised,iia_1933_34,1335,iia_1938_39,1000,1.3350
-french tonkin,cottonseed,production,tonnes,1933,revised,iia_1933_34,60,iia_1938_39,300,5.0000
-french tonkin,groundnut,area,hectares,1933,revised,iia_1933_34,1370,iia_1938_39,1000,1.3700
-french tonkin,groundnut,production,tonnes,1933,revised,iia_1933_34,1010,iia_1938_39,1000,1.0100
-french tonkin,tobacco,area,hectares,1933,revised,iia_1933_34,1453,iia_1938_39,1000,1.4530
-french tunisia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,18550,iia_1938_39,18600,1.0027
-french tunisia,olive: oil,production,tonnes,1933,revised,iia_1933_34,60000,iia_1938_39,33000,1.8182
-german togoland,cacao: raw,area,hectares,1933,revised,iia_1933_34,15400,iia_1938_39,15000,1.0267
-german togoland,cacao: raw,production,tonnes,1933,revised,iia_1933_34,9038.5,iia_1938_39,11000,1.2170
-german togoland,groundnut,production,tonnes,1933,revised,iia_1933_34,64.3,iia_1938_39,500,7.7760
-germany,eggs,production,tonnes,1933,revised,iia_1933_34,291060,iia_1938_39,334180,1.1481
-germany,flax: fibre,area,hectares,1933,revised,iia_1933_34,4889,iia_1938_39,5000,1.0227
-germany,flax: fibre,production,tonnes,1933,revised,iia_1933_34,3114.8,iia_1938_39,3100,1.0048
-germany,hops,production,tonnes,1920,revised,iia_1909_21,6025.3,iia_1925_26,6216.1,1.0317
-germany,meslin,area,hectares,1933,revised,iia_1933_34,371859,iia_1938_39,113000,3.2908
-germany,meslin,production,tonnes,1933,revised,iia_1933_34,715992,iia_1938_39,160500,4.4610
-germany,rapeseed,area,hectares,1933,revised,iia_1933_34,5103,iia_1938_39,5000,1.0206
-germany,rapeseed,production,tonnes,1933,revised,iia_1933_34,6702,iia_1938_39,6700,1.0003
-germany,rye,area,hectares,1933,revised,iia_1933_34,4524199,iia_1938_39,4540000,1.0035
-germany,rye,production,tonnes,1933,revised,iia_1933_34,8727173,iia_1938_39,8760800,1.0039
-germany,slag: basic,production,tonnes,1933,revised,iia_1933_34,800000,iia_1938_39,1098800,1.3735
-germany,spelt,area,hectares,1933,revised,iia_1933_34,113116,iia_1938_39,372000,3.2887
-germany,spelt,production,tonnes,1933,revised,iia_1933_34,160513,iia_1938_39,716000,4.4607
-germany,sugar: beet,production,tonnes,1933,revised,iia_1933_34,1429175.2,iia_1938_39,1285500,1.1118
-germany,tobacco,area,hectares,1933,revised,iia_1933_34,11977,iia_1938_39,12000,1.0019
-germany,wine,production,tonnes,1933,revised,iia_1933_34,163666.776,iia_1938_39,151970,1.0770
-greece,citrus fruits: cedrats,production,tonnes,1933,revised,iia_1933_34,509.3,iia_1938_39,500,1.0186
-greece,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,10013.5,iia_1938_39,10000,1.0013
-greece,citrus fruits: mandarins,production,tonnes,1933,revised,iia_1933_34,7315,iia_1938_39,3700,1.9770
-greece,citrus fruits: oranges,production,tonnes,1933,revised,iia_1933_34,16280.4,iia_1938_39,16300,1.0012
-greece,cottonseed,area,hectares,1933,revised,iia_1933_34,28615,iia_1938_39,29000,1.0135
-greece,cottonseed,production,tonnes,1933,revised,iia_1933_34,16110,iia_1938_39,16100,1.0006
-greece,eggs,production,tonnes,1932,revised,iia_1933_34,21723.1553,iia_1938_39,21721.7,1.0001
-greece,eggs,production,tonnes,1933,revised,iia_1933_34,27431.866,iia_1938_39,27435.1,1.0001
-greece,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,28465,iia_1938_39,28500,1.0012
-greece,olive grove,production,tonnes,1933,revised,iia_1933_34,24485.9,iia_1938_39,24500,1.0006
-greece,olive: oil,production,tonnes,1933,revised,iia_1933_34,105355.2,iia_1938_39,105400,1.0004
-greece,rye,area,hectares,1933,revised,iia_1933_34,74021,iia_1938_39,74000,1.0003
-greece,rye,production,tonnes,1933,revised,iia_1933_34,71112.5,iia_1938_39,71100,1.0002
-greece,sesame,area,hectares,1933,revised,iia_1933_34,42186,iia_1938_39,42000,1.0044
-greece,sesame,production,tonnes,1933,revised,iia_1933_34,7302,iia_1938_39,7300,1.0003
-greece,tobacco,area,hectares,1933,revised,iia_1933_34,77556,iia_1938_39,78000,1.0057
-greece,wine,production,tonnes,1933,revised,iia_1933_34,351848.679,iia_1938_39,203294,1.7307
-guatemala,coffee: raw,production,tonnes,1933,revised,iia_1933_34,48000,iia_1938_39,36000,1.3333
-guatemala,eggs,production,tonnes,1932,revised,iia_1933_34,847.9009,iia_1938_39,862.4,1.0171
-guatemala,eggs,production,tonnes,1933,revised,iia_1933_34,903.6874,iia_1938_39,862.4,1.0479
-guatemala,sugar: cane,production,tonnes,1933,revised,iia_1933_34,32500,iia_1938_39,30000,1.0833
-haiti,coffee: raw,area,hectares,1933,revised,iia_1933_34,141600,iia_1938_39,142000,1.0028
-haiti,coffee: raw,production,tonnes,1933,revised,iia_1933_34,18000,iia_1938_39,34000,1.8889
-haiti,cottonseed,area,hectares,1933,revised,iia_1933_34,109300,iia_1938_39,102000,1.0716
-haiti,sugar: cane,production,tonnes,1933,revised,iia_1933_34,2590.5,iia_1938_39,22500,8.6856
-honduras,coffee: raw,production,tonnes,1933,revised,iia_1933_34,1500,iia_1938_39,1900,1.2667
-hungary,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,1445,iia_1938_39,1400,1.0321
-hungary,flax: fibre,area,hectares,1933,revised,iia_1933_34,7942,iia_1938_39,8000,1.0073
-hungary,flax: fibre,production,tonnes,1933,revised,iia_1933_34,3375.6,iia_1938_39,3400,1.0072
-hungary,hemp: fibre,area,hectares,1933,revised,iia_1933_34,8694,iia_1938_39,9000,1.0352
-hungary,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,4051.25,iia_1938_39,4050,1.0003
-hungary,hempseed,area,hectares,1933,revised,iia_1933_34,8694,iia_1938_39,9000,1.0352
-hungary,hempseed,production,tonnes,1933,revised,iia_1933_34,2908.55,iia_1938_39,2950,1.0143
-hungary,hops,area,hectares,1933,revised,iia_1933_34,107,iia_1938_39,1000,9.3458
-hungary,linseed,area,hectares,1933,revised,iia_1933_34,7942,iia_1938_39,8000,1.0073
-hungary,linseed,production,tonnes,1933,revised,iia_1933_34,5121.6,iia_1938_39,5100,1.0042
-hungary,rapeseed,area,hectares,1933,revised,iia_1933_34,7102,iia_1938_39,7000,1.0146
-hungary,rapeseed,production,tonnes,1933,revised,iia_1933_34,7118.6,iia_1938_39,7100,1.0026
-hungary,rye,area,hectares,1933,revised,iia_1933_34,678583,iia_1938_39,679000,1.0006
-hungary,rye,production,tonnes,1933,revised,iia_1933_34,71112.5,iia_1938_39,956500,13.4505
-hungary,sugar: beet,production,tonnes,1933,revised,iia_1933_34,135579,iia_1938_39,122000,1.1113
-hungary,tobacco,area,hectares,1933,revised,iia_1933_34,18296,iia_1938_39,18000,1.0164
-hungary,wine,production,tonnes,1933,revised,iia_1933_34,280591.948,iia_1938_39,263900,1.0633
-ireland,eggs,production,tonnes,1933,revised,iia_1933_34,66404.8,iia_1938_39,66458.7,1.0008
-ireland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,2030,iia_1938_39,2000,1.0150
-ireland,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,93476,iia_1938_39,95100,1.0174
-ireland,flax: fibre,production,tonnes,1933,revised,iia_1933_34,183.9,iia_1938_39,200,1.0875
-ireland,rye,area,hectares,1933,revised,iia_1933_34,1213,iia_1938_39,1000,1.2130
-ireland,rye,production,tonnes,1933,revised,iia_1933_34,2194.7,iia_1938_39,2200,1.0024
-ireland,sugar: beet,production,tonnes,1933,revised,iia_1933_34,35284.3,iia_1938_39,31800,1.1096
-italian dodecanese islands,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,190,iia_1938_39,200,1.0526
-italian dodecanese islands,citrus fruits: mandarins,production,tonnes,1933,revised,iia_1933_34,450,iia_1938_39,400,1.1250
-italian dodecanese islands,citrus fruits: oranges,production,tonnes,1933,revised,iia_1933_34,790,iia_1938_39,800,1.0127
-italian dodecanese islands,olive grove,production,tonnes,1933,revised,iia_1933_34,1767.1,iia_1938_39,1800,1.0186
-italian dodecanese islands,olive: oil,production,tonnes,1933,revised,iia_1933_34,569.5,iia_1938_39,600,1.0536
-italian dodecanese islands,wine,production,tonnes,1933,revised,iia_1933_34,1398.579,iia_1938_39,1365,1.0246
-italian eritrea,cottonseed,production,tonnes,1933,revised,iia_1933_34,460,iia_1938_39,500,1.0870
-italian eritrea,linseed,area,hectares,1933,revised,iia_1933_34,1500,iia_1938_39,1000,1.5000
-italy,blackberries,production,tonnes,1933,revised,iia_1933_34,1165429,iia_1938_39,1165400,1.0000
-italy,cottonseed,area,hectares,1933,revised,iia_1933_34,1465,iia_1938_39,1000,1.4650
-italy,cottonseed,production,tonnes,1933,revised,iia_1933_34,520,iia_1938_39,500,1.0400
-italy,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,105000,iia_1938_39,105700,1.0067
-italy,fertilizers: calcium cyanamide,production,tonnes,1933,revised,iia_1933_34,136591,iia_1938_39,77300,1.7670
-italy,fertilizers: calcium nitrate,production,tonnes,1933,revised,iia_1933_34,77257,iia_1938_39,137200,1.7759
-italy,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,1003298,iia_1938_39,1026200,1.0228
-italy,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,106645,iia_1938_39,106600,1.0004
-italy,fertilizers: sodium nitrate,production,tonnes,1933,revised,iia_1933_34,12288,iia_1938_39,12300,1.0010
-italy,flax: fibre,area,hectares,1933,revised,iia_1933_34,3376,iia_1938_39,3000,1.1253
-italy,flax: fibre,production,tonnes,1933,revised,iia_1933_34,1810,iia_1938_39,1800,1.0056
-italy,hemp: fibre,area,hectares,1933,revised,iia_1933_34,57182,iia_1938_39,57000,1.0032
-italy,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,57916,iia_1938_39,58800,1.0153
-italy,hempseed,production,tonnes,1933,revised,iia_1933_34,1922,iia_1938_39,1900,1.0116
-italy,linseed,area,hectares,1933,revised,iia_1933_34,4022,iia_1938_39,4000,1.0055
-italy,linseed,production,tonnes,1933,revised,iia_1933_34,2276,iia_1938_39,2200,1.0345
-italy,olive grove,area,hectares,1933,revised,iia_1933_34,1039051.5,iia_1938_39,1039500,1.0004
-italy,olive grove,production,tonnes,1933,revised,iia_1933_34,1173605,iia_1938_39,1173700,1.0001
-italy,olive: oil,production,tonnes,1933,revised,iia_1933_34,163789.7,iia_1938_39,163800,1.0001
-italy,rye,area,hectares,1933,revised,iia_1933_34,114274,iia_1938_39,114000,1.0024
-italy,rye,production,tonnes,1933,revised,iia_1933_34,171177,iia_1938_39,171200,1.0001
-italy,sugar: beet,production,tonnes,1933,revised,iia_1933_34,304492,iia_1938_39,274000,1.1113
-italy,sulphur,production,tonnes,1933,revised,iia_1933_34,401586,iia_1938_39,401600,1.0000
-italy,tobacco,area,hectares,1933,revised,iia_1933_34,35447,iia_1938_39,35000,1.0128
-italy,wine,production,tonnes,1933,revised,iia_1933_34,2993922.75,iia_1938_39,3006185,1.0041
-japan,citrus fruits: mandarins,area,hectares,1933,revised,iia_1933_34,30170,iia_1938_39,32000,1.0607
-japan,citrus fruits: mandarins,production,tonnes,1933,revised,iia_1933_34,341144.6,iia_1938_39,267700,1.2744
-japan,cottonseed,area,hectares,1933,revised,iia_1933_34,739,iia_1938_39,1000,1.3532
-japan,cottonseed,production,tonnes,1933,revised,iia_1933_34,529,iia_1938_39,500,1.0580
-japan,eggs,production,tonnes,1929,revised,iia_1929_30,136460.247,iia_1933_34,136285.072,1.0013
-japan,eggs,production,tonnes,1932,revised,iia_1933_34,191846.1083,iia_1938_39,191830.1,1.0001
-japan,eggs,production,tonnes,1933,revised,iia_1933_34,183739.0632,iia_1938_39,183745.1,1.0000
-japan,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,475000,iia_1938_39,471400,1.0076
-japan,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,1128000,iia_1938_39,1116600,1.0102
-japan,flax: fibre,area,hectares,1933,revised,iia_1933_34,13066,iia_1938_39,13000,1.0051
-japan,flax: fibre,production,tonnes,1933,revised,iia_1933_34,4011.4,iia_1938_39,4000,1.0029
-japan,hemp: fibre,area,hectares,1933,revised,iia_1933_34,6338,iia_1938_39,6000,1.0563
-japan,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,7869.2,iia_1938_39,7900,1.0039
-japan,jute,area,hectares,1933,revised,iia_1933_34,579,iia_1938_39,1000,1.7271
-japan,jute,production,tonnes,1933,revised,iia_1933_34,1208.5,iia_1938_39,1200,1.0071
-japan,linseed,area,hectares,1933,revised,iia_1933_34,13066,iia_1938_39,13000,1.0051
-japan,linseed,production,tonnes,1933,revised,iia_1933_34,3730.2,iia_1938_39,3700,1.0082
-japan,rapeseed,area,hectares,1933,revised,iia_1933_34,80813,iia_1938_39,81000,1.0023
-japan,rapeseed,production,tonnes,1933,revised,iia_1933_34,87951.8,iia_1938_39,87900,1.0006
-japan,sesame,area,hectares,1933,revised,iia_1933_34,4950,iia_1938_39,5000,1.0101
-japan,sesame,production,tonnes,1933,revised,iia_1933_34,3906.7,iia_1938_39,3900,1.0017
-japan,soybean,production,tonnes,1933,revised,iia_1933_34,362170.2,iia_1938_39,362200,1.0001
-japan,sugar: beet,production,tonnes,1933,revised,iia_1933_34,25563.9,iia_1938_39,23000,1.1115
-japan,sugar: cane,production,tonnes,1933,revised,iia_1933_34,108683.8,iia_1938_39,70700,1.5373
-japan,sulphur,production,tonnes,1933,revised,iia_1933_34,116000,iia_1938_39,114400,1.0140
-japan,tea,area,hectares,1933,revised,iia_1933_34,38167,iia_1938_39,38000,1.0044
-japan,tea,production,tonnes,1933,revised,iia_1933_34,21718.498,iia_1938_39,21718.5,1.0000
-japan,tobacco,area,hectares,1933,revised,iia_1933_34,33855,iia_1938_39,34000,1.0043
-japan: karafuto prefecture,eggs,production,tonnes,1932,revised,iia_1933_34,336.4438,iia_1938_39,323.4,1.0403
-japan: karafuto prefecture,eggs,production,tonnes,1933,revised,iia_1933_34,352.7216,iia_1938_39,377.3,1.0697
-japan: kwantung leased territory,eggs,production,tonnes,1932,revised,iia_1933_34,886.0082,iia_1938_39,862.4,1.0274
-japan: kwantung leased territory,eggs,production,tonnes,1933,revised,iia_1933_34,939.3153,iia_1938_39,916.3,1.0251
-japan: kwantung leased territory,groundnut,area,hectares,1933,revised,iia_1933_34,34600,iia_1938_39,35000,1.0116
-japan: kwantung leased territory,groundnut,production,tonnes,1933,revised,iia_1933_34,78072.9,iia_1938_39,78100,1.0003
-japan: kwantung leased territory,sesame,production,tonnes,1933,revised,iia_1933_34,70.1,iia_1938_39,100,1.4265
-japan: kwantung leased territory,soybean,area,hectares,1933,revised,iia_1933_34,52103,iia_1938_39,52000,1.0020
-japan: kwantung leased territory,soybean,production,tonnes,1933,revised,iia_1933_34,22905.9,iia_1938_39,22900,1.0003
-japanese korea,cottonseed,area,hectares,1933,revised,iia_1933_34,175200,iia_1938_39,175000,1.0011
-japanese korea,cottonseed,production,tonnes,1933,revised,iia_1933_34,70710,iia_1938_39,62200,1.1368
-japanese korea,eggs,production,tonnes,1932,revised,iia_1933_34,11052.4645,iia_1938_39,11049.5,1.0003
-japanese korea,eggs,production,tonnes,1933,revised,iia_1933_34,11587.5298,iia_1938_39,11588.5,1.0001
-japanese korea,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,247019,iia_1938_39,247000,1.0001
-japanese korea,groundnut,area,hectares,1933,revised,iia_1933_34,1431,iia_1938_39,1000,1.4310
-japanese korea,groundnut,production,tonnes,1933,revised,iia_1933_34,2540.4,iia_1938_39,2500,1.0162
-japanese korea,hemp: fibre,area,hectares,1933,revised,iia_1933_34,27054,iia_1938_39,27000,1.0020
-japanese korea,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,19752.7,iia_1938_39,19800,1.0024
-japanese korea,sesame,area,hectares,1933,revised,iia_1933_34,9959,iia_1938_39,10000,1.0041
-japanese korea,sesame,production,tonnes,1933,revised,iia_1933_34,4102.7,iia_1938_39,4500,1.0968
-japanese korea,soybean,area,hectares,1933,revised,iia_1933_34,797208,iia_1938_39,797000,1.0003
-japanese korea,soybean,production,tonnes,1933,revised,iia_1933_34,587658.3,iia_1938_39,587700,1.0001
-japanese korea,tobacco,area,hectares,1933,revised,iia_1933_34,13446,iia_1938_39,13000,1.0343
-japanese taiwan,blackberries,area,hectares,1933,revised,iia_1933_34,630,iia_1938_39,1000,1.5873
-japanese taiwan,groundnut,area,hectares,1933,revised,iia_1933_34,29800,iia_1938_39,30000,1.0067
-japanese taiwan,groundnut,production,tonnes,1933,revised,iia_1933_34,43825.8,iia_1938_39,43800,1.0006
-japanese taiwan,jute,area,hectares,1933,revised,iia_1933_34,2915,iia_1938_39,3000,1.0292
-japanese taiwan,jute,production,tonnes,1933,revised,iia_1933_34,5277,iia_1938_39,5300,1.0044
-japanese taiwan,rapeseed,production,tonnes,1933,revised,iia_1933_34,105.7,iia_1938_39,100,1.0570
-japanese taiwan,sesame,area,hectares,1933,revised,iia_1933_34,3783,iia_1938_39,4000,1.0574
-japanese taiwan,sesame,production,tonnes,1933,revised,iia_1933_34,1212.7,iia_1938_39,1300,1.0720
-japanese taiwan,soybean,area,hectares,1933,revised,iia_1933_34,8044,iia_1938_39,8000,1.0055
-japanese taiwan,soybean,production,tonnes,1933,revised,iia_1933_34,4647.4,iia_1938_39,4600,1.0103
-japanese taiwan,sugar: cane,production,tonnes,1933,revised,iia_1933_34,647031.6,iia_1938_39,647000,1.0000
-japanese taiwan,tea,area,hectares,1933,revised,iia_1933_34,40663,iia_1938_39,44000,1.0821
-japanese taiwan,tea,production,tonnes,1933,revised,iia_1933_34,9326.925,iia_1938_39,9327,1.0000
-japanese taiwan,tobacco,area,hectares,1933,revised,iia_1933_34,777,iia_1938_39,1000,1.2870
-latvia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,56306,iia_1938_39,56300,1.0001
-latvia,flax: fibre,area,hectares,1933,revised,iia_1933_34,41500,iia_1938_39,41000,1.0122
-latvia,linseed,area,hectares,1933,revised,iia_1933_34,41500,iia_1938_39,41000,1.0122
-latvia,linseed,production,tonnes,1933,revised,iia_1933_34,12320,iia_1938_39,12300,1.0016
-latvia,rye,area,hectares,1933,revised,iia_1933_34,257900,iia_1938_39,258000,1.0004
-latvia,rye,production,tonnes,1933,revised,iia_1933_34,355090,iia_1938_39,355100,1.0000
-latvia,slag: basic,production,tonnes,1933,revised,iia_1933_34,6319,iia_1938_39,6300,1.0030
-latvia,sugar: beet,production,tonnes,1933,revised,iia_1933_34,32400,iia_1938_39,29100,1.1134
-lithuania,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,45870,iia_1938_39,45700,1.0037
-lithuania,flax: fibre,area,hectares,1933,revised,iia_1933_34,54700,iia_1938_39,57000,1.0420
-lithuania,flax: fibre,production,tonnes,1933,revised,iia_1933_34,18130.5,iia_1938_39,18700,1.0314
-lithuania,linseed,area,hectares,1933,revised,iia_1933_34,54700,iia_1938_39,57000,1.0420
-lithuania,linseed,production,tonnes,1933,revised,iia_1933_34,20901,iia_1938_39,21500,1.0287
-lithuania,rye,area,hectares,1933,revised,iia_1933_34,489590,iia_1938_39,490000,1.0008
-lithuania,rye,production,tonnes,1933,revised,iia_1933_34,551998.6,iia_1938_39,552000,1.0000
-lithuania,sugar: beet,production,tonnes,1933,revised,iia_1933_34,8.1,iia_1938_39,7300,901.2346
-luxembourg,rye,area,hectares,1933,revised,iia_1933_34,8329,iia_1938_39,8000,1.0411
-luxembourg,rye,production,tonnes,1933,revised,iia_1933_34,14611.3,iia_1938_39,14600,1.0008
-luxembourg,slag: basic,production,tonnes,1933,revised,iia_1933_34,392961,iia_1938_39,393000,1.0001
-luxembourg,wine,production,tonnes,1933,revised,iia_1933_34,5156.06,iia_1938_39,4823,1.0691
-mexico,coffee: raw,area,hectares,1933,revised,iia_1933_34,81394,iia_1938_39,87000,1.0689
-mexico,coffee: raw,production,tonnes,1933,revised,iia_1933_34,35327.2,iia_1938_39,36800,1.0417
-mexico,cottonseed,area,hectares,1933,revised,iia_1933_34,171707,iia_1938_39,172000,1.0017
-mexico,cottonseed,production,tonnes,1933,revised,iia_1933_34,112930,iia_1938_39,105500,1.0704
-mexico,groundnut,area,hectares,1933,revised,iia_1933_34,6520,iia_1938_39,6000,1.0867
-mexico,groundnut,production,tonnes,1933,revised,iia_1933_34,5162.4,iia_1938_39,5200,1.0073
-mexico,linseed,area,hectares,1933,revised,iia_1933_34,2977,iia_1938_39,3000,1.0077
-mexico,linseed,production,tonnes,1933,revised,iia_1933_34,1792.8,iia_1938_39,1800,1.0040
-mexico,sesame,production,tonnes,1933,revised,iia_1933_34,12505.3,iia_1938_39,12800,1.0236
-mexico,tobacco,area,hectares,1933,revised,iia_1933_34,12565,iia_1938_39,13000,1.0346
-nepal,jute,production,tonnes,1933,revised,iia_1933_34,10428,iia_1938_39,10400,1.0027
-netherlands,eggs,production,tonnes,1929,revised,iia_1929_30,107800,iia_1933_34,101062.5,1.0667
-netherlands,eggs,production,tonnes,1932,revised,iia_1933_34,118580,iia_1938_39,114537.5,1.0353
-netherlands,eggs,production,tonnes,1933,revised,iia_1933_34,107800,iia_1938_39,103488,1.0417
-netherlands,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,348920,iia_1938_39,349600,1.0019
-netherlands,flax: fibre,area,hectares,1933,revised,iia_1933_34,4885,iia_1938_39,5000,1.0235
-netherlands,flax: fibre,production,tonnes,1933,revised,iia_1933_34,3944.1,iia_1938_39,3900,1.0113
-netherlands,linseed,area,hectares,1933,revised,iia_1933_34,4885,iia_1938_39,5000,1.0235
-netherlands,linseed,production,tonnes,1933,revised,iia_1933_34,3533.2,iia_1938_39,3500,1.0095
-netherlands,rapeseed,area,hectares,1933,revised,iia_1933_34,1460,iia_1938_39,1000,1.4600
-netherlands,rapeseed,production,tonnes,1920,revised,iia_1909_21,7499,iia_1925_26,964.2,7.7774
-netherlands,rapeseed,production,tonnes,1933,revised,iia_1933_34,2906.5,iia_1938_39,2900,1.0022
-netherlands,rye,area,hectares,1933,revised,iia_1933_34,165295,iia_1938_39,165000,1.0018
-netherlands,rye,production,tonnes,1933,revised,iia_1933_34,396297.1,iia_1938_39,396300,1.0000
-netherlands,sugar: beet,production,tonnes,1933,revised,iia_1933_34,278024.2,iia_1938_39,261100,1.0648
-new zealand,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,270138,iia_1938_39,270100,1.0001
-new zealand,linseed,area,hectares,1933,revised,iia_1933_34,583,iia_1938_39,2000,3.4305
-new zealand,linseed,production,tonnes,1933,revised,iia_1933_34,638.3,iia_1938_39,600,1.0638
-new zealand,rye,production,tonnes,1933,revised,iia_1933_34,93.3,iia_1938_39,100,1.0718
-new zealand,tobacco,area,hectares,1933,revised,iia_1933_34,730,iia_1938_39,1000,1.3699
-new zealand western samoa,cacao: raw,area,hectares,1933,revised,iia_1933_34,1900,iia_1938_39,2000,1.0526
-new zealand western samoa,cacao: raw,production,tonnes,1933,revised,iia_1933_34,913.4,iia_1938_39,900,1.0149
-norway,fertilizers: calcium cyanamide,production,tonnes,1933,revised,iia_1933_34,20246,iia_1938_39,174550,8.6215
-norway,fertilizers: calcium nitrate,production,tonnes,1933,revised,iia_1933_34,174556,iia_1938_39,20200,8.6414
-norway,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,21031,iia_1938_39,21000,1.0015
-norway,fertilizers: sodium nitrate,production,tonnes,1933,revised,iia_1933_34,83155,iia_1938_39,83200,1.0005
-norway,rye,area,hectares,1933,revised,iia_1933_34,6352,iia_1938_39,6000,1.0587
-norway,rye,production,tonnes,1933,revised,iia_1933_34,11130.3,iia_1938_39,11100,1.0027
-peru,cottonseed,production,tonnes,1933,revised,iia_1933_34,102390,iia_1938_39,101300,1.0108
-peru,"fertilizers: guano, natural",production,tonnes,1933,revised,iia_1933_34,162358,iia_1938_39,162400,1.0003
-peru,sugar: cane,production,tonnes,1933,revised,iia_1933_34,432643,iia_1938_39,390000,1.1093
-poland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,57222,iia_1938_39,57200,1.0004
-poland,fertilizers: bone superphosphate,production,tonnes,1933,revised,iia_1933_34,4923,iia_1938_39,4900,1.0047
-poland,fertilizers: calcium cyanamide,production,tonnes,1933,revised,iia_1933_34,10118,iia_1938_39,31100,3.0737
-poland,fertilizers: calcium nitrate,production,tonnes,1933,revised,iia_1933_34,31058,iia_1938_39,10100,3.0750
-poland,"fertilizers: mineral, calcium superphosphate",production,tonnes,1933,revised,iia_1933_34,49166,iia_1938_39,49200,1.0007
-poland,fertilizers: sodium nitrate,production,tonnes,1933,revised,iia_1933_34,7596,iia_1938_39,7600,1.0005
-poland,flax: fibre,area,hectares,1933,revised,iia_1933_34,95047,iia_1938_39,95000,1.0005
-poland,flax: fibre,production,tonnes,1933,revised,iia_1933_34,26619.3,iia_1938_39,26600,1.0007
-poland,hemp: fibre,area,hectares,1933,revised,iia_1933_34,32047,iia_1938_39,32000,1.0015
-poland,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,10429.5,iia_1938_39,10400,1.0028
-poland,hempseed,area,hectares,1933,revised,iia_1933_34,32047,iia_1938_39,32000,1.0015
-poland,hempseed,production,tonnes,1933,revised,iia_1933_34,15680.6,iia_1938_39,15700,1.0012
-poland,linseed,area,hectares,1933,revised,iia_1933_34,95047,iia_1938_39,95000,1.0005
-poland,linseed,production,tonnes,1933,revised,iia_1933_34,45060.4,iia_1938_39,45100,1.0009
-poland,rapeseed,area,hectares,1933,revised,iia_1933_34,30327,iia_1938_39,30000,1.0109
-poland,rapeseed,production,tonnes,1920,revised,iia_1909_21,29991.6,iia_1925_26,36972.6,1.2328
-poland,rapeseed,production,tonnes,1933,revised,iia_1933_34,27846.2,iia_1938_39,27800,1.0017
-poland,rye,area,hectares,1933,revised,iia_1933_34,5775306,iia_1938_39,5775000,1.0001
-poland,rye,production,tonnes,1933,revised,iia_1933_34,7073289.3,iia_1938_39,7073300,1.0000
-poland,sugar: beet,production,tonnes,1933,revised,iia_1933_34,342913.7,iia_1938_39,308600,1.1112
-poland,tobacco,area,hectares,1933,revised,iia_1933_34,4717,iia_1938_39,5000,1.0600
-portugal,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,180000,iia_1938_39,180700,1.0039
-portugal,olive grove,area,hectares,1933,revised,iia_1933_34,481119,iia_1938_39,481000,1.0002
-portugal,olive: oil,production,tonnes,1933,revised,iia_1933_34,74941.8,iia_1938_39,73600,1.0182
-portugal,rye,area,hectares,1933,revised,iia_1933_34,165586,iia_1938_39,166000,1.0025
-portugal,rye,production,tonnes,1933,revised,iia_1933_34,91814.8,iia_1938_39,91800,1.0002
-portugal,wine,production,tonnes,1933,revised,iia_1933_34,837234.58,iia_1938_39,837200,1.0000
-portugal: madeira,wine,production,tonnes,1933,revised,iia_1933_34,9114.196,iia_1938_39,9100,1.0016
-portuguese angola,sugar: cane,production,tonnes,1933,revised,iia_1933_34,25000,iia_1938_39,24600,1.0163
-portuguese guinea,groundnut,production,tonnes,1933,revised,iia_1933_34,27390.8,iia_1938_39,27400,1.0003
-portuguese mozambique,groundnut,production,tonnes,1933,revised,iia_1933_34,19241.1,iia_1938_39,19200,1.0021
-portuguese mozambique,sesame,production,tonnes,1933,revised,iia_1933_34,2148.2,iia_1938_39,2100,1.0230
-portuguese mozambique: company concession,eggs,production,tonnes,1932,revised,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
-portuguese mozambique: company concession,eggs,production,tonnes,1933,revised,iia_1933_34,67.1055,iia_1938_39,53.9,1.2450
-portuguese sao tome and principe,cacao: raw,production,tonnes,1933,revised,iia_1933_34,8979,iia_1938_39,9000,1.0023
-portuguese sao tome and principe,coffee: raw,production,tonnes,1933,revised,iia_1933_34,751.5,iia_1938_39,800,1.0645
-portuguese timor and kambing,coffee: raw,production,tonnes,1933,revised,iia_1933_34,965.5,iia_1938_39,1000,1.0357
-romania,cottonseed,area,hectares,1933,revised,iia_1933_34,2198,iia_1938_39,2000,1.0990
-romania,cottonseed,production,tonnes,1933,revised,iia_1933_34,900,iia_1938_39,300,3.0000
-romania,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,5205,iia_1938_39,5200,1.0010
-romania,flax: fibre,area,hectares,1933,revised,iia_1933_34,18774,iia_1938_39,19000,1.0120
-romania,flax: fibre,production,tonnes,1933,revised,iia_1933_34,6329.8,iia_1938_39,6300,1.0047
-romania,hemp: fibre,area,hectares,1933,revised,iia_1933_34,47874,iia_1938_39,48000,1.0026
-romania,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,26034.9,iia_1938_39,26000,1.0013
-romania,hempseed,area,hectares,1933,revised,iia_1933_34,47874,iia_1938_39,48000,1.0026
-romania,hempseed,production,tonnes,1933,revised,iia_1933_34,18934.2,iia_1938_39,18900,1.0018
-romania,hops,area,hectares,1933,revised,iia_1933_34,2,iia_1938_39,1000,500.0000
-romania,hops,production,tonnes,1933,revised,iia_1933_34,9.5,iia_1938_39,900,94.7368
-romania,linseed,area,hectares,1933,revised,iia_1933_34,18774,iia_1938_39,19000,1.0120
-romania,linseed,production,tonnes,1933,revised,iia_1933_34,10674.3,iia_1938_39,10700,1.0024
-romania,rapeseed,area,hectares,1933,revised,iia_1933_34,38718,iia_1938_39,39000,1.0073
-romania,rapeseed,production,tonnes,1920,revised,iia_1909_21,23669.2,iia_1925_26,19644.6,1.2049
-romania,rapeseed,production,tonnes,1933,revised,iia_1933_34,26855.9,iia_1938_39,26900,1.0016
-romania,rye,area,hectares,1933,revised,iia_1933_34,387545,iia_1938_39,388000,1.0012
-romania,rye,production,tonnes,1933,revised,iia_1933_34,445918.7,iia_1938_39,445900,1.0000
-romania,sugar: beet,production,tonnes,1933,revised,iia_1933_34,161196,iia_1938_39,105100,1.5337
-romania,tobacco,area,hectares,1933,revised,iia_1933_34,10103,iia_1938_39,10000,1.0103
-romania,wine,production,tonnes,1933,revised,iia_1933_34,683771.634,iia_1938_39,683774,1.0000
-spain,blackberries,production,tonnes,1933,revised,iia_1933_34,24834.7,iia_1938_39,24800,1.0014
-spain,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,59427.8,iia_1938_39,59400,1.0005
-spain,citrus fruits: oranges,production,tonnes,1933,revised,iia_1933_34,967185.5,iia_1938_39,967200,1.0000
-spain,cottonseed,area,hectares,1933,revised,iia_1933_34,7500,iia_1938_39,8000,1.0667
-spain,cottonseed,production,tonnes,1933,revised,iia_1933_34,1720,iia_1938_39,1700,1.0118
-spain,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,12203,iia_1938_39,12200,1.0002
-spain,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,966653,iia_1938_39,966700,1.0000
-spain,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,14507,iia_1938_39,14500,1.0005
-spain,flax: fibre,production,tonnes,1933,revised,iia_1933_34,403,iia_1938_39,400,1.0075
-spain,groundnut,production,tonnes,1933,revised,iia_1933_34,21184.8,iia_1938_39,21200,1.0007
-spain,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,3711,iia_1938_39,3700,1.0030
-spain,hempseed,production,tonnes,1933,revised,iia_1933_34,973.4,iia_1938_39,1000,1.0273
-spain,linseed,production,tonnes,1933,revised,iia_1933_34,233.8,iia_1938_39,200,1.1690
-spain,meslin,area,hectares,1933,revised,iia_1933_34,46980,iia_1938_39,30000,1.5660
-spain,meslin,production,tonnes,1933,revised,iia_1933_34,24295.2,iia_1938_39,21700,1.1196
-spain,olive grove,production,tonnes,1933,revised,iia_1933_34,1647151,iia_1938_39,1647200,1.0000
-spain,olive: oil,production,tonnes,1933,revised,iia_1933_34,310168.3,iia_1938_39,310200,1.0001
-spain,rye,production,tonnes,1933,revised,iia_1933_34,525866.9,iia_1938_39,525900,1.0001
-spain,spelt,area,hectares,1933,revised,iia_1933_34,29935,iia_1938_39,47000,1.5701
-spain,spelt,production,tonnes,1933,revised,iia_1933_34,21728.7,iia_1938_39,24300,1.1183
-spain,sugar: beet,production,tonnes,1933,revised,iia_1933_34,220000,iia_1938_39,215800,1.0195
-spain,sugar: cane,production,tonnes,1933,revised,iia_1933_34,14000,iia_1938_39,15700,1.1214
-spain,tobacco,area,hectares,1933,revised,iia_1933_34,5000,iia_1938_39,4000,1.2500
-spain,wine,production,tonnes,1933,revised,iia_1933_34,1798500.704,iia_1938_39,1753570,1.0256
-spanish fernando po,cacao: raw,area,hectares,1933,revised,iia_1933_34,36000,iia_1938_39,35000,1.0286
-spanish fernando po,cacao: raw,production,tonnes,1933,revised,iia_1933_34,11726.6,iia_1938_39,10300,1.1385
-spanish spanish guinea,cacao: raw,production,tonnes,1933,revised,iia_1933_34,660.3,iia_1938_39,700,1.0601
-sweden,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,219030,iia_1938_39,219000,1.0001
-sweden,rye,production,tonnes,1933,revised,iia_1933_34,460471,iia_1938_39,462700,1.0048
-sweden,sugar: beet,production,tonnes,1933,revised,iia_1933_34,304792,iia_1938_39,274500,1.1104
-switzerland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,909,iia_1938_39,900,1.0100
-switzerland,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,3152,iia_1938_39,3200,1.0152
-switzerland,meslin,area,hectares,1933,revised,iia_1933_34,5505,iia_1938_39,12000,2.1798
-switzerland,meslin,production,tonnes,1933,revised,iia_1933_34,13995.8,iia_1938_39,28600,2.0435
-switzerland,rye,area,hectares,1933,revised,iia_1933_34,18603,iia_1938_39,17000,1.0943
-switzerland,rye,production,tonnes,1933,revised,iia_1933_34,39249.8,iia_1938_39,35800,1.0964
-switzerland,spelt,area,hectares,1933,revised,iia_1933_34,12756,iia_1938_39,7000,1.8223
-switzerland,spelt,production,tonnes,1933,revised,iia_1933_34,31365.4,iia_1938_39,15200,2.0635
-switzerland,sugar: beet,production,tonnes,1933,revised,iia_1933_34,8970,iia_1938_39,8100,1.1074
-switzerland,wine,production,tonnes,1933,revised,iia_1933_34,21844.459,iia_1938_39,21840,1.0002
-total,cacao: raw,production,tonnes,1933,revised,iia_1933_34,45000,iia_1938_39,58000,1.2889
-total,cottonseed,area,hectares,1933,revised,iia_1933_34,1595000,iia_1938_39,1795000,1.1254
-total,cottonseed,production,tonnes,1933,revised,iia_1933_34,975500,iia_1938_39,911000,1.0708
-total,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,731000,iia_1938_39,607200,1.2039
-total,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,1145000,iia_1938_39,1133900,1.0098
-total,"fertilizers: guano, natural",production,tonnes,1933,revised,iia_1933_34,95500,iia_1938_39,103000,1.0785
-total,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,696000,iia_1938_39,718600,1.0325
-total,flax: fibre,area,hectares,1933,revised,iia_1933_34,156500,iia_1938_39,164500,1.0511
-total,flax: fibre,production,tonnes,1933,revised,iia_1933_34,63650,iia_1938_39,61100,1.0417
-total,groundnut,area,hectares,1933,revised,iia_1933_34,551000,iia_1938_39,425000,1.2965
-total,groundnut,production,tonnes,1933,revised,iia_1933_34,416000,iia_1938_39,322000,1.2919
-total,hemp: fibre,area,hectares,1933,revised,iia_1933_34,115500,iia_1938_39,119000,1.0303
-total,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,86350,iia_1938_39,91400,1.0585
-total,hempseed,area,hectares,1933,revised,iia_1933_34,117000,iia_1938_39,124000,1.0598
-total,hempseed,production,tonnes,1933,revised,iia_1933_34,50700,iia_1938_39,51000,1.0059
-total,hops,area,hectares,1933,revised,iia_1933_34,22000,iia_1938_39,130000,5.9091
-total,hops,production,tonnes,1933,revised,iia_1933_34,23300,iia_1938_39,1880000,80.6867
-total,linseed,area,hectares,1933,revised,iia_1933_34,461500,iia_1938_39,467500,1.0130
-total,linseed,production,tonnes,1933,revised,iia_1933_34,158650,iia_1938_39,160500,1.0117
-total,olive: oil,production,tonnes,1933,revised,iia_1933_34,79000,iia_1938_39,85000,1.0759
-total,rapeseed,area,hectares,1933,revised,iia_1933_34,1324000,iia_1938_39,1325000,1.0008
-total,rapeseed,production,tonnes,1933,revised,iia_1933_34,621400,iia_1938_39,620500,1.0015
-total,rye,area,hectares,1933,revised,iia_1933_34,1187000,iia_1938_39,1215000,1.0236
-total,rye,production,tonnes,1933,revised,iia_1933_34,643300,iia_1938_39,650100,1.0106
-total,soybean,area,hectares,1933,revised,iia_1933_34,5444000,iia_1938_39,5340000,1.0195
-total,soybean,production,tonnes,1933,revised,iia_1933_34,6364100,iia_1938_39,2880800,2.2091
-total,sugar: beet,production,tonnes,1933,revised,iia_1933_34,884000,iia_1938_39,1549000,1.7523
-total,sugar: cane,production,tonnes,1933,revised,iia_1933_34,1746000,iia_1938_39,2132000,1.2211
-total,sulphur,production,tonnes,1933,revised,iia_1933_34,414000,iia_1938_39,412600,1.0034
-total,tobacco,area,hectares,1933,revised,iia_1933_34,168000,iia_1938_39,149000,1.1275
-total,tobacco,production,tonnes,1933,revised,iia_1933_34,102850,iia_1938_39,8750000,85.0754
-total,wine,production,tonnes,1933,revised,iia_1933_34,888660.5,iia_1938_39,1058330,1.1909
-total general,cacao: raw,production,tonnes,1933,revised,iia_1933_34,580000,iia_1938_39,602000,1.0379
-total general,coffee: raw,production,tonnes,1933,revised,iia_1933_34,1600000,iia_1938_39,2574000,1.6087
-total general,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,4131000,iia_1938_39,4016200,1.0286
-total general,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,11804000,iia_1938_39,12009000,1.0174
-total general,"fertilizers: guano, natural",production,tonnes,1933,revised,iia_1933_34,196000,iia_1938_39,210700,1.0750
-total general,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,8155000,iia_1938_39,8779000,1.0765
-total general,groundnut,area,hectares,1933,revised,iia_1933_34,6090000,iia_1938_39,6170000,1.0131
-total general,groundnut,production,tonnes,1933,revised,iia_1933_34,5620000,iia_1938_39,5770000,1.0267
-total general,olive: oil,production,tonnes,1933,revised,iia_1933_34,779000,iia_1938_39,789000,1.0128
-total general,rapeseed,production,tonnes,1933,revised,iia_1933_34,1243000,iia_1938_39,1241000,1.0016
-total general,slag: basic,production,tonnes,1933,revised,iia_1933_34,3340000,iia_1938_39,3389700,1.0149
-total general,sugar: cane,production,tonnes,1933,revised,iia_1933_34,16880000,iia_1938_39,14910000,1.1321
-total general,sulphur,production,tonnes,1933,revised,iia_1933_34,1980000,iia_1938_39,1980500,1.0003
-total general,tea,area,hectares,1933,revised,iia_1933_34,850000,iia_1938_39,840000,1.0119
-total general,tea,production,tonnes,1933,revised,iia_1933_34,413000,iia_1938_39,412600,1.0010
-total general,wine,production,tonnes,1933,revised,iia_1933_34,15288000,iia_1938_39,15652000,1.0238
-total general excluding the ussr,cottonseed,area,hectares,1933,revised,iia_1933_34,28220000,iia_1938_39,28590000,1.0131
-total general excluding the ussr,cottonseed,production,tonnes,1933,revised,iia_1933_34,11033000,iia_1938_39,10970000,1.0057
-total general excluding the ussr,flax: fibre,area,hectares,1933,revised,iia_1933_34,314000,iia_1938_39,330000,1.0510
-total general excluding the ussr,flax: fibre,production,tonnes,1933,revised,iia_1933_34,128000,iia_1938_39,123000,1.0407
-total general excluding the ussr,hemp: fibre,area,hectares,1933,revised,iia_1933_34,231000,iia_1938_39,238000,1.0303
-total general excluding the ussr,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,173000,iia_1938_39,183000,1.0578
-total general excluding the ussr,hempseed,area,hectares,1933,revised,iia_1933_34,118000,iia_1938_39,135000,1.1441
-total general excluding the ussr,hempseed,production,tonnes,1933,revised,iia_1933_34,51000,iia_1938_39,53700,1.0529
-total general excluding the ussr,linseed,area,hectares,1933,revised,iia_1933_34,4400000,iia_1938_39,4390000,1.0023
-total general excluding the ussr,linseed,production,tonnes,1933,revised,iia_1933_34,2250000,iia_1938_39,2415000,1.0733
-total general excluding the ussr,rye,production,tonnes,1933,revised,iia_1933_34,26760000,iia_1938_39,26650000,1.0041
-total general excluding the ussr,sugar: beet,production,tonnes,1933,revised,iia_1933_34,7790000,iia_1938_39,7060000,1.1034
-total general including the ussr,cottonseed,area,hectares,1933,revised,iia_1933_34,30270000,iia_1938_39,30640000,1.0122
-total general including the ussr,cottonseed,production,tonnes,1933,revised,iia_1933_34,11904000,iia_1938_39,11840000,1.0054
-total general including the ussr,flax: fibre,area,hectares,1933,revised,iia_1933_34,2710000,iia_1938_39,2720000,1.0037
-total general including the ussr,flax: fibre,production,tonnes,1933,revised,iia_1933_34,688000,iia_1938_39,671000,1.0253
-total general including the ussr,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,327000,iia_1938_39,339000,1.0367
-total general including the ussr,hempseed,area,hectares,1933,revised,iia_1933_34,870000,iia_1938_39,850000,1.0235
-total general including the ussr,linseed,area,hectares,1933,revised,iia_1933_34,7130000,iia_1938_39,7100000,1.0042
-total general including the ussr,linseed,production,tonnes,1933,revised,iia_1933_34,3030000,iia_1938_39,3159000,1.0426
-total general including the ussr,rye,area,hectares,1933,revised,iia_1933_34,44150000,iia_1938_39,44140000,1.0002
-total general including the ussr,rye,production,tonnes,1933,revised,iia_1933_34,50950000,iia_1938_39,50840000,1.0022
-total general including the ussr,sugar: beet,production,tonnes,1933,revised,iia_1933_34,8873000,iia_1938_39,8050000,1.1022
-total general including the ussr,tobacco,area,hectares,1933,revised,iia_1933_34,2360000,iia_1938_39,2390000,1.0127
-total north hemisphere aggregated,groundnut,area,hectares,1933,revised,iia_1933_34,5540000,iia_1938_39,5610000,1.0126
-total north hemisphere aggregated,groundnut,production,tonnes,1933,revised,iia_1933_34,5130000,iia_1938_39,5230000,1.0195
-total north hemisphere aggregated,tea,area,hectares,1933,revised,iia_1933_34,655000,iia_1938_39,647000,1.0124
-total north hemisphere aggregated,tea,production,tonnes,1933,revised,iia_1933_34,335800,iia_1938_39,335400,1.0012
-total north hemisphere aggregated,wine,production,tonnes,1933,revised,iia_1933_34,13913900,iia_1938_39,14469000,1.0399
-total north hemisphere aggregated excluding the ussr,rye,area,hectares,1933,revised,iia_1933_34,18300000,iia_1938_39,18410000,1.0060
-total north hemisphere aggregated excluding the ussr,rye,production,tonnes,1933,revised,iia_1933_34,26467000,iia_1938_39,26430000,1.0014
-total north hemisphere aggregated excluding the ussr,tobacco,area,hectares,1933,revised,iia_1933_34,1800000,iia_1938_39,1820000,1.0111
-total south hemisphere aggregated,groundnut,area,hectares,1933,revised,iia_1933_34,550000,iia_1938_39,560000,1.0182
-total south hemisphere aggregated,groundnut,production,tonnes,1933,revised,iia_1933_34,490000,iia_1938_39,540000,1.1020
-total south hemisphere aggregated,linseed,production,tonnes,1933,revised,iia_1933_34,1515000,iia_1938_39,1665000,1.0990
-total south hemisphere aggregated,rye,area,hectares,1933,revised,iia_1933_34,450000,iia_1938_39,350000,1.2857
-total south hemisphere aggregated,rye,production,tonnes,1933,revised,iia_1933_34,290000,iia_1938_39,225000,1.2889
-total south hemisphere aggregated,tobacco,production,tonnes,1933,revised,iia_1933_34,250000,iia_1938_39,21800000,87.2000
-total south hemisphere aggregated,wine,production,tonnes,1933,revised,iia_1933_34,10465000,iia_1938_39,1221220,8.5693
-turkey,cottonseed,area,hectares,1933,revised,iia_1933_34,161950,iia_1938_39,162000,1.0003
-turkey,cottonseed,production,tonnes,1933,revised,iia_1933_34,55380,iia_1938_39,64800,1.1701
-turkey,linseed,area,hectares,1933,revised,iia_1933_34,34300,iia_1938_39,8000,4.2875
-turkey,linseed,production,tonnes,1933,revised,iia_1933_34,5201,iia_1938_39,6900,1.3267
-turkey,olive grove,area,hectares,1933,revised,iia_1933_34,665952,iia_1938_39,694000,1.0421
-turkey,olive: oil,production,tonnes,1933,revised,iia_1933_34,19640.9,iia_1938_39,22700,1.1558
-turkey,rye,area,hectares,1933,revised,iia_1933_34,281800,iia_1938_39,344000,1.2207
-turkey,rye,production,tonnes,1933,revised,iia_1933_34,341147,iia_1938_39,264300,1.2908
-turkey,sesame,area,hectares,1933,revised,iia_1933_34,84800,iia_1938_39,71000,1.1944
-turkey,sesame,production,tonnes,1933,revised,iia_1933_34,39960,iia_1938_39,26700,1.4966
-turkey,spelt,area,hectares,1933,revised,iia_1933_34,92900,iia_1938_39,31000,2.9968
-turkey,spelt,production,tonnes,1933,revised,iia_1933_34,114656,iia_1938_39,47100,2.4343
-turkey,sugar: beet,production,tonnes,1933,revised,iia_1933_34,73097,iia_1938_39,65500,1.1160
-turkey,tobacco,area,hectares,1933,revised,iia_1933_34,51032,iia_1938_39,51000,1.0006
-turkey,tobacco,production,tonnes,1933,revised,iia_1933_34,35367.1,iia_1938_39,4014800,113.5179
-uk,eggs,production,tonnes,1929,revised,iia_1929_30,136906,iia_1933_34,160622,1.1732
-uk,eggs,production,tonnes,1932,revised,iia_1933_34,209185.9,iia_1938_39,209239.8,1.0003
-uk,eggs,production,tonnes,1933,revised,iia_1933_34,219265.2,iia_1938_39,219480.8,1.0010
-uk,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,571018,iia_1938_39,571000,1.0000
-uk,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,382034,iia_1938_39,382000,1.0001
-uk,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,41165,iia_1938_39,41200,1.0009
-uk,hops,production,tonnes,1920,revised,iia_1909_21,14275.4,iia_1925_26,15291.4,1.0712
-uk,rye,area,hectares,1933,revised,iia_1933_34,5804,iia_1938_39,6000,1.0338
-uk,rye,production,tonnes,1933,revised,iia_1933_34,10058.9,iia_1938_39,10100,1.0041
-uk,slag: basic,production,tonnes,1933,revised,iia_1933_34,194065,iia_1938_39,194100,1.0002
-uk,sugar: beet,production,tonnes,1933,revised,iia_1933_34,506029,iia_1938_39,462600,1.0939
-uk: england and wales,eggs,production,tonnes,1929,revised,iia_1929_30,100469.6,iia_1933_34,123808.3,1.2323
-uk: england and wales,eggs,production,tonnes,1933,revised,iia_1933_34,169892.8,iia_1938_39,170000.6,1.0006
-uk: great britain,flax: fibre,area,hectares,1933,revised,iia_1933_34,226,iia_1938_39,1000,4.4248
-uk: northern ireland,eggs,production,tonnes,1929,revised,iia_1929_30,23392.6,iia_1933_34,23769.9,1.0161
-uk: northern ireland,eggs,production,tonnes,1932,revised,iia_1933_34,25872,iia_1938_39,25925.9,1.0021
-uk: northern ireland,eggs,production,tonnes,1933,revised,iia_1933_34,27542.9,iia_1938_39,27650.7,1.0039
-uk: northern ireland,flax: fibre,area,hectares,1933,revised,iia_1933_34,3959,iia_1938_39,4000,1.0104
-uk: northern ireland,flax: fibre,production,tonnes,1933,revised,iia_1933_34,2207.9,iia_1938_39,2200,1.0036
-union of south africa,cottonseed,production,tonnes,1933,revised,iia_1933_34,990,iia_1938_39,800,1.2375
-union of south africa,"fertilizers: guano, natural",production,tonnes,1933,revised,iia_1933_34,6460,iia_1938_39,5100,1.2667
-union of south africa,groundnut,production,tonnes,1933,revised,iia_1933_34,9729.4,iia_1938_39,11000,1.1306
-union of south africa,sugar: cane,production,tonnes,1933,revised,iia_1933_34,354866.3,iia_1938_39,354900,1.0001
-union of south africa,tobacco,production,tonnes,1933,revised,iia_1933_34,6894.6,iia_1938_39,634900,92.0866
-union of south africa,wine,production,tonnes,1933,revised,iia_1933_34,82906.551,iia_1938_39,105014,1.2667
-uruguay,linseed,area,hectares,1933,revised,iia_1933_34,104988,iia_1938_39,105000,1.0001
-uruguay,linseed,production,tonnes,1933,revised,iia_1933_34,73059.9,iia_1938_39,73100,1.0005
-uruguay,wine,production,tonnes,1933,revised,iia_1933_34,50050,iia_1938_39,53053,1.0600
-us philippines,eggs,production,tonnes,1932,revised,iia_1933_34,5898.5465,iia_1938_39,5875.1,1.0040
-us philippines,eggs,production,tonnes,1933,revised,iia_1933_34,6330.1777,iia_1938_39,6198.5,1.0212
-us philippines,groundnut,area,hectares,1933,revised,iia_1933_34,6535,iia_1938_39,7000,1.0712
-us philippines,groundnut,production,tonnes,1933,revised,iia_1933_34,5978.4,iia_1938_39,6000,1.0036
-us philippines,hemp: manila,area,hectares,1933,revised,iia_1933_34,447170,iia_1938_39,447000,1.0004
-us philippines,hemp: manila,production,tonnes,1933,revised,iia_1933_34,134456.3,iia_1938_39,134500,1.0003
-us philippines,sugar: cane,production,tonnes,1933,revised,iia_1933_34,715000,iia_1938_39,749600,1.0484
-us philippines,tobacco,area,hectares,1933,revised,iia_1933_34,74610,iia_1938_39,75000,1.0052
-us puerto rico,coffee: raw,area,hectares,1933,revised,iia_1933_34,80900,iia_1938_39,62000,1.3048
-us puerto rico,coffee: raw,production,tonnes,1933,revised,iia_1933_34,50.8,iia_1938_39,4100,80.7087
-us puerto rico,sugar: cane,production,tonnes,1933,revised,iia_1933_34,890057.1,iia_1938_39,947000,1.0640
-us puerto rico,tobacco,area,hectares,1933,revised,iia_1933_34,10239,iia_1938_39,10000,1.0239
-us virgin islands,sugar: cane,production,tonnes,1933,revised,iia_1933_34,4800,iia_1938_39,3100,1.5484
-usa,citrus fruits: grapefruits,production,tonnes,1933,revised,iia_1933_34,453304.8,iia_1938_39,498000,1.0986
-usa,citrus fruits: lemons,production,tonnes,1933,revised,iia_1933_34,228250,iia_1938_39,251500,1.1019
-usa,cottonseed,area,hectares,1933,revised,iia_1933_34,12131800,iia_1938_39,11891000,1.0203
-usa,cottonseed,production,tonnes,1933,revised,iia_1933_34,5264390,iia_1938_39,5264800,1.0001
-usa,eggs,production,tonnes,1932,revised,iia_1933_34,1741401.2,iia_1938_39,1956462.2,1.1235
-usa,eggs,production,tonnes,1933,revised,iia_1933_34,1714720.7,iia_1938_39,1914204.6,1.1163
-usa,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,201981,iia_1938_39,190650,1.0594
-usa,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,2444746,iia_1938_39,2444700,1.0000
-usa,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,iia_1933_34,25378,iia_1938_39,22200,1.1432
-usa,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,2346326,iia_1938_39,2397500,1.0218
-usa,groundnut,area,hectares,1933,revised,iia_1933_34,544308,iia_1938_39,594000,1.0913
-usa,groundnut,production,tonnes,1933,revised,iia_1933_34,410821,iia_1938_39,438900,1.0683
-usa,hops,production,tonnes,1920,revised,iia_1909_21,15549.1,iia_1925_26,12584.4,1.2356
-usa,linseed,area,hectares,1933,revised,iia_1933_34,537428,iia_1938_39,543000,1.0104
-usa,linseed,production,tonnes,1933,revised,iia_1933_34,176460.7,iia_1938_39,175400,1.0060
-usa,olive grove,production,tonnes,1933,revised,iia_1933_34,12700.6,iia_1938_39,12700,1.0000
-usa,rye,area,hectares,1933,revised,iia_1933_34,950617,iia_1938_39,979000,1.0299
-usa,rye,production,tonnes,1933,revised,iia_1933_34,537231.1,iia_1938_39,544000,1.0126
-usa,soybean,area,hectares,1933,revised,iia_1933_34,330600,iia_1938_39,403000,1.2190
-usa,soybean,production,tonnes,1933,revised,iia_1933_34,304200,iia_1938_39,357800,1.1762
-usa,sugar: beet,production,tonnes,1933,revised,iia_1933_34,1601700,iia_1938_39,1489600,1.0753
-usa,sulphur,production,tonnes,1933,revised,iia_1933_34,1428626,iia_1938_39,1428600,1.0000
-usa,tobacco,area,hectares,1933,revised,iia_1933_34,710878,iia_1938_39,704000,1.0098
-usa: hawaii,eggs,production,tonnes,1929,revised,iia_1929_30,1034.88,iia_1933_34,1028.1964,1.0065
-usa: hawaii,eggs,production,tonnes,1932,revised,iia_1933_34,1098.9132,iia_1938_39,1078,1.0194
-usa: hawaii,sugar: cane,production,tonnes,1933,revised,iia_1933_34,933493.4,iia_1938_39,813400,1.1476
-ussr,cottonseed,area,hectares,1933,revised,iia_1933_34,2051600,iia_1938_39,2052000,1.0002
-ussr,cottonseed,production,tonnes,1933,revised,iia_1933_34,871200,iia_1938_39,868200,1.0035
-ussr,fertilizers: ammonium sulfate,production,tonnes,1933,revised,iia_1933_34,140000,iia_1938_39,138400,1.0116
-ussr,fertilizers: calcium superphosphate,production,tonnes,1933,revised,iia_1933_34,688800,iia_1938_39,690200,1.0020
-ussr,"fertilizers: phosphate, natural",production,tonnes,1933,revised,iia_1933_34,487000,iia_1938_39,370800,1.3134
-ussr,flax: fibre,area,hectares,1933,revised,iia_1933_34,2399100,iia_1938_39,2395000,1.0017
-ussr,flax: fibre,production,tonnes,1933,revised,iia_1933_34,560000,iia_1938_39,548000,1.0219
-ussr,groundnut,area,hectares,1933,revised,iia_1933_34,2600,iia_1938_39,3000,1.1538
-ussr,hemp: fibre,area,hectares,1933,revised,iia_1933_34,755000,iia_1938_39,711000,1.0619
-ussr,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,154100,iia_1938_39,156500,1.0156
-ussr,hempseed,area,hectares,1933,revised,iia_1933_34,755000,iia_1938_39,711000,1.0619
-ussr,hempseed,production,tonnes,1933,revised,iia_1933_34,280000,iia_1938_39,276900,1.0112
-ussr,linseed,area,hectares,1933,revised,iia_1933_34,2734600,iia_1938_39,2711000,1.0087
-ussr,linseed,production,tonnes,1933,revised,iia_1933_34,780000,iia_1938_39,744400,1.0478
-ussr,rapeseed,area,hectares,1933,revised,iia_1933_34,20400,iia_1938_39,20000,1.0200
-ussr,rye,area,hectares,1933,revised,iia_1933_34,25400000,iia_1938_39,25382000,1.0007
-ussr,rye,production,tonnes,1933,revised,iia_1933_34,24190000,iia_1938_39,24185700,1.0002
-ussr,sesame,area,hectares,1933,revised,iia_1933_34,23200,iia_1938_39,23000,1.0087
-ussr,sesame,production,tonnes,1933,revised,iia_1933_34,8110,iia_1938_39,8100,1.0012
-ussr,soybean,area,hectares,1933,revised,iia_1933_34,163600,iia_1938_39,164000,1.0024
-ussr,soybean,production,tonnes,1933,revised,iia_1933_34,105580,iia_1938_39,105600,1.0002
-ussr,sugar: beet,production,tonnes,1933,revised,iia_1933_34,1083500,iia_1938_39,995300,1.0886
-ussr,tobacco,area,hectares,1933,revised,iia_1933_34,188100,iia_1938_39,196000,1.0420
-ussr,tobacco,production,tonnes,1933,revised,iia_1933_34,169170,iia_1938_39,14821000,87.6101
-ussr: transcaucasian sfsr,tea,area,hectares,1933,revised,iia_1933_34,33325,iia_1938_39,33000,1.0098
-ussr: transcaucasian sfsr,tea,production,tonnes,1933,revised,iia_1933_34,748,iia_1938_39,792,1.0588
-venezuela,cacao: raw,production,tonnes,1933,revised,iia_1933_34,11441,iia_1938_39,14000,1.2237
-venezuela,coffee: raw,production,tonnes,1933,revised,iia_1933_34,57000,iia_1938_39,48100,1.1850
-venezuela,sugar: cane,production,tonnes,1933,revised,iia_1933_34,20320,iia_1938_39,20300,1.0010
-yugoslavia,cottonseed,area,hectares,1933,revised,iia_1933_34,820,iia_1938_39,1000,1.2195
-yugoslavia,cottonseed,production,tonnes,1933,revised,iia_1933_34,160,iia_1938_39,200,1.2500
-yugoslavia,flax: fibre,area,hectares,1933,revised,iia_1933_34,11129,iia_1938_39,11000,1.0117
-yugoslavia,flax: fibre,production,tonnes,1933,revised,iia_1933_34,9927.7,iia_1938_39,9900,1.0028
-yugoslavia,hemp: fibre,area,hectares,1933,revised,iia_1933_34,30394,iia_1938_39,30000,1.0131
-yugoslavia,hemp: fibre,production,tonnes,1933,revised,iia_1933_34,27863.3,iia_1938_39,27900,1.0013
-yugoslavia,hempseed,production,tonnes,1933,revised,iia_1933_34,1503.8,iia_1938_39,1500,1.0025
-yugoslavia,linseed,production,tonnes,1933,revised,iia_1933_34,997.5,iia_1938_39,1000,1.0025
-yugoslavia,meslin,area,hectares,1933,revised,iia_1933_34,54584,iia_1938_39,17000,3.2108
-yugoslavia,meslin,production,tonnes,1933,revised,iia_1933_34,55573,iia_1938_39,14400,3.8592
-yugoslavia,olive: oil,production,tonnes,1933,revised,iia_1933_34,4253.2,iia_1938_39,4300,1.0110
-yugoslavia,rapeseed,area,hectares,1933,revised,iia_1933_34,3383,iia_1938_39,3000,1.1277
-yugoslavia,rapeseed,production,tonnes,1933,revised,iia_1933_34,2776.8,iia_1938_39,2800,1.0084
-yugoslavia,rye,area,hectares,1933,revised,iia_1933_34,256200,iia_1938_39,256000,1.0008
-yugoslavia,rye,production,tonnes,1933,revised,iia_1933_34,245348.7,iia_1938_39,245300,1.0002
-yugoslavia,spelt,area,hectares,1933,revised,iia_1933_34,16716,iia_1938_39,55000,3.2903
-yugoslavia,spelt,production,tonnes,1933,revised,iia_1933_34,14415.2,iia_1938_39,55600,3.8570
-yugoslavia,sugar: beet,production,tonnes,1933,revised,iia_1933_34,74466.9,iia_1938_39,67100,1.1098
-yugoslavia,tobacco,area,hectares,1933,revised,iia_1933_34,11144,iia_1938_39,11000,1.0131
-yugoslavia,wine,production,tonnes,1933,revised,iia_1933_34,259596.155,iia_1938_39,259623,1.0001
-austria,hemp: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,310,iia_1938_39,0,inf
-austria,hempseed,area,hectares,1933,zero_contradicted,iia_1933_34,78,iia_1938_39,0,inf
-austria,hempseed,production,tonnes,1933,zero_contradicted,iia_1933_34,36.6,iia_1938_39,0,inf
-austria,meslin,area,hectares,1933,zero_contradicted,iia_1933_34,8588,iia_1938_39,0,inf
-austria,meslin,production,tonnes,1933,zero_contradicted,iia_1933_34,11582.5,iia_1938_39,0,inf
-austria,soybean,area,hectares,1933,zero_contradicted,iia_1933_34,240,iia_1938_39,0,inf
-belgian ruanda-urundi,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,450,iia_1938_39,0,inf
-belgium,hemp: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,17,iia_1938_39,0,inf
-belgium,hemp: fibre,production,tonnes,1933,zero_contradicted,iia_1933_34,16.7,iia_1938_39,0,inf
-belgium,hempseed,area,hectares,1933,zero_contradicted,iia_1933_34,17,iia_1938_39,0,inf
-belgium,hempseed,production,tonnes,1933,zero_contradicted,iia_1933_34,13.1,iia_1938_39,0,inf
-belgium,rapeseed,area,hectares,1933,zero_contradicted,iia_1933_34,70,iia_1938_39,0,inf
-british antigua,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,26,iia_1938_39,0,inf
-british antigua,cottonseed,production,tonnes,1933,zero_contradicted,iia_1933_34,3,iia_1938_39,0,inf
-british barbados,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,25,iia_1938_39,0,inf
-british barbados,cottonseed,production,tonnes,1933,zero_contradicted,iia_1933_34,2,iia_1938_39,0,inf
-british borneo,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,303,iia_1938_39,0,inf
-british cyprus,hemp: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,71,iia_1938_39,0,inf
-british cyprus,hemp: fibre,production,tonnes,1933,zero_contradicted,iia_1933_34,42.8,iia_1938_39,0,inf
-british cyprus,hempseed,area,hectares,1933,zero_contradicted,iia_1933_34,71,iia_1938_39,0,inf
-british cyprus,hempseed,production,tonnes,1933,zero_contradicted,iia_1933_34,13.4,iia_1938_39,0,inf
-british cyprus,sesame,production,tonnes,1933,zero_contradicted,iia_1933_34,35.8,iia_1938_39,0,inf
-british cyprus,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,387,iia_1938_39,0,inf
-british dominica,citrus fruits: limes,area,hectares,1933,zero_contradicted,iia_1933_34,400,iia_1938_39,0,inf
-british guiana,citrus fruits: limes,area,hectares,1933,zero_contradicted,iia_1933_34,352,iia_1938_39,0,inf
-british malta,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,25,iia_1938_39,0,inf
-british malta,cottonseed,production,tonnes,1933,zero_contradicted,iia_1933_34,17,iia_1938_39,0,inf
-british mauritius,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,40,iia_1938_39,0,inf
-british mauritius,tea,area,hectares,1933,zero_contradicted,iia_1933_34,40,iia_1938_39,0,inf
-british montserrat,citrus fruits: limes,area,hectares,1933,zero_contradicted,iia_1933_34,200,iia_1938_39,0,inf
-british nyasaland,coffee: raw,area,hectares,1933,zero_contradicted,iia_1933_34,490,iia_1938_39,0,inf
-british nyasaland,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,41,iia_1938_39,0,inf
-british nyasaland,groundnut,production,tonnes,1933,zero_contradicted,iia_1933_34,39.2,iia_1938_39,0,inf
-british saint christopher and nevis,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,154,iia_1938_39,0,inf
-british saint vincent,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,60,iia_1938_39,0,inf
-british saint vincent,groundnut,production,tonnes,1933,zero_contradicted,iia_1933_34,21.5,iia_1938_39,0,inf
-british sierra leone,sesame,production,tonnes,1933,zero_contradicted,iia_1933_34,14.2,iia_1938_39,0,inf
-british trinidad and tobago,coffee: raw,area,hectares,1933,zero_contradicted,iia_1933_34,490,iia_1938_39,0,inf
-british uganda,tea,area,hectares,1933,zero_contradicted,iia_1933_34,346,iia_1938_39,0,inf
-bulgaria,flax: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,474,iia_1938_39,0,inf
-bulgaria,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,463,iia_1938_39,0,inf
-bulgaria,linseed,area,hectares,1933,zero_contradicted,iia_1933_34,474,iia_1938_39,0,inf
-czechoslovakia,meslin,area,hectares,1933,zero_contradicted,iia_1933_34,6610,iia_1938_39,0,inf
-french algeria,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,20,iia_1938_39,0,inf
-french algeria,cottonseed,production,tonnes,1933,zero_contradicted,iia_1933_34,9,iia_1938_39,0,inf
-french annam,jute,area,hectares,1933,zero_contradicted,iia_1933_34,200,iia_1938_39,0,inf
-french cochinchina,coffee: raw,production,tonnes,1933,zero_contradicted,iia_1933_34,100,iia_1938_39,0,inf
-french cochinchina,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,100,iia_1938_39,0,inf
-french cochinchina,cottonseed,production,tonnes,1933,zero_contradicted,iia_1933_34,18,iia_1938_39,0,inf
-french dahomey,cacao: raw,area,hectares,1933,zero_contradicted,iia_1933_34,100,iia_1938_39,0,inf
-french guadeloupe,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,300,iia_1938_39,0,inf
-french india,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,178,iia_1938_39,0,inf
-french laos,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,180,iia_1938_39,0,inf
-french madagascar,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,70,iia_1938_39,0,inf
-french mauritania,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,70,iia_1938_39,0,inf
-french morocco,cottonseed,area,hectares,1933,zero_contradicted,iia_1933_34,150,iia_1938_39,0,inf
-french morocco,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,160,iia_1938_39,0,inf
-french niger,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,400,iia_1938_39,0,inf
-french oceania,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,30,iia_1938_39,0,inf
-french saint pierre and miquelon,eggs,production,tonnes,1932,zero_contradicted,iia_1933_34,7.7616,iia_1938_39,0,inf
-french tonkin,jute,area,hectares,1933,zero_contradicted,iia_1933_34,90,iia_1938_39,0,inf
-french tunisia,linseed,area,hectares,1933,zero_contradicted,iia_1933_34,500,iia_1938_39,0,inf
-french tunisia,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,392,iia_1938_39,0,inf
-germany,hemp: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,210,iia_1938_39,0,inf
-guatemala,groundnut,area,hectares,1933,zero_contradicted,iia_1933_34,28,iia_1938_39,0,inf
-guatemala,groundnut,production,tonnes,1933,zero_contradicted,iia_1933_34,39.1,iia_1938_39,0,inf
-ireland,flax: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,379,iia_1938_39,0,inf
-italian eritrea,sesame,area,hectares,1933,zero_contradicted,iia_1933_34,40,iia_1938_39,0,inf
-italian eritrea,sesame,production,tonnes,1933,zero_contradicted,iia_1933_34,36,iia_1938_39,0,inf
-italian eritrea,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,50,iia_1938_39,0,inf
-italian libya: tripolitania,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,221,iia_1938_39,0,inf
-japan: kwantung leased territory,sesame,area,hectares,1933,zero_contradicted,iia_1933_34,126,iia_1938_39,0,inf
-japanese taiwan,rapeseed,area,hectares,1933,zero_contradicted,iia_1933_34,308,iia_1938_39,0,inf
-netherlands,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,21,iia_1938_39,0,inf
-new zealand,rye,area,hectares,1933,zero_contradicted,iia_1933_34,105,iia_1938_39,0,inf
-sweden,flax: fibre,area,hectares,1933,zero_contradicted,iia_1933_34,535,iia_1938_39,0,inf
-sweden,linseed,area,hectares,1933,zero_contradicted,iia_1933_34,535,iia_1938_39,0,inf
-sweden,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,282,iia_1938_39,0,inf
-union of south africa,fertilizers: ammonium sulfate,production,tonnes,1933,zero_contradicted,iia_1933_34,38,iia_1938_39,0,inf
-uruguay,rye,area,hectares,1933,zero_contradicted,iia_1933_34,97,iia_1938_39,0,inf
-uruguay,rye,production,tonnes,1933,zero_contradicted,iia_1933_34,42.1,iia_1938_39,0,inf
-us samoa,tobacco,area,hectares,1933,zero_contradicted,iia_1933_34,61,iia_1938_39,0,inf
-yugoslavia,sesame,area,hectares,1933,zero_contradicted,iia_1933_34,350,iia_1938_39,0,inf
+label,product,variable,unit,year,kind,zero_grid_verdict,volume_a,value_a,volume_b,value_b,ratio
+albania,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1087.3,iia_1938_39,108700,99.9724
+australia,sugar: cane,production,tonnes,1933,power_of_ten,,iia_1933_34,65128.6,iia_1938_39,636200,9.7684
+austria,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,67.2,iia_1938_39,6700,99.7024
+belgian ruanda-urundi,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,525,iia_1938_39,52500,100.0000
+belgium,hops,area,hectares,1933,power_of_ten,,iia_1933_34,597,iia_1938_39,6000,10.0503
+belgium,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,716.7,iia_1938_39,71700,100.0419
+belgium,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,6385.1,iia_1938_39,638500,99.9984
+british antigua,sugar: cane,production,tonnes,1933,power_of_ten,,iia_1933_34,2100,iia_1938_39,21000,10.0000
+british borneo,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,179.2,iia_1938_39,17900,99.8884
+british cyprus,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,207.6,iia_1938_39,20800,100.1927
+british jamaica,cacao: raw,area,hectares,1933,power_of_ten,,iia_1933_34,390,iia_1938_39,4000,10.2564
+british nyasaland,cottonseed,production,tonnes,1933,power_of_ten,,iia_1933_34,1133.5,iia_1938_39,11250,9.9250
+british palestine,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,420.6,iia_1938_39,42100,100.0951
+british transjordan,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,19.9,iia_1938_39,2000,100.5025
+british uganda,groundnut,area,hectares,1933,power_of_ten,,iia_1933_34,5103,iia_1938_39,51000,9.9941
+bulgaria,meslin,production,tonnes,1933,power_of_ten,,iia_1933_34,115096.1,iia_1938_39,11900,9.6719
+bulgaria,spelt,production,tonnes,1933,power_of_ten,,iia_1933_34,11889.9,iia_1938_39,115100,9.6805
+bulgaria,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,24455.6,iia_1938_39,2445600,100.0016
+canada,hops,area,hectares,1933,power_of_ten,,iia_1933_34,398,iia_1938_39,4000,10.0503
+canada,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,670.1,iia_1938_39,67000,99.9851
+canada,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,20354,iia_1938_39,2036800,100.0688
+cuba,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,16488.9,iia_1938_39,1672200,101.4137
+czechoslovakia,hops,area,hectares,1933,power_of_ten,,iia_1933_34,10267,iia_1938_39,103000,10.0321
+czechoslovakia,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,6267.7,iia_1938_39,626800,100.0048
+czechoslovakia,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,11777.6,iia_1938_39,1177800,100.0034
+denmark,rye,area,hectares,1933,power_of_ten,,iia_1933_34,14302,iia_1938_39,143000,9.9986
+dutch east indies,sesame,area,hectares,1933,power_of_ten,,iia_1933_34,1580,iia_1938_39,16000,10.1266
+france,hops,area,hectares,1933,power_of_ten,,iia_1933_34,1708,iia_1938_39,17000,9.9532
+france,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,1441.7,iia_1938_39,144200,100.0208
+france,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,28429.4,iia_1938_39,2842900,99.9986
+french algeria,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,13086,iia_1938_39,1307500,99.9159
+french annam,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,2800,iia_1938_39,280000,100.0000
+french cambodia,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,7000,iia_1938_39,700000,100.0000
+french dahomey,cacao: raw,production,tonnes,1933,power_of_ten,,iia_1933_34,30,iia_1938_39,300,10.0000
+french dahomey,eggs,production,tonnes,1932,power_of_ten,,iia_1933_34,129.36,iia_1938_39,1293.6,10.0000
+french equatorial africa,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1220,iia_1938_39,122000,100.0000
+french guadeloupe,sugar: cane,production,tonnes,1933,power_of_ten,,iia_1933_34,4179.7,iia_1938_39,41800,10.0007
+french guinea,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,530,iia_1938_39,53000,100.0000
+french indochine,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,13450,iia_1938_39,1401000,104.1636
+french ivory coast,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,334,iia_1938_39,3300,9.8802
+french laos,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,410,iia_1938_39,41000,100.0000
+french madagascar,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,7700,iia_1938_39,770000,100.0000
+french mauritania,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,4,iia_1938_39,400,100.0000
+french morocco,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,160.9,iia_1938_39,16100,100.0622
+french syria and lebanon,cottonseed,area,hectares,1933,power_of_ten,,iia_1933_34,780,iia_1938_39,8000,10.2564
+french syria and lebanon,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,3044.5,iia_1938_39,304400,99.9836
+french tonkin,tea,area,hectares,1933,power_of_ten,,iia_1933_34,406,iia_1938_39,4000,9.8522
+french tonkin,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1100,iia_1938_39,110000,100.0000
+french tunisia,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,510.5,iia_1938_39,51000,99.9021
+german south west africa,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,26.3,iia_1938_39,2600,98.8593
+germany,hops,area,hectares,1933,power_of_ten,,iia_1933_34,9566,iia_1938_39,96000,10.0355
+germany,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,6793.6,iia_1938_39,679400,100.0059
+germany,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,29433.4,iia_1938_39,2943300,99.9986
+greece,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,54878.4,iia_1938_39,5487800,99.9993
+guatemala,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,120.4,iia_1938_39,12000,99.6678
+hungary,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,59.1,iia_1938_39,5900,99.8308
+hungary,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,23851.2,iia_1938_39,2385100,99.9992
+italian dodecanese islands,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,74.3,iia_1938_39,7400,99.5962
+italian eritrea,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,20,iia_1938_39,2000,100.0000
+italian libya: tripolitania,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,336.5,iia_1938_39,33600,99.8514
+italy,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,44380.3,iia_1938_39,4438000,99.9993
+japan,soybean,area,hectares,1933,power_of_ten,,iia_1933_34,32367,iia_1938_39,324000,10.0102
+japan,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,66540.1,iia_1938_39,6654000,99.9998
+japanese korea,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,16553.5,iia_1938_39,1655300,99.9970
+japanese taiwan,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1536.7,iia_1938_39,153700,100.0195
+mexico,sesame,area,hectares,1933,power_of_ten,,iia_1933_34,3187,iia_1938_39,32000,10.0408
+mexico,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,9524.2,iia_1938_39,975300,102.4023
+new zealand,hops,area,hectares,1933,power_of_ten,,iia_1933_34,206,iia_1938_39,2000,9.7087
+new zealand,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,562.4,iia_1938_39,56200,99.9289
+nicaragua,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,550,iia_1938_39,55000,100.0000
+peru,cottonseed,area,hectares,1933,power_of_ten,,iia_1933_34,13048,iia_1938_39,130000,9.9632
+poland,hops,area,hectares,1933,power_of_ten,,iia_1933_34,2195,iia_1938_39,22000,10.0228
+poland,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,1152.7,iia_1938_39,115300,100.0260
+poland,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,7226.7,iia_1938_39,722700,100.0042
+romania,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,6279.7,iia_1938_39,628000,100.0048
+spain,rye,area,hectares,1933,power_of_ten,,iia_1933_34,59073,iia_1938_39,591000,10.0046
+spain,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,7257.7,iia_1938_39,725900,100.0179
+spanish spanish guinea,cacao: raw,area,hectares,1933,power_of_ten,,iia_1933_34,600,iia_1938_39,6000,10.0000
+sweden,rye,area,hectares,1933,power_of_ten,,iia_1933_34,22103,iia_1938_39,226000,10.2249
+sweden,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,545,iia_1938_39,54500,100.0000
+switzerland,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1105,iia_1938_39,110500,100.0000
+total general,hops,area,hectares,1933,power_of_ten,,iia_1933_34,45000,iia_1938_39,470000,10.4444
+total general,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,47600,iia_1938_39,4920000,103.3613
+total general excluding the ussr,rye,area,hectares,1933,power_of_ten,,iia_1933_34,18750,iia_1938_39,18760000,1000.5333
+total general including the ussr,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,2200000,iia_1938_39,217000000,98.6364
+total north hemisphere aggregated,hops,area,hectares,1933,power_of_ten,,iia_1933_34,44000,iia_1938_39,460000,10.4545
+total north hemisphere aggregated,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,46600,iia_1938_39,4770000,102.3605
+total north hemisphere aggregated excluding the ussr,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,1782000,iia_1938_39,180700000,101.4029
+uk,hops,area,hectares,1933,power_of_ten,,iia_1933_34,6837,iia_1938_39,68000,9.9459
+uk,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,10973.2,iia_1938_39,1097300,99.9982
+us philippines,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,41750.3,iia_1938_39,4175000,99.9993
+us puerto rico,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,7711,iia_1938_39,761300,98.7291
+us samoa,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,34,iia_1938_39,3400,100.0000
+usa,hops,area,hectares,1933,power_of_ten,,iia_1933_34,12262,iia_1938_39,123000,10.0310
+usa,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,18127.7,iia_1938_39,1812800,100.0017
+usa,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,624883.3,iia_1938_39,62193100,99.5275
+yugoslavia,hops,area,hectares,1933,power_of_ten,,iia_1933_34,1694,iia_1938_39,17000,10.0354
+yugoslavia,hops,production,tonnes,1933,power_of_ten,,iia_1933_34,1464.3,iia_1938_39,146400,99.9795
+yugoslavia,tobacco,production,tonnes,1933,power_of_ten,,iia_1933_34,8750.7,iia_1938_39,875100,100.0034
+albania,rye,area,hectares,1933,revised,,iia_1933_34,3482,iia_1938_39,3000,1.1607
+albania,rye,production,tonnes,1933,revised,,iia_1933_34,4580.4,iia_1938_39,4800,1.0479
+albania,tobacco,area,hectares,1933,revised,,iia_1933_34,1042,iia_1938_39,1000,1.0420
+argentina,cottonseed,area,hectares,1933,revised,,iia_1933_34,194258,iia_1938_39,195000,1.0038
+argentina,cottonseed,production,tonnes,1933,revised,,iia_1933_34,113000,iia_1938_39,106800,1.0581
+argentina,groundnut,area,hectares,1933,revised,,iia_1933_34,83193,iia_1938_39,83000,1.0023
+argentina,linseed,production,tonnes,1933,revised,,iia_1933_34,1440000,iia_1938_39,1590000,1.1042
+argentina,rye,area,hectares,1933,revised,,iia_1933_34,366,iia_1938_39,290000,792.3497
+argentina,rye,production,tonnes,1933,revised,,iia_1933_34,237000,iia_1938_39,184100,1.2873
+argentina,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,3167,iia_1938_39,3200,1.0104
+argentina,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,315744,iia_1938_39,315700,1.0001
+argentina,wine,production,tonnes,1933,revised,,iia_1933_34,728000,iia_1938_39,682500,1.0667
+australia,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,12818,iia_1938_39,12800,1.0014
+australia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,649237,iia_1938_39,759000,1.1691
+australia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,369516,iia_1938_39,100,3695.1600
+australia,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,5388.1,iia_1938_39,5400,1.0022
+australia,wine,production,tonnes,1933,revised,,iia_1933_34,56420,iia_1938_39,57876,1.0258
+austria,eggs,production,tonnes,1932,revised,,iia_1933_34,23716,iia_1938_39,25872,1.0909
+austria,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,6497,iia_1938_39,6500,1.0005
+austria,flax: fibre,area,hectares,1933,revised,,iia_1933_34,1812,iia_1938_39,2000,1.1038
+austria,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,2839.5,iia_1938_39,600,4.7325
+austria,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,598.8,iia_1938_39,100,5.9880
+austria,hops,area,hectares,1933,revised,,iia_1933_34,56,iia_1938_39,1000,17.8571
+austria,hops,production,tonnes,1920,revised,,iia_1909_21,39.3,iia_1925_26,38.9,1.0103
+austria,linseed,area,hectares,1933,revised,,iia_1933_34,1127,iia_1938_39,1000,1.1270
+austria,linseed,production,tonnes,1933,revised,,iia_1933_34,437.2,iia_1938_39,400,1.0930
+austria,rapeseed,area,hectares,1933,revised,,iia_1933_34,1804,iia_1938_39,2000,1.1086
+austria,rapeseed,production,tonnes,1920,revised,,iia_1909_21,780.1,iia_1925_26,1109.5,1.4223
+austria,rapeseed,production,tonnes,1933,revised,,iia_1933_34,2114.1,iia_1938_39,2100,1.0067
+austria,rye,area,hectares,1933,revised,,iia_1933_34,387545,iia_1938_39,388000,1.0012
+austria,rye,production,tonnes,1933,revised,,iia_1933_34,686960.9,iia_1938_39,687000,1.0001
+austria,soybean,production,tonnes,1933,revised,,iia_1933_34,327.9,iia_1938_39,300,1.0930
+austria,spelt,area,hectares,1933,revised,,iia_1933_34,6,iia_1938_39,9000,1500.0000
+austria,spelt,production,tonnes,1933,revised,,iia_1933_34,13.3,iia_1938_39,11600,872.1805
+austria,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,170459.2,iia_1938_39,150000,1.1364
+austria,wine,production,tonnes,1933,revised,,iia_1933_34,84623.175,iia_1938_39,84630,1.0001
+belgian congo,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,7566,iia_1938_39,10000,1.3217
+belgian congo,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,7850,iia_1938_39,7800,1.0064
+belgian ruanda-urundi,cottonseed,area,hectares,1933,revised,,iia_1933_34,3077,iia_1938_39,3000,1.0257
+belgian ruanda-urundi,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1190,iia_1938_39,1200,1.0084
+belgian ruanda-urundi,groundnut,area,hectares,1933,revised,,iia_1933_34,2330,iia_1938_39,2000,1.1650
+belgian ruanda-urundi,groundnut,production,tonnes,1933,revised,,iia_1933_34,1599,iia_1938_39,1600,1.0006
+belgium,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,38386,iia_1938_39,38400,1.0004
+belgium,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,25130,iia_1938_39,25100,1.0012
+belgium,flax: fibre,area,hectares,1933,revised,,iia_1933_34,10812,iia_1938_39,11000,1.0174
+belgium,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,16864.7,iia_1938_39,7800,2.1621
+belgium,hops,production,tonnes,1920,revised,,iia_1909_21,2285.3,iia_1925_26,1516.7,1.5068
+belgium,linseed,area,hectares,1933,revised,,iia_1933_34,10812,iia_1938_39,11000,1.0174
+belgium,linseed,production,tonnes,1933,revised,,iia_1933_34,6080.7,iia_1938_39,6900,1.1347
+belgium,meslin,area,hectares,1933,revised,,iia_1933_34,3400,iia_1938_39,14000,4.1176
+belgium,meslin,production,tonnes,1933,revised,,iia_1933_34,5715.3,iia_1938_39,30700,5.3715
+belgium,rapeseed,production,tonnes,1920,revised,,iia_1909_21,2379.3,iia_1925_26,687.9,3.4588
+belgium,rapeseed,production,tonnes,1933,revised,,iia_1933_34,100.9,iia_1938_39,100,1.0090
+belgium,rye,area,hectares,1933,revised,,iia_1933_34,224164,iia_1938_39,224000,1.0007
+belgium,rye,production,tonnes,1933,revised,,iia_1933_34,566693.5,iia_1938_39,566700,1.0000
+belgium,spelt,area,hectares,1933,revised,,iia_1933_34,14376,iia_1938_39,3000,4.7920
+belgium,spelt,production,tonnes,1933,revised,,iia_1933_34,30736.9,iia_1938_39,5700,5.3924
+belgium,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,243107.5,iia_1938_39,221000,1.1000
+belgium,tobacco,area,hectares,1933,revised,,iia_1933_34,2688,iia_1938_39,3000,1.1161
+brazil,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,90000,iia_1938_39,107900,1.1989
+brazil,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,860000,iia_1938_39,1776600,2.0658
+brazil,cottonseed,area,hectares,1933,revised,,iia_1933_34,790000,iia_1938_39,1154000,1.4608
+brazil,cottonseed,production,tonnes,1933,revised,,iia_1933_34,634000,iia_1938_39,512100,1.2380
+brazil,rye,production,tonnes,1933,revised,,iia_1933_34,17.5,iia_1938_39,16000,914.2857
+brazil,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,650000,iia_1938_39,1084600,1.6686
+brazil,tobacco,production,tonnes,1933,revised,,iia_1933_34,110000,iia_1938_39,9954000,90.4909
+brazil,wine,production,tonnes,1933,revised,,iia_1933_34,182000,iia_1938_39,47866,3.8023
+british aden,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,4485.3,iia_1938_39,4500,1.0033
+british barbados,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,18693.4,iia_1938_39,56650,3.0305
+british bermuda,eggs,production,tonnes,1932,revised,,iia_1933_34,81.4968,iia_1938_39,107.8,1.3228
+british bermuda,eggs,production,tonnes,1933,revised,,iia_1933_34,81.4968,iia_1938_39,107.8,1.3228
+british brunei,eggs,production,tonnes,1932,revised,,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
+british brunei,eggs,production,tonnes,1933,revised,,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
+british ceylon,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,4001,iia_1938_39,4100,1.0247
+british ceylon,cottonseed,area,hectares,1933,revised,,iia_1933_34,800,iia_1938_39,1000,1.2500
+british ceylon,tea,production,tonnes,1933,revised,,iia_1933_34,97922.118,iia_1938_39,97922,1.0000
+british ceylon,tobacco,area,hectares,1933,revised,,iia_1933_34,5700,iia_1938_39,6000,1.0526
+british cyprus,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,1277,iia_1938_39,1300,1.0180
+british cyprus,citrus fruits: oranges,production,tonnes,1933,revised,,iia_1933_34,5275,iia_1938_39,5300,1.0047
+british cyprus,cottonseed,area,hectares,1933,revised,,iia_1933_34,1925,iia_1938_39,2000,1.0390
+british cyprus,cottonseed,production,tonnes,1933,revised,,iia_1933_34,390,iia_1938_39,400,1.0256
+british cyprus,flax: fibre,area,hectares,1933,revised,,iia_1933_34,816,iia_1938_39,1000,1.2255
+british cyprus,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,234.3,iia_1938_39,200,1.1715
+british cyprus,linseed,production,tonnes,1933,revised,,iia_1933_34,388.7,iia_1938_39,400,1.0291
+british cyprus,olive grove,production,tonnes,1933,revised,,iia_1933_34,1626.6,iia_1938_39,1800,1.1066
+british cyprus,olive: oil,production,tonnes,1933,revised,,iia_1933_34,191.7,iia_1938_39,200,1.0433
+british cyprus,sesame,area,hectares,1933,revised,,iia_1933_34,562,iia_1938_39,1000,1.7794
+british cyprus,wine,production,tonnes,1933,revised,,iia_1933_34,11425.141,iia_1938_39,9737,1.1734
+british dominica,citrus fruits: limes,production,tonnes,1933,revised,,iia_1933_34,2610,iia_1938_39,2600,1.0038
+british fiji islands,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,117000,iia_1938_39,106700,1.0965
+british gambia,groundnut,production,tonnes,1933,revised,,iia_1933_34,68451.1,iia_1938_39,68500,1.0007
+british gold coast,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,210800,iia_1938_39,212600,1.0085
+british grenada,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,4360,iia_1938_39,4400,1.0092
+british guiana,cacao: raw,area,hectares,1933,revised,,iia_1933_34,323,iia_1938_39,3000,9.2879
+british guiana,coffee: raw,area,hectares,1933,revised,,iia_1933_34,1874,iia_1938_39,2000,1.0672
+british guiana,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,132000,iia_1938_39,134400,1.0182
+british india,rapeseed,production,tonnes,1920,revised,,iia_1909_21,585751.05,iia_1925_26,593350,1.0130
+british iraq,cottonseed,production,tonnes,1933,revised,,iia_1933_34,216,iia_1938_39,200,1.0800
+british jamaica,coffee: raw,area,hectares,1933,revised,,iia_1933_34,2535,iia_1938_39,3000,1.1834
+british jamaica,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,73000,iia_1938_39,73600,1.0082
+british kenya,coffee: raw,area,hectares,1933,revised,,iia_1933_34,41374,iia_1938_39,38500,1.0746
+british kenya,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,13631.9,iia_1938_39,13600,1.0023
+british kenya,cottonseed,production,tonnes,1933,revised,,iia_1933_34,2850,iia_1938_39,2900,1.0175
+british kenya,eggs,production,tonnes,1932,revised,,iia_1933_34,57.3496,iia_1938_39,53.9,1.0640
+british kenya,eggs,production,tonnes,1933,revised,,iia_1933_34,64.7339,iia_1938_39,53.9,1.2010
+british kenya,groundnut,production,tonnes,1933,revised,,iia_1933_34,403.4,iia_1938_39,400,1.0085
+british kenya,sesame,production,tonnes,1933,revised,,iia_1933_34,3294,iia_1938_39,3300,1.0018
+british kenya,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,5808.7,iia_1938_39,5800,1.0015
+british kenya,tea,area,hectares,1933,revised,,iia_1933_34,5047,iia_1938_39,5000,1.0094
+british kenya,tea,production,tonnes,1933,revised,,iia_1933_34,1389.658,iia_1938_39,1390,1.0002
+british malaya,coffee: raw,area,hectares,1933,revised,,iia_1933_34,7517,iia_1938_39,8000,1.0643
+british malaya,tea,area,hectares,1933,revised,,iia_1933_34,1016,iia_1938_39,1000,1.0160
+british mauritius,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,261459,iia_1938_39,261500,1.0002
+british montserrat,citrus fruits: limes,production,tonnes,1933,revised,,iia_1933_34,617.9,iia_1938_39,600,1.0298
+british montserrat,cottonseed,area,hectares,1933,revised,,iia_1933_34,883,iia_1938_39,1000,1.1325
+british nauru,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,97,iia_1938_39,369500,3809.2784
+british newfoundland,eggs,production,tonnes,1933,revised,,iia_1933_34,857.6568,iia_1938_39,862.4,1.0055
+british nigeria,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,69481,iia_1938_39,68500,1.0143
+british nigeria,cottonseed,production,tonnes,1933,revised,,iia_1933_34,10990,iia_1938_39,11000,1.0009
+british nigeria,groundnut,production,tonnes,1933,revised,,iia_1933_34,296984.8,iia_1938_39,297000,1.0001
+british nigeria,sesame,production,tonnes,1933,revised,,iia_1933_34,9813,iia_1938_39,9800,1.0013
+british nyasaland,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,57.3,iia_1938_39,100,1.7452
+british nyasaland,cottonseed,area,hectares,1933,revised,,iia_1933_34,6119,iia_1938_39,6000,1.0198
+british nyasaland,tea,area,hectares,1933,revised,,iia_1933_34,5597,iia_1938_39,6000,1.0720
+british nyasaland,tea,production,tonnes,1933,revised,,iia_1933_34,1383.338,iia_1938_39,1383,1.0002
+british nyasaland,tobacco,area,hectares,1933,revised,,iia_1933_34,3182,iia_1938_39,6500,2.0427
+british nyasaland,tobacco,production,tonnes,1933,revised,,iia_1933_34,1582.1,iia_1938_39,286200,180.8988
+british ocean island,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,191779,iia_1938_39,191800,1.0001
+british palestine,olive grove,production,tonnes,1933,revised,,iia_1933_34,3599,iia_1938_39,3600,1.0003
+british palestine,sesame,production,tonnes,1933,revised,,iia_1933_34,214,iia_1938_39,200,1.0700
+british palestine,tobacco,area,hectares,1933,revised,,iia_1933_34,933,iia_1938_39,1000,1.0718
+british palestine,wine,production,tonnes,1933,revised,,iia_1933_34,2711.254,iia_1938_39,1456,1.8621
+british saint christopher and nevis,cottonseed,production,tonnes,1933,revised,,iia_1933_34,60,iia_1938_39,200,3.3333
+british saint christopher and nevis,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,28715.5,iia_1938_39,28800,1.0029
+british saint lucia,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,5700,iia_1938_39,5600,1.0179
+british seychelles,"fertilizers: guano, natural",production,tonnes,1933,revised,,iia_1933_34,12307,iia_1938_39,12300,1.0006
+british southern rhodesia,eggs,production,tonnes,1932,revised,,iia_1933_34,523.8541,iia_1938_39,539,1.0289
+british southern rhodesia,eggs,production,tonnes,1933,revised,,iia_1933_34,474.8051,iia_1938_39,485.1,1.0217
+british tanganyika,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,12922,iia_1938_39,12900,1.0017
+british tanganyika,cottonseed,production,tonnes,1933,revised,,iia_1933_34,12060,iia_1938_39,13000,1.0779
+british tanganyika,groundnut,production,tonnes,1933,revised,,iia_1933_34,27840,iia_1938_39,27800,1.0014
+british tanganyika,sesame,production,tonnes,1933,revised,,iia_1933_34,4512.2,iia_1938_39,4500,1.0027
+british transjordan,eggs,production,tonnes,1932,revised,,iia_1933_34,1585.3068,iia_1938_39,1563.1,1.0142
+british transjordan,eggs,production,tonnes,1933,revised,,iia_1933_34,1619.9645,iia_1938_39,1617,1.0018
+british trinidad and tobago,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,13180,iia_1938_39,12200,1.0803
+british trinidad and tobago,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,153.9,iia_1938_39,200,1.2995
+british trinidad and tobago,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,107032,iia_1938_39,107000,1.0003
+british uganda,coffee: raw,area,hectares,1933,revised,,iia_1933_34,17029,iia_1938_39,17000,1.0017
+british uganda,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,5102.8,iia_1938_39,5100,1.0005
+british uganda,cottonseed,area,hectares,1933,revised,,iia_1933_34,441364,iia_1938_39,441000,1.0008
+british uganda,cottonseed,production,tonnes,1933,revised,,iia_1933_34,118370,iia_1938_39,120800,1.0205
+british uganda,sesame,area,hectares,1933,revised,,iia_1933_34,81643,iia_1938_39,82000,1.0044
+british uganda,tobacco,area,hectares,1933,revised,,iia_1933_34,1644,iia_1938_39,2000,1.2165
+british‑egyptian sudan,cottonseed,area,hectares,1933,revised,,iia_1933_34,134818,iia_1938_39,135000,1.0013
+british‑egyptian sudan,cottonseed,production,tonnes,1933,revised,,iia_1933_34,68230,iia_1938_39,66100,1.0322
+british‑egyptian sudan,groundnut,area,hectares,1933,revised,,iia_1933_34,12369,iia_1938_39,12000,1.0308
+british‑egyptian sudan,groundnut,production,tonnes,1933,revised,,iia_1933_34,5988,iia_1938_39,6000,1.0020
+british‑egyptian sudan,sesame,area,hectares,1933,revised,,iia_1933_34,58169,iia_1938_39,58000,1.0029
+british‑egyptian sudan,sesame,production,tonnes,1933,revised,,iia_1933_34,15675,iia_1938_39,15700,1.0016
+british‑french cameroon,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,3800,iia_1938_39,11600,3.0526
+british‑french cameroon,groundnut,production,tonnes,1933,revised,,iia_1933_34,24510,iia_1938_39,24500,1.0004
+british‑french cameroon,sesame,area,hectares,1933,revised,,iia_1933_34,10650,iia_1938_39,2000,5.3250
+british‑french cameroon,sesame,production,tonnes,1933,revised,,iia_1933_34,3205,iia_1938_39,700,4.5786
+british‑french new hebrides,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,439.9,iia_1938_39,400,1.0998
+bulgaria,blackberries,area,hectares,1933,revised,,iia_1933_34,4402,iia_1938_39,4000,1.1005
+bulgaria,blackberries,production,tonnes,1933,revised,,iia_1933_34,33108.8,iia_1938_39,33100,1.0003
+bulgaria,cottonseed,area,hectares,1933,revised,,iia_1933_34,20533,iia_1938_39,21000,1.0227
+bulgaria,cottonseed,production,tonnes,1933,revised,,iia_1933_34,6350,iia_1938_39,6400,1.0079
+bulgaria,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,106.6,iia_1938_39,100,1.0660
+bulgaria,groundnut,production,tonnes,1933,revised,,iia_1933_34,302.8,iia_1938_39,300,1.0093
+bulgaria,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,5272,iia_1938_39,5000,1.0544
+bulgaria,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,2128.7,iia_1938_39,2100,1.0137
+bulgaria,hempseed,area,hectares,1933,revised,,iia_1933_34,5272,iia_1938_39,5000,1.0544
+bulgaria,hempseed,production,tonnes,1933,revised,,iia_1933_34,1703.9,iia_1938_39,1700,1.0023
+bulgaria,linseed,production,tonnes,1933,revised,,iia_1933_34,203.7,iia_1938_39,200,1.0185
+bulgaria,meslin,area,hectares,1933,revised,,iia_1933_34,92168,iia_1938_39,12000,7.6807
+bulgaria,rapeseed,area,hectares,1933,revised,,iia_1933_34,69,iia_1938_39,1000,14.4928
+bulgaria,rapeseed,production,tonnes,1920,revised,,iia_1909_21,1391.6,iia_1925_26,434.7,3.2013
+bulgaria,rapeseed,production,tonnes,1933,revised,,iia_1933_34,897.3,iia_1938_39,900,1.0030
+bulgaria,rye,area,hectares,1933,revised,,iia_1933_34,208627,iia_1938_39,209000,1.0018
+bulgaria,rye,production,tonnes,1933,revised,,iia_1933_34,245956.7,iia_1938_39,246000,1.0002
+bulgaria,sesame,area,hectares,1933,revised,,iia_1933_34,10393,iia_1938_39,10000,1.0393
+bulgaria,sesame,production,tonnes,1933,revised,,iia_1933_34,3395.5,iia_1938_39,3400,1.0013
+bulgaria,spelt,area,hectares,1933,revised,,iia_1933_34,11784,iia_1938_39,92000,7.8072
+bulgaria,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,41545.7,iia_1938_39,40400,1.0284
+bulgaria,tobacco,area,hectares,1933,revised,,iia_1933_34,27209,iia_1938_39,27000,1.0077
+bulgaria,wine,production,tonnes,1933,revised,,iia_1933_34,217345.492,iia_1938_39,138593,1.5682
+canada,eggs,production,tonnes,1929,revised,,iia_1929_30,179872.8701,iia_1933_34,146658.666,1.2265
+canada,eggs,production,tonnes,1932,revised,,iia_1933_34,148415.3748,iia_1938_39,148440.6,1.0002
+canada,eggs,production,tonnes,1933,revised,,iia_1933_34,136206.378,iia_1938_39,143751.3,1.0554
+canada,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,74874,iia_1938_39,74900,1.0003
+canada,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,31425,iia_1938_39,31400,1.0008
+canada,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,2008,iia_1938_39,2000,1.0040
+canada,flax: fibre,area,hectares,1933,revised,,iia_1933_34,2060,iia_1938_39,2000,1.0300
+canada,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,1385.75,iia_1938_39,2800,2.0206
+canada,hops,production,tonnes,1920,revised,,iia_1909_21,391.3,iia_1925_26,308.8,1.2672
+canada,linseed,area,hectares,1933,revised,,iia_1933_34,50330,iia_1938_39,50500,1.0034
+canada,linseed,production,tonnes,1933,revised,,iia_1933_34,16050,iia_1938_39,8450,1.8994
+canada,rye,area,hectares,1933,revised,,iia_1933_34,235969,iia_1938_39,236000,1.0001
+canada,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,67730,iia_1938_39,59600,1.1364
+canada,tobacco,area,hectares,1933,revised,,iia_1933_34,18596,iia_1938_39,19000,1.0217
+chile,fertilizers: sodium nitrate,production,tonnes,1933,revised,,iia_1933_34,443000,iia_1938_39,437700,1.0121
+china,cottonseed,area,hectares,1933,revised,,iia_1933_34,2485500,iia_1938_39,2485000,1.0002
+china,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1376750,iia_1938_39,1359200,1.0129
+china,groundnut,production,tonnes,1933,revised,,iia_1933_34,191860,iia_1938_39,2980600,15.5353
+china,rapeseed,production,tonnes,1933,revised,,iia_1933_34,16540.6,iia_1938_39,2106600,127.3593
+china,sesame,production,tonnes,1933,revised,,iia_1933_34,33442.3,iia_1938_39,963400,28.8078
+china,tea,production,tonnes,1933,revised,,iia_1933_34,41939.7,iia_1938_39,40957,1.0240
+colombia,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,203000,iia_1938_39,230400,1.1350
+costa rica,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,18000,iia_1938_39,19100,1.0611
+cuba,coffee: raw,area,hectares,1933,revised,,iia_1933_34,42576,iia_1938_39,56000,1.3153
+cuba,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,23680.8,iia_1938_39,26400,1.1148
+cuba,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,2310798.7,iia_1938_39,2210000,1.0456
+cuba,tobacco,area,hectares,1933,revised,,iia_1933_34,45474,iia_1938_39,45000,1.0105
+czechoslovakia,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,31950,iia_1938_39,32000,1.0016
+czechoslovakia,fertilizers: bone superphosphate,production,tonnes,1933,revised,,iia_1933_34,3067,iia_1938_39,3100,1.0108
+czechoslovakia,fertilizers: calcium cyanamide,production,tonnes,1933,revised,,iia_1933_34,18330,iia_1938_39,16800,1.0911
+czechoslovakia,fertilizers: calcium nitrate,production,tonnes,1933,revised,,iia_1933_34,16762,iia_1938_39,18300,1.0918
+czechoslovakia,"fertilizers: mineral, calcium superphosphate",production,tonnes,1933,revised,,iia_1933_34,102512,iia_1938_39,102500,1.0001
+czechoslovakia,flax: fibre,area,hectares,1933,revised,,iia_1933_34,7098,iia_1938_39,7000,1.0140
+czechoslovakia,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,3597.3,iia_1938_39,3600,1.0008
+czechoslovakia,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,7627,iia_1938_39,8000,1.0489
+czechoslovakia,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,5337.8,iia_1938_39,5300,1.0071
+czechoslovakia,hempseed,area,hectares,1933,revised,,iia_1933_34,7627,iia_1938_39,8000,1.0489
+czechoslovakia,hempseed,production,tonnes,1933,revised,,iia_1933_34,3469,iia_1938_39,3500,1.0089
+czechoslovakia,hops,production,tonnes,1920,revised,,iia_1909_21,5265.6,iia_1925_26,5642.1,1.0715
+czechoslovakia,linseed,area,hectares,1933,revised,,iia_1933_34,7098,iia_1938_39,7000,1.0140
+czechoslovakia,linseed,production,tonnes,1933,revised,,iia_1933_34,2676.7,iia_1938_39,2700,1.0087
+czechoslovakia,meslin,production,tonnes,1933,revised,,iia_1933_34,12438.1,iia_1938_39,700,17.7687
+czechoslovakia,rapeseed,area,hectares,1933,revised,,iia_1933_34,970,iia_1938_39,1000,1.0309
+czechoslovakia,rapeseed,production,tonnes,1920,revised,,iia_1909_21,7203.5,iia_1925_26,4251.6,1.6943
+czechoslovakia,rapeseed,production,tonnes,1933,revised,,iia_1933_34,1033.5,iia_1938_39,1000,1.0335
+czechoslovakia,rye,area,hectares,1933,revised,,iia_1933_34,1045658,iia_1938_39,1046000,1.0003
+czechoslovakia,rye,production,tonnes,1933,revised,,iia_1933_34,2085537.2,iia_1938_39,2085500,1.0000
+czechoslovakia,slag: basic,production,tonnes,1933,revised,,iia_1933_34,71383,iia_1938_39,71400,1.0002
+czechoslovakia,spelt,area,hectares,1933,revised,,iia_1933_34,440,iia_1938_39,7000,15.9091
+czechoslovakia,spelt,production,tonnes,1933,revised,,iia_1933_34,700.2,iia_1938_39,12400,17.7092
+czechoslovakia,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,515766,iia_1938_39,455300,1.1328
+czechoslovakia,tobacco,area,hectares,1933,revised,,iia_1933_34,10030,iia_1938_39,10000,1.0030
+czechoslovakia,wine,production,tonnes,1933,revised,,iia_1933_34,30727.242,iia_1938_39,30758,1.0010
+denmark,eggs,production,tonnes,1929,revised,,iia_1929_30,59424.75,iia_1933_34,62516.6157,1.0520
+denmark,eggs,production,tonnes,1933,revised,,iia_1933_34,73074.7094,iia_1938_39,79664.2,1.0902
+denmark,rye,production,tonnes,1933,revised,,iia_1933_34,251441,iia_1938_39,251400,1.0002
+denmark,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,243800,iia_1938_39,229200,1.0637
+dominican republic,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,22461,iia_1938_39,22900,1.0195
+dominican republic,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,388510,iia_1938_39,362000,1.0732
+dutch east indies,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,1903,iia_1938_39,1600,1.1894
+dutch east indies,coffee: raw,area,hectares,1933,revised,,iia_1933_34,116897,iia_1938_39,117000,1.0009
+dutch east indies,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,53222.1,iia_1938_39,53200,1.0004
+dutch east indies,cottonseed,area,hectares,1933,revised,,iia_1933_34,8094,iia_1938_39,8000,1.0117
+dutch east indies,cottonseed,production,tonnes,1933,revised,,iia_1933_34,2850,iia_1938_39,2900,1.0175
+dutch east indies,sesame,production,tonnes,1933,revised,,iia_1933_34,3143.5,iia_1938_39,3100,1.0140
+dutch east indies,sulphur,production,tonnes,1933,revised,,iia_1933_34,11213,iia_1938_39,11200,1.0012
+dutch east indies,tea,area,hectares,1933,revised,,iia_1933_34,128078,iia_1938_39,128000,1.0006
+dutch east indies,tea,production,tonnes,1933,revised,,iia_1933_34,63977.2,iia_1938_39,63986,1.0001
+dutch east indies,tobacco,area,hectares,1933,revised,,iia_1933_34,84153.5,iia_1938_39,39000,2.1578
+dutch east indies,tobacco,production,tonnes,1933,revised,,iia_1933_34,27828.9,iia_1938_39,3255800,116.9935
+dutch guiana,coffee: raw,area,hectares,1933,revised,,iia_1933_34,10825,iia_1938_39,9000,1.2028
+dutch guiana,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,2624.8,iia_1938_39,2600,1.0095
+dutch guiana,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,16454.9,iia_1938_39,16500,1.0027
+dutch java and madura,groundnut,area,hectares,1933,revised,,iia_1933_34,218054,iia_1938_39,218000,1.0002
+dutch java and madura,soybean,area,hectares,1933,revised,,iia_1933_34,280494,iia_1938_39,280000,1.0018
+dutch java and madura,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,617059,iia_1938_39,636100,1.0309
+ecuador,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,16909,iia_1938_39,19000,1.1237
+ecuador,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,20000,iia_1938_39,20700,1.0350
+egypt,cottonseed,area,hectares,1933,revised,,iia_1933_34,757912,iia_1938_39,758000,1.0001
+egypt,cottonseed,production,tonnes,1933,revised,,iia_1933_34,798850,iia_1938_39,783400,1.0197
+egypt,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,440632,iia_1938_39,440600,1.0001
+egypt,flax: fibre,area,hectares,1933,revised,,iia_1933_34,1405,iia_1938_39,1000,1.4050
+egypt,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,1131.3,iia_1938_39,1100,1.0285
+egypt,groundnut,area,hectares,1933,revised,,iia_1933_34,8707,iia_1938_39,9000,1.0337
+egypt,groundnut,production,tonnes,1933,revised,,iia_1933_34,11392.4,iia_1938_39,11400,1.0007
+egypt,linseed,area,hectares,1933,revised,,iia_1933_34,1405,iia_1938_39,1000,1.4050
+egypt,linseed,production,tonnes,1933,revised,,iia_1933_34,1245.1,iia_1938_39,1200,1.0376
+egypt,sesame,area,hectares,1933,revised,,iia_1933_34,8161,iia_1938_39,8000,1.0201
+egypt,sesame,production,tonnes,1933,revised,,iia_1933_34,5741.9,iia_1938_39,5700,1.0074
+egypt,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,154358,iia_1938_39,154500,1.0009
+el salvador,coffee: raw,area,hectares,1933,revised,,iia_1933_34,100000,iia_1938_39,102000,1.0200
+el salvador,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,45000,iia_1938_39,58000,1.2889
+estonia,eggs,production,tonnes,1932,revised,,iia_1933_34,5296.3218,iia_1938_39,90390.3,17.0666
+estonia,eggs,production,tonnes,1933,revised,,iia_1933_34,5345.5325,iia_1938_39,90444.2,16.9196
+estonia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,8949,iia_1938_39,8900,1.0055
+estonia,flax: fibre,area,hectares,1933,revised,,iia_1933_34,16610,iia_1938_39,17000,1.0235
+estonia,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,5157.1,iia_1938_39,5200,1.0083
+estonia,linseed,area,hectares,1933,revised,,iia_1933_34,16610,iia_1938_39,17000,1.0235
+estonia,linseed,production,tonnes,1933,revised,,iia_1933_34,6187.6,iia_1938_39,6200,1.0020
+estonia,rye,area,hectares,1933,revised,,iia_1933_34,151103,iia_1938_39,151000,1.0007
+estonia,rye,production,tonnes,1933,revised,,iia_1933_34,221890.2,iia_1938_39,221900,1.0000
+finland,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,45302,iia_1938_39,45300,1.0000
+finland,flax: fibre,area,hectares,1933,revised,,iia_1933_34,4540,iia_1938_39,5000,1.1013
+finland,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,1796,iia_1938_39,1800,1.0022
+finland,rye,area,hectares,1933,revised,,iia_1933_34,232742,iia_1938_39,233000,1.0011
+finland,rye,production,tonnes,1933,revised,,iia_1933_34,371694.2,iia_1938_39,372700,1.0027
+finland,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,7287,iia_1938_39,5900,1.2351
+france,blackberries,production,tonnes,1933,revised,,iia_1933_34,55427,iia_1938_39,55400,1.0005
+france,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,231,iia_1938_39,200,1.1550
+france,citrus fruits: mandarins,production,tonnes,1933,revised,,iia_1933_34,279,iia_1938_39,300,1.0753
+france,citrus fruits: oranges,production,tonnes,1933,revised,,iia_1933_34,1132,iia_1938_39,1100,1.0291
+france,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,343000,iia_1938_39,351000,1.0233
+france,fertilizers: calcium cyanamide,production,tonnes,1933,revised,,iia_1933_34,45000,iia_1938_39,130200,2.8933
+france,fertilizers: calcium nitrate,production,tonnes,1933,revised,,iia_1933_34,130000,iia_1938_39,47000,2.7660
+france,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,71100,iia_1938_39,75700,1.0647
+france,flax: fibre,area,hectares,1933,revised,,iia_1933_34,14944,iia_1938_39,15000,1.0037
+france,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,9201.2,iia_1938_39,9200,1.0001
+france,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,2470,iia_1938_39,2000,1.2350
+france,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,2626.8,iia_1938_39,2600,1.0103
+france,hempseed,area,hectares,1933,revised,,iia_1933_34,2470,iia_1938_39,2000,1.2350
+france,hempseed,production,tonnes,1933,revised,,iia_1933_34,626.4,iia_1938_39,600,1.0440
+france,hops,production,tonnes,1920,revised,,iia_1909_21,4711.5,iia_1925_26,4055,1.1619
+france,linseed,area,hectares,1933,revised,,iia_1933_34,14944,iia_1938_39,15000,1.0037
+france,linseed,production,tonnes,1933,revised,,iia_1933_34,4650.3,iia_1938_39,4700,1.0107
+france,olive grove,production,tonnes,1933,revised,,iia_1933_34,26705,iia_1938_39,26700,1.0002
+france,olive: oil,production,tonnes,1933,revised,,iia_1933_34,4810,iia_1938_39,4000,1.2025
+france,rapeseed,area,hectares,1933,revised,,iia_1933_34,11340,iia_1938_39,14000,1.2346
+france,rapeseed,production,tonnes,1920,revised,,iia_1909_21,41155,iia_1925_26,23767,1.7316
+france,rapeseed,production,tonnes,1933,revised,,iia_1933_34,13510,iia_1938_39,15900,1.1769
+france,rye,area,hectares,1933,revised,,iia_1933_34,690410,iia_1938_39,690000,1.0006
+france,rye,production,tonnes,1933,revised,,iia_1933_34,897612,iia_1938_39,897600,1.0000
+france,slag: basic,production,tonnes,1933,revised,,iia_1933_34,988000,iia_1938_39,988500,1.0005
+france,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,942901.7,iia_1938_39,851600,1.1072
+france,tobacco,area,hectares,1933,revised,,iia_1933_34,17687,iia_1938_39,18000,1.0177
+france,wine,production,tonnes,1933,revised,,iia_1933_34,4710693.26,iia_1938_39,4710706,1.0000
+french algeria,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,587750,iia_1938_39,587800,1.0001
+french algeria,olive grove,area,hectares,1933,revised,,iia_1933_34,67984,iia_1938_39,68000,1.0002
+french algeria,olive grove,production,tonnes,1933,revised,,iia_1933_34,40833.25,iia_1938_39,40850,1.0004
+french algeria,olive: oil,production,tonnes,1933,revised,,iia_1933_34,8311.1,iia_1938_39,8300,1.0013
+french algeria,rye,area,hectares,1933,revised,,iia_1933_34,1228,iia_1938_39,1000,1.2280
+french algeria,rye,production,tonnes,1933,revised,,iia_1933_34,731.5,iia_1938_39,700,1.0450
+french algeria,tobacco,area,hectares,1933,revised,,iia_1933_34,16918,iia_1938_39,17000,1.0048
+french algeria,wine,production,tonnes,1933,revised,,iia_1933_34,1522516.996,iia_1938_39,1522521,1.0000
+french annam,blackberries,area,hectares,1933,revised,,iia_1933_34,3500,iia_1938_39,3000,1.1667
+french annam,coffee: raw,area,hectares,1933,revised,,iia_1933_34,6500,iia_1938_39,6000,1.0833
+french annam,cottonseed,area,hectares,1933,revised,,iia_1933_34,7600,iia_1938_39,8000,1.0526
+french annam,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1550,iia_1938_39,1500,1.0333
+french annam,sesame,area,hectares,1933,revised,,iia_1933_34,2500,iia_1938_39,2000,1.2500
+french cambodia,blackberries,area,hectares,1933,revised,,iia_1933_34,1500,iia_1938_39,1000,1.5000
+french cambodia,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1290,iia_1938_39,1000,1.2900
+french cochinchina,blackberries,area,hectares,1933,revised,,iia_1933_34,625,iia_1938_39,1000,1.6000
+french cochinchina,blackberries,production,tonnes,1933,revised,,iia_1933_34,1203,iia_1938_39,1200,1.0025
+french cochinchina,coffee: raw,area,hectares,1933,revised,,iia_1933_34,600,iia_1938_39,1000,1.6667
+french cochinchina,groundnut,area,hectares,1933,revised,,iia_1933_34,3020,iia_1938_39,3000,1.0067
+french cochinchina,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,19400,iia_1938_39,5400,3.5926
+french cochinchina,tea,production,tonnes,1933,revised,,iia_1933_34,880,iia_1938_39,236,3.7288
+french cochinchina,tobacco,area,hectares,1933,revised,,iia_1933_34,3060,iia_1938_39,3000,1.0200
+french cochinchina,tobacco,production,tonnes,1933,revised,,iia_1933_34,2140,iia_1938_39,270000,126.1682
+french equatorial africa,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,179.9,iia_1938_39,200,1.1117
+french equatorial africa,cottonseed,production,tonnes,1933,revised,,iia_1933_34,9530,iia_1938_39,9500,1.0032
+french equatorial africa,groundnut,area,hectares,1933,revised,,iia_1933_34,12700,iia_1938_39,13000,1.0236
+french equatorial africa,sesame,area,hectares,1933,revised,,iia_1933_34,8520,iia_1938_39,8000,1.0650
+french equatorial africa,sesame,production,tonnes,1933,revised,,iia_1933_34,1260,iia_1938_39,1300,1.0317
+french equatorial africa,tobacco,area,hectares,1933,revised,,iia_1933_34,9250,iia_1938_39,9000,1.0278
+french guadeloupe,coffee: raw,area,hectares,1933,revised,,iia_1933_34,7600,iia_1938_39,6000,1.2667
+french guadeloupe,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,293.5,iia_1938_39,300,1.0221
+french guinea,groundnut,area,hectares,1933,revised,,iia_1933_34,20500,iia_1938_39,20000,1.0250
+french guinea,groundnut,production,tonnes,1933,revised,,iia_1933_34,12274,iia_1938_39,12300,1.0021
+french india,groundnut,area,hectares,1933,revised,,iia_1933_34,3026,iia_1938_39,3000,1.0087
+french india,groundnut,production,tonnes,1933,revised,,iia_1933_34,1201.1,iia_1938_39,1200,1.0009
+french india,sesame,area,hectares,1933,revised,,iia_1933_34,677,iia_1938_39,1000,1.4771
+french india,sesame,production,tonnes,1933,revised,,iia_1933_34,227.4,iia_1938_39,200,1.1370
+french indochine,tobacco,area,hectares,1933,revised,,iia_1933_34,15013,iia_1938_39,15000,1.0009
+french ivory coast,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,31789,iia_1938_39,41600,1.3086
+french ivory coast,coffee: raw,area,hectares,1933,revised,,iia_1933_34,24812,iia_1938_39,25000,1.0076
+french ivory coast,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,1697.8,iia_1938_39,1700,1.0013
+french ivory coast,eggs,production,tonnes,1929,revised,,iia_1929_30,381.612,iia_1933_34,217.9716,1.7507
+french ivory coast,groundnut,area,hectares,1933,revised,,iia_1933_34,105540,iia_1938_39,106000,1.0044
+french ivory coast,groundnut,production,tonnes,1933,revised,,iia_1933_34,49714,iia_1938_39,49700,1.0003
+french ivory coast,tobacco,area,hectares,1933,revised,,iia_1933_34,1640,iia_1938_39,2000,1.2195
+french laos,cottonseed,area,hectares,1933,revised,,iia_1933_34,1400,iia_1938_39,1000,1.4000
+french laos,cottonseed,production,tonnes,1933,revised,,iia_1933_34,225,iia_1938_39,200,1.1250
+french laos,groundnut,production,tonnes,1933,revised,,iia_1933_34,180,iia_1938_39,200,1.1111
+french laos,tobacco,area,hectares,1933,revised,,iia_1933_34,500,iia_1938_39,1000,2.0000
+french madagascar,coffee: raw,area,hectares,1933,revised,,iia_1933_34,69500,iia_1938_39,69000,1.0072
+french madagascar,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,13110,iia_1938_39,13100,1.0008
+french madagascar,groundnut,area,hectares,1933,revised,,iia_1933_34,4601,iia_1938_39,3000,1.5337
+french madagascar,groundnut,production,tonnes,1933,revised,,iia_1933_34,6440,iia_1938_39,2600,2.4769
+french martinique,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,48220,iia_1938_39,50700,1.0514
+french morocco,cottonseed,production,tonnes,1933,revised,,iia_1933_34,60,iia_1938_39,100,1.6667
+french morocco,eggs,production,tonnes,1933,revised,,iia_1933_34,32340,iia_1938_39,53900,1.6667
+french morocco,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,39000,iia_1938_39,28000,1.3929
+french morocco,linseed,area,hectares,1933,revised,,iia_1933_34,12115,iia_1938_39,12000,1.0096
+french morocco,linseed,production,tonnes,1933,revised,,iia_1933_34,3185,iia_1938_39,3200,1.0047
+french morocco,rye,area,hectares,1933,revised,,iia_1933_34,1130,iia_1938_39,1000,1.1300
+french morocco,rye,production,tonnes,1933,revised,,iia_1933_34,565,iia_1938_39,600,1.0619
+french morocco,wine,production,tonnes,1933,revised,,iia_1933_34,40677,iia_1938_39,40040,1.0159
+french new caledonia,coffee: raw,area,hectares,1933,revised,,iia_1933_34,2696,iia_1938_39,3000,1.1128
+french new caledonia,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,6698,iia_1938_39,6700,1.0003
+french niger,tobacco,production,tonnes,1933,revised,,iia_1933_34,250,iia_1938_39,22000,88.0000
+french oceania,tobacco,production,tonnes,1933,revised,,iia_1933_34,22,iia_1938_39,300,13.6364
+french oceania: makatea island,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,78000,iia_1938_39,78400,1.0051
+french reunion,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,77430,iia_1938_39,77400,1.0004
+french sudan,tobacco,area,hectares,1933,revised,,iia_1933_34,2235,iia_1938_39,3000,1.3423
+french sudan,tobacco,production,tonnes,1933,revised,,iia_1933_34,1245,iia_1938_39,138500,111.2450
+french syria,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,960,iia_1938_39,1000,1.0417
+french syria,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,780,iia_1938_39,800,1.0256
+french syria and lebanon,blackberries,area,hectares,1933,revised,,iia_1933_34,24500,iia_1938_39,21000,1.1667
+french syria and lebanon,blackberries,production,tonnes,1933,revised,,iia_1933_34,220000,iia_1938_39,210000,1.0476
+french syria and lebanon,"citrus fruits: oranges, other",area,hectares,1933,revised,,iia_1933_34,2504,iia_1938_39,3000,1.1981
+french syria and lebanon,"citrus fruits: oranges, other",production,tonnes,1933,revised,,iia_1933_34,32810,iia_1938_39,32800,1.0003
+french syria and lebanon,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1940,iia_1938_39,1900,1.0211
+french syria and lebanon,olive grove,area,hectares,1933,revised,,iia_1933_34,77620,iia_1938_39,78000,1.0049
+french syria and lebanon,olive grove,production,tonnes,1933,revised,,iia_1933_34,24764.75,iia_1938_39,24750,1.0006
+french syria and lebanon,olive: oil,production,tonnes,1933,revised,,iia_1933_34,15824.5,iia_1938_39,15800,1.0016
+french syria and lebanon,sesame,area,hectares,1933,revised,,iia_1933_34,3520,iia_1938_39,4000,1.1364
+french syria and lebanon,sesame,production,tonnes,1933,revised,,iia_1933_34,1107,iia_1938_39,1100,1.0064
+french syria and lebanon,tobacco,area,hectares,1933,revised,,iia_1933_34,6920,iia_1938_39,7000,1.0116
+french tonkin,blackberries,area,hectares,1933,revised,,iia_1933_34,2670,iia_1938_39,3000,1.1236
+french tonkin,coffee: raw,area,hectares,1933,revised,,iia_1933_34,3190,iia_1938_39,3000,1.0633
+french tonkin,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,1250,iia_1938_39,1200,1.0417
+french tonkin,cottonseed,area,hectares,1933,revised,,iia_1933_34,1335,iia_1938_39,1000,1.3350
+french tonkin,cottonseed,production,tonnes,1933,revised,,iia_1933_34,60,iia_1938_39,300,5.0000
+french tonkin,groundnut,area,hectares,1933,revised,,iia_1933_34,1370,iia_1938_39,1000,1.3700
+french tonkin,groundnut,production,tonnes,1933,revised,,iia_1933_34,1010,iia_1938_39,1000,1.0100
+french tonkin,tobacco,area,hectares,1933,revised,,iia_1933_34,1453,iia_1938_39,1000,1.4530
+french tunisia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,18550,iia_1938_39,18600,1.0027
+french tunisia,olive: oil,production,tonnes,1933,revised,,iia_1933_34,60000,iia_1938_39,33000,1.8182
+german togoland,cacao: raw,area,hectares,1933,revised,,iia_1933_34,15400,iia_1938_39,15000,1.0267
+german togoland,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,9038.5,iia_1938_39,11000,1.2170
+german togoland,groundnut,production,tonnes,1933,revised,,iia_1933_34,64.3,iia_1938_39,500,7.7760
+germany,eggs,production,tonnes,1933,revised,,iia_1933_34,291060,iia_1938_39,334180,1.1481
+germany,flax: fibre,area,hectares,1933,revised,,iia_1933_34,4889,iia_1938_39,5000,1.0227
+germany,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,3114.8,iia_1938_39,3100,1.0048
+germany,hops,production,tonnes,1920,revised,,iia_1909_21,6025.3,iia_1925_26,6216.1,1.0317
+germany,meslin,area,hectares,1933,revised,,iia_1933_34,371859,iia_1938_39,113000,3.2908
+germany,meslin,production,tonnes,1933,revised,,iia_1933_34,715992,iia_1938_39,160500,4.4610
+germany,rapeseed,area,hectares,1933,revised,,iia_1933_34,5103,iia_1938_39,5000,1.0206
+germany,rapeseed,production,tonnes,1933,revised,,iia_1933_34,6702,iia_1938_39,6700,1.0003
+germany,rye,area,hectares,1933,revised,,iia_1933_34,4524199,iia_1938_39,4540000,1.0035
+germany,rye,production,tonnes,1933,revised,,iia_1933_34,8727173,iia_1938_39,8760800,1.0039
+germany,slag: basic,production,tonnes,1933,revised,,iia_1933_34,800000,iia_1938_39,1098800,1.3735
+germany,spelt,area,hectares,1933,revised,,iia_1933_34,113116,iia_1938_39,372000,3.2887
+germany,spelt,production,tonnes,1933,revised,,iia_1933_34,160513,iia_1938_39,716000,4.4607
+germany,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,1429175.2,iia_1938_39,1285500,1.1118
+germany,tobacco,area,hectares,1933,revised,,iia_1933_34,11977,iia_1938_39,12000,1.0019
+germany,wine,production,tonnes,1933,revised,,iia_1933_34,163666.776,iia_1938_39,151970,1.0770
+greece,citrus fruits: cedrats,production,tonnes,1933,revised,,iia_1933_34,509.3,iia_1938_39,500,1.0186
+greece,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,10013.5,iia_1938_39,10000,1.0013
+greece,citrus fruits: mandarins,production,tonnes,1933,revised,,iia_1933_34,7315,iia_1938_39,3700,1.9770
+greece,citrus fruits: oranges,production,tonnes,1933,revised,,iia_1933_34,16280.4,iia_1938_39,16300,1.0012
+greece,cottonseed,area,hectares,1933,revised,,iia_1933_34,28615,iia_1938_39,29000,1.0135
+greece,cottonseed,production,tonnes,1933,revised,,iia_1933_34,16110,iia_1938_39,16100,1.0006
+greece,eggs,production,tonnes,1932,revised,,iia_1933_34,21723.1553,iia_1938_39,21721.7,1.0001
+greece,eggs,production,tonnes,1933,revised,,iia_1933_34,27431.866,iia_1938_39,27435.1,1.0001
+greece,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,28465,iia_1938_39,28500,1.0012
+greece,olive grove,production,tonnes,1933,revised,,iia_1933_34,24485.9,iia_1938_39,24500,1.0006
+greece,olive: oil,production,tonnes,1933,revised,,iia_1933_34,105355.2,iia_1938_39,105400,1.0004
+greece,rye,area,hectares,1933,revised,,iia_1933_34,74021,iia_1938_39,74000,1.0003
+greece,rye,production,tonnes,1933,revised,,iia_1933_34,71112.5,iia_1938_39,71100,1.0002
+greece,sesame,area,hectares,1933,revised,,iia_1933_34,42186,iia_1938_39,42000,1.0044
+greece,sesame,production,tonnes,1933,revised,,iia_1933_34,7302,iia_1938_39,7300,1.0003
+greece,tobacco,area,hectares,1933,revised,,iia_1933_34,77556,iia_1938_39,78000,1.0057
+greece,wine,production,tonnes,1933,revised,,iia_1933_34,351848.679,iia_1938_39,203294,1.7307
+guatemala,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,48000,iia_1938_39,36000,1.3333
+guatemala,eggs,production,tonnes,1932,revised,,iia_1933_34,847.9009,iia_1938_39,862.4,1.0171
+guatemala,eggs,production,tonnes,1933,revised,,iia_1933_34,903.6874,iia_1938_39,862.4,1.0479
+guatemala,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,32500,iia_1938_39,30000,1.0833
+haiti,coffee: raw,area,hectares,1933,revised,,iia_1933_34,141600,iia_1938_39,142000,1.0028
+haiti,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,18000,iia_1938_39,34000,1.8889
+haiti,cottonseed,area,hectares,1933,revised,,iia_1933_34,109300,iia_1938_39,102000,1.0716
+haiti,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,2590.5,iia_1938_39,22500,8.6856
+honduras,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,1500,iia_1938_39,1900,1.2667
+hungary,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,1445,iia_1938_39,1400,1.0321
+hungary,flax: fibre,area,hectares,1933,revised,,iia_1933_34,7942,iia_1938_39,8000,1.0073
+hungary,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,3375.6,iia_1938_39,3400,1.0072
+hungary,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,8694,iia_1938_39,9000,1.0352
+hungary,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,4051.25,iia_1938_39,4050,1.0003
+hungary,hempseed,area,hectares,1933,revised,,iia_1933_34,8694,iia_1938_39,9000,1.0352
+hungary,hempseed,production,tonnes,1933,revised,,iia_1933_34,2908.55,iia_1938_39,2950,1.0143
+hungary,hops,area,hectares,1933,revised,,iia_1933_34,107,iia_1938_39,1000,9.3458
+hungary,linseed,area,hectares,1933,revised,,iia_1933_34,7942,iia_1938_39,8000,1.0073
+hungary,linseed,production,tonnes,1933,revised,,iia_1933_34,5121.6,iia_1938_39,5100,1.0042
+hungary,rapeseed,area,hectares,1933,revised,,iia_1933_34,7102,iia_1938_39,7000,1.0146
+hungary,rapeseed,production,tonnes,1933,revised,,iia_1933_34,7118.6,iia_1938_39,7100,1.0026
+hungary,rye,area,hectares,1933,revised,,iia_1933_34,678583,iia_1938_39,679000,1.0006
+hungary,rye,production,tonnes,1933,revised,,iia_1933_34,71112.5,iia_1938_39,956500,13.4505
+hungary,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,135579,iia_1938_39,122000,1.1113
+hungary,tobacco,area,hectares,1933,revised,,iia_1933_34,18296,iia_1938_39,18000,1.0164
+hungary,wine,production,tonnes,1933,revised,,iia_1933_34,280591.948,iia_1938_39,263900,1.0633
+ireland,eggs,production,tonnes,1933,revised,,iia_1933_34,66404.8,iia_1938_39,66458.7,1.0008
+ireland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,2030,iia_1938_39,2000,1.0150
+ireland,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,93476,iia_1938_39,95100,1.0174
+ireland,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,183.9,iia_1938_39,200,1.0875
+ireland,rye,area,hectares,1933,revised,,iia_1933_34,1213,iia_1938_39,1000,1.2130
+ireland,rye,production,tonnes,1933,revised,,iia_1933_34,2194.7,iia_1938_39,2200,1.0024
+ireland,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,35284.3,iia_1938_39,31800,1.1096
+italian dodecanese islands,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,190,iia_1938_39,200,1.0526
+italian dodecanese islands,citrus fruits: mandarins,production,tonnes,1933,revised,,iia_1933_34,450,iia_1938_39,400,1.1250
+italian dodecanese islands,citrus fruits: oranges,production,tonnes,1933,revised,,iia_1933_34,790,iia_1938_39,800,1.0127
+italian dodecanese islands,olive grove,production,tonnes,1933,revised,,iia_1933_34,1767.1,iia_1938_39,1800,1.0186
+italian dodecanese islands,olive: oil,production,tonnes,1933,revised,,iia_1933_34,569.5,iia_1938_39,600,1.0536
+italian dodecanese islands,wine,production,tonnes,1933,revised,,iia_1933_34,1398.579,iia_1938_39,1365,1.0246
+italian eritrea,cottonseed,production,tonnes,1933,revised,,iia_1933_34,460,iia_1938_39,500,1.0870
+italian eritrea,linseed,area,hectares,1933,revised,,iia_1933_34,1500,iia_1938_39,1000,1.5000
+italy,blackberries,production,tonnes,1933,revised,,iia_1933_34,1165429,iia_1938_39,1165400,1.0000
+italy,cottonseed,area,hectares,1933,revised,,iia_1933_34,1465,iia_1938_39,1000,1.4650
+italy,cottonseed,production,tonnes,1933,revised,,iia_1933_34,520,iia_1938_39,500,1.0400
+italy,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,105000,iia_1938_39,105700,1.0067
+italy,fertilizers: calcium cyanamide,production,tonnes,1933,revised,,iia_1933_34,136591,iia_1938_39,77300,1.7670
+italy,fertilizers: calcium nitrate,production,tonnes,1933,revised,,iia_1933_34,77257,iia_1938_39,137200,1.7759
+italy,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,1003298,iia_1938_39,1026200,1.0228
+italy,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,106645,iia_1938_39,106600,1.0004
+italy,fertilizers: sodium nitrate,production,tonnes,1933,revised,,iia_1933_34,12288,iia_1938_39,12300,1.0010
+italy,flax: fibre,area,hectares,1933,revised,,iia_1933_34,3376,iia_1938_39,3000,1.1253
+italy,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,1810,iia_1938_39,1800,1.0056
+italy,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,57182,iia_1938_39,57000,1.0032
+italy,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,57916,iia_1938_39,58800,1.0153
+italy,hempseed,production,tonnes,1933,revised,,iia_1933_34,1922,iia_1938_39,1900,1.0116
+italy,linseed,area,hectares,1933,revised,,iia_1933_34,4022,iia_1938_39,4000,1.0055
+italy,linseed,production,tonnes,1933,revised,,iia_1933_34,2276,iia_1938_39,2200,1.0345
+italy,olive grove,area,hectares,1933,revised,,iia_1933_34,1039051.5,iia_1938_39,1039500,1.0004
+italy,olive grove,production,tonnes,1933,revised,,iia_1933_34,1173605,iia_1938_39,1173700,1.0001
+italy,olive: oil,production,tonnes,1933,revised,,iia_1933_34,163789.7,iia_1938_39,163800,1.0001
+italy,rye,area,hectares,1933,revised,,iia_1933_34,114274,iia_1938_39,114000,1.0024
+italy,rye,production,tonnes,1933,revised,,iia_1933_34,171177,iia_1938_39,171200,1.0001
+italy,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,304492,iia_1938_39,274000,1.1113
+italy,sulphur,production,tonnes,1933,revised,,iia_1933_34,401586,iia_1938_39,401600,1.0000
+italy,tobacco,area,hectares,1933,revised,,iia_1933_34,35447,iia_1938_39,35000,1.0128
+italy,wine,production,tonnes,1933,revised,,iia_1933_34,2993922.75,iia_1938_39,3006185,1.0041
+japan,citrus fruits: mandarins,area,hectares,1933,revised,,iia_1933_34,30170,iia_1938_39,32000,1.0607
+japan,citrus fruits: mandarins,production,tonnes,1933,revised,,iia_1933_34,341144.6,iia_1938_39,267700,1.2744
+japan,cottonseed,area,hectares,1933,revised,,iia_1933_34,739,iia_1938_39,1000,1.3532
+japan,cottonseed,production,tonnes,1933,revised,,iia_1933_34,529,iia_1938_39,500,1.0580
+japan,eggs,production,tonnes,1929,revised,,iia_1929_30,136460.247,iia_1933_34,136285.072,1.0013
+japan,eggs,production,tonnes,1932,revised,,iia_1933_34,191846.1083,iia_1938_39,191830.1,1.0001
+japan,eggs,production,tonnes,1933,revised,,iia_1933_34,183739.0632,iia_1938_39,183745.1,1.0000
+japan,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,475000,iia_1938_39,471400,1.0076
+japan,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,1128000,iia_1938_39,1116600,1.0102
+japan,flax: fibre,area,hectares,1933,revised,,iia_1933_34,13066,iia_1938_39,13000,1.0051
+japan,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,4011.4,iia_1938_39,4000,1.0029
+japan,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,6338,iia_1938_39,6000,1.0563
+japan,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,7869.2,iia_1938_39,7900,1.0039
+japan,jute,area,hectares,1933,revised,,iia_1933_34,579,iia_1938_39,1000,1.7271
+japan,jute,production,tonnes,1933,revised,,iia_1933_34,1208.5,iia_1938_39,1200,1.0071
+japan,linseed,area,hectares,1933,revised,,iia_1933_34,13066,iia_1938_39,13000,1.0051
+japan,linseed,production,tonnes,1933,revised,,iia_1933_34,3730.2,iia_1938_39,3700,1.0082
+japan,rapeseed,area,hectares,1933,revised,,iia_1933_34,80813,iia_1938_39,81000,1.0023
+japan,rapeseed,production,tonnes,1933,revised,,iia_1933_34,87951.8,iia_1938_39,87900,1.0006
+japan,sesame,area,hectares,1933,revised,,iia_1933_34,4950,iia_1938_39,5000,1.0101
+japan,sesame,production,tonnes,1933,revised,,iia_1933_34,3906.7,iia_1938_39,3900,1.0017
+japan,soybean,production,tonnes,1933,revised,,iia_1933_34,362170.2,iia_1938_39,362200,1.0001
+japan,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,25563.9,iia_1938_39,23000,1.1115
+japan,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,108683.8,iia_1938_39,70700,1.5373
+japan,sulphur,production,tonnes,1933,revised,,iia_1933_34,116000,iia_1938_39,114400,1.0140
+japan,tea,area,hectares,1933,revised,,iia_1933_34,38167,iia_1938_39,38000,1.0044
+japan,tea,production,tonnes,1933,revised,,iia_1933_34,21718.498,iia_1938_39,21718.5,1.0000
+japan,tobacco,area,hectares,1933,revised,,iia_1933_34,33855,iia_1938_39,34000,1.0043
+japan: karafuto prefecture,eggs,production,tonnes,1932,revised,,iia_1933_34,336.4438,iia_1938_39,323.4,1.0403
+japan: karafuto prefecture,eggs,production,tonnes,1933,revised,,iia_1933_34,352.7216,iia_1938_39,377.3,1.0697
+japan: kwantung leased territory,eggs,production,tonnes,1932,revised,,iia_1933_34,886.0082,iia_1938_39,862.4,1.0274
+japan: kwantung leased territory,eggs,production,tonnes,1933,revised,,iia_1933_34,939.3153,iia_1938_39,916.3,1.0251
+japan: kwantung leased territory,groundnut,area,hectares,1933,revised,,iia_1933_34,34600,iia_1938_39,35000,1.0116
+japan: kwantung leased territory,groundnut,production,tonnes,1933,revised,,iia_1933_34,78072.9,iia_1938_39,78100,1.0003
+japan: kwantung leased territory,sesame,production,tonnes,1933,revised,,iia_1933_34,70.1,iia_1938_39,100,1.4265
+japan: kwantung leased territory,soybean,area,hectares,1933,revised,,iia_1933_34,52103,iia_1938_39,52000,1.0020
+japan: kwantung leased territory,soybean,production,tonnes,1933,revised,,iia_1933_34,22905.9,iia_1938_39,22900,1.0003
+japanese korea,cottonseed,area,hectares,1933,revised,,iia_1933_34,175200,iia_1938_39,175000,1.0011
+japanese korea,cottonseed,production,tonnes,1933,revised,,iia_1933_34,70710,iia_1938_39,62200,1.1368
+japanese korea,eggs,production,tonnes,1932,revised,,iia_1933_34,11052.4645,iia_1938_39,11049.5,1.0003
+japanese korea,eggs,production,tonnes,1933,revised,,iia_1933_34,11587.5298,iia_1938_39,11588.5,1.0001
+japanese korea,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,247019,iia_1938_39,247000,1.0001
+japanese korea,groundnut,area,hectares,1933,revised,,iia_1933_34,1431,iia_1938_39,1000,1.4310
+japanese korea,groundnut,production,tonnes,1933,revised,,iia_1933_34,2540.4,iia_1938_39,2500,1.0162
+japanese korea,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,27054,iia_1938_39,27000,1.0020
+japanese korea,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,19752.7,iia_1938_39,19800,1.0024
+japanese korea,sesame,area,hectares,1933,revised,,iia_1933_34,9959,iia_1938_39,10000,1.0041
+japanese korea,sesame,production,tonnes,1933,revised,,iia_1933_34,4102.7,iia_1938_39,4500,1.0968
+japanese korea,soybean,area,hectares,1933,revised,,iia_1933_34,797208,iia_1938_39,797000,1.0003
+japanese korea,soybean,production,tonnes,1933,revised,,iia_1933_34,587658.3,iia_1938_39,587700,1.0001
+japanese korea,tobacco,area,hectares,1933,revised,,iia_1933_34,13446,iia_1938_39,13000,1.0343
+japanese taiwan,blackberries,area,hectares,1933,revised,,iia_1933_34,630,iia_1938_39,1000,1.5873
+japanese taiwan,groundnut,area,hectares,1933,revised,,iia_1933_34,29800,iia_1938_39,30000,1.0067
+japanese taiwan,groundnut,production,tonnes,1933,revised,,iia_1933_34,43825.8,iia_1938_39,43800,1.0006
+japanese taiwan,jute,area,hectares,1933,revised,,iia_1933_34,2915,iia_1938_39,3000,1.0292
+japanese taiwan,jute,production,tonnes,1933,revised,,iia_1933_34,5277,iia_1938_39,5300,1.0044
+japanese taiwan,rapeseed,production,tonnes,1933,revised,,iia_1933_34,105.7,iia_1938_39,100,1.0570
+japanese taiwan,sesame,area,hectares,1933,revised,,iia_1933_34,3783,iia_1938_39,4000,1.0574
+japanese taiwan,sesame,production,tonnes,1933,revised,,iia_1933_34,1212.7,iia_1938_39,1300,1.0720
+japanese taiwan,soybean,area,hectares,1933,revised,,iia_1933_34,8044,iia_1938_39,8000,1.0055
+japanese taiwan,soybean,production,tonnes,1933,revised,,iia_1933_34,4647.4,iia_1938_39,4600,1.0103
+japanese taiwan,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,647031.6,iia_1938_39,647000,1.0000
+japanese taiwan,tea,area,hectares,1933,revised,,iia_1933_34,40663,iia_1938_39,44000,1.0821
+japanese taiwan,tea,production,tonnes,1933,revised,,iia_1933_34,9326.925,iia_1938_39,9327,1.0000
+japanese taiwan,tobacco,area,hectares,1933,revised,,iia_1933_34,777,iia_1938_39,1000,1.2870
+latvia,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,56306,iia_1938_39,56300,1.0001
+latvia,flax: fibre,area,hectares,1933,revised,,iia_1933_34,41500,iia_1938_39,41000,1.0122
+latvia,linseed,area,hectares,1933,revised,,iia_1933_34,41500,iia_1938_39,41000,1.0122
+latvia,linseed,production,tonnes,1933,revised,,iia_1933_34,12320,iia_1938_39,12300,1.0016
+latvia,rye,area,hectares,1933,revised,,iia_1933_34,257900,iia_1938_39,258000,1.0004
+latvia,rye,production,tonnes,1933,revised,,iia_1933_34,355090,iia_1938_39,355100,1.0000
+latvia,slag: basic,production,tonnes,1933,revised,,iia_1933_34,6319,iia_1938_39,6300,1.0030
+latvia,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,32400,iia_1938_39,29100,1.1134
+lithuania,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,45870,iia_1938_39,45700,1.0037
+lithuania,flax: fibre,area,hectares,1933,revised,,iia_1933_34,54700,iia_1938_39,57000,1.0420
+lithuania,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,18130.5,iia_1938_39,18700,1.0314
+lithuania,linseed,area,hectares,1933,revised,,iia_1933_34,54700,iia_1938_39,57000,1.0420
+lithuania,linseed,production,tonnes,1933,revised,,iia_1933_34,20901,iia_1938_39,21500,1.0287
+lithuania,rye,area,hectares,1933,revised,,iia_1933_34,489590,iia_1938_39,490000,1.0008
+lithuania,rye,production,tonnes,1933,revised,,iia_1933_34,551998.6,iia_1938_39,552000,1.0000
+lithuania,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,8.1,iia_1938_39,7300,901.2346
+luxembourg,rye,area,hectares,1933,revised,,iia_1933_34,8329,iia_1938_39,8000,1.0411
+luxembourg,rye,production,tonnes,1933,revised,,iia_1933_34,14611.3,iia_1938_39,14600,1.0008
+luxembourg,slag: basic,production,tonnes,1933,revised,,iia_1933_34,392961,iia_1938_39,393000,1.0001
+luxembourg,wine,production,tonnes,1933,revised,,iia_1933_34,5156.06,iia_1938_39,4823,1.0691
+mexico,coffee: raw,area,hectares,1933,revised,,iia_1933_34,81394,iia_1938_39,87000,1.0689
+mexico,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,35327.2,iia_1938_39,36800,1.0417
+mexico,cottonseed,area,hectares,1933,revised,,iia_1933_34,171707,iia_1938_39,172000,1.0017
+mexico,cottonseed,production,tonnes,1933,revised,,iia_1933_34,112930,iia_1938_39,105500,1.0704
+mexico,groundnut,area,hectares,1933,revised,,iia_1933_34,6520,iia_1938_39,6000,1.0867
+mexico,groundnut,production,tonnes,1933,revised,,iia_1933_34,5162.4,iia_1938_39,5200,1.0073
+mexico,linseed,area,hectares,1933,revised,,iia_1933_34,2977,iia_1938_39,3000,1.0077
+mexico,linseed,production,tonnes,1933,revised,,iia_1933_34,1792.8,iia_1938_39,1800,1.0040
+mexico,sesame,production,tonnes,1933,revised,,iia_1933_34,12505.3,iia_1938_39,12800,1.0236
+mexico,tobacco,area,hectares,1933,revised,,iia_1933_34,12565,iia_1938_39,13000,1.0346
+nepal,jute,production,tonnes,1933,revised,,iia_1933_34,10428,iia_1938_39,10400,1.0027
+netherlands,eggs,production,tonnes,1929,revised,,iia_1929_30,107800,iia_1933_34,101062.5,1.0667
+netherlands,eggs,production,tonnes,1932,revised,,iia_1933_34,118580,iia_1938_39,114537.5,1.0353
+netherlands,eggs,production,tonnes,1933,revised,,iia_1933_34,107800,iia_1938_39,103488,1.0417
+netherlands,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,348920,iia_1938_39,349600,1.0019
+netherlands,flax: fibre,area,hectares,1933,revised,,iia_1933_34,4885,iia_1938_39,5000,1.0235
+netherlands,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,3944.1,iia_1938_39,3900,1.0113
+netherlands,linseed,area,hectares,1933,revised,,iia_1933_34,4885,iia_1938_39,5000,1.0235
+netherlands,linseed,production,tonnes,1933,revised,,iia_1933_34,3533.2,iia_1938_39,3500,1.0095
+netherlands,rapeseed,area,hectares,1933,revised,,iia_1933_34,1460,iia_1938_39,1000,1.4600
+netherlands,rapeseed,production,tonnes,1920,revised,,iia_1909_21,7499,iia_1925_26,964.2,7.7774
+netherlands,rapeseed,production,tonnes,1933,revised,,iia_1933_34,2906.5,iia_1938_39,2900,1.0022
+netherlands,rye,area,hectares,1933,revised,,iia_1933_34,165295,iia_1938_39,165000,1.0018
+netherlands,rye,production,tonnes,1933,revised,,iia_1933_34,396297.1,iia_1938_39,396300,1.0000
+netherlands,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,278024.2,iia_1938_39,261100,1.0648
+new zealand,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,270138,iia_1938_39,270100,1.0001
+new zealand,linseed,area,hectares,1933,revised,,iia_1933_34,583,iia_1938_39,2000,3.4305
+new zealand,linseed,production,tonnes,1933,revised,,iia_1933_34,638.3,iia_1938_39,600,1.0638
+new zealand,rye,production,tonnes,1933,revised,,iia_1933_34,93.3,iia_1938_39,100,1.0718
+new zealand,tobacco,area,hectares,1933,revised,,iia_1933_34,730,iia_1938_39,1000,1.3699
+new zealand western samoa,cacao: raw,area,hectares,1933,revised,,iia_1933_34,1900,iia_1938_39,2000,1.0526
+new zealand western samoa,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,913.4,iia_1938_39,900,1.0149
+norway,fertilizers: calcium cyanamide,production,tonnes,1933,revised,,iia_1933_34,20246,iia_1938_39,174550,8.6215
+norway,fertilizers: calcium nitrate,production,tonnes,1933,revised,,iia_1933_34,174556,iia_1938_39,20200,8.6414
+norway,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,21031,iia_1938_39,21000,1.0015
+norway,fertilizers: sodium nitrate,production,tonnes,1933,revised,,iia_1933_34,83155,iia_1938_39,83200,1.0005
+norway,rye,area,hectares,1933,revised,,iia_1933_34,6352,iia_1938_39,6000,1.0587
+norway,rye,production,tonnes,1933,revised,,iia_1933_34,11130.3,iia_1938_39,11100,1.0027
+peru,cottonseed,production,tonnes,1933,revised,,iia_1933_34,102390,iia_1938_39,101300,1.0108
+peru,"fertilizers: guano, natural",production,tonnes,1933,revised,,iia_1933_34,162358,iia_1938_39,162400,1.0003
+peru,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,432643,iia_1938_39,390000,1.1093
+poland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,57222,iia_1938_39,57200,1.0004
+poland,fertilizers: bone superphosphate,production,tonnes,1933,revised,,iia_1933_34,4923,iia_1938_39,4900,1.0047
+poland,fertilizers: calcium cyanamide,production,tonnes,1933,revised,,iia_1933_34,10118,iia_1938_39,31100,3.0737
+poland,fertilizers: calcium nitrate,production,tonnes,1933,revised,,iia_1933_34,31058,iia_1938_39,10100,3.0750
+poland,"fertilizers: mineral, calcium superphosphate",production,tonnes,1933,revised,,iia_1933_34,49166,iia_1938_39,49200,1.0007
+poland,fertilizers: sodium nitrate,production,tonnes,1933,revised,,iia_1933_34,7596,iia_1938_39,7600,1.0005
+poland,flax: fibre,area,hectares,1933,revised,,iia_1933_34,95047,iia_1938_39,95000,1.0005
+poland,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,26619.3,iia_1938_39,26600,1.0007
+poland,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,32047,iia_1938_39,32000,1.0015
+poland,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,10429.5,iia_1938_39,10400,1.0028
+poland,hempseed,area,hectares,1933,revised,,iia_1933_34,32047,iia_1938_39,32000,1.0015
+poland,hempseed,production,tonnes,1933,revised,,iia_1933_34,15680.6,iia_1938_39,15700,1.0012
+poland,linseed,area,hectares,1933,revised,,iia_1933_34,95047,iia_1938_39,95000,1.0005
+poland,linseed,production,tonnes,1933,revised,,iia_1933_34,45060.4,iia_1938_39,45100,1.0009
+poland,rapeseed,area,hectares,1933,revised,,iia_1933_34,30327,iia_1938_39,30000,1.0109
+poland,rapeseed,production,tonnes,1920,revised,,iia_1909_21,29991.6,iia_1925_26,36972.6,1.2328
+poland,rapeseed,production,tonnes,1933,revised,,iia_1933_34,27846.2,iia_1938_39,27800,1.0017
+poland,rye,area,hectares,1933,revised,,iia_1933_34,5775306,iia_1938_39,5775000,1.0001
+poland,rye,production,tonnes,1933,revised,,iia_1933_34,7073289.3,iia_1938_39,7073300,1.0000
+poland,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,342913.7,iia_1938_39,308600,1.1112
+poland,tobacco,area,hectares,1933,revised,,iia_1933_34,4717,iia_1938_39,5000,1.0600
+portugal,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,180000,iia_1938_39,180700,1.0039
+portugal,olive grove,area,hectares,1933,revised,,iia_1933_34,481119,iia_1938_39,481000,1.0002
+portugal,olive: oil,production,tonnes,1933,revised,,iia_1933_34,74941.8,iia_1938_39,73600,1.0182
+portugal,rye,area,hectares,1933,revised,,iia_1933_34,165586,iia_1938_39,166000,1.0025
+portugal,rye,production,tonnes,1933,revised,,iia_1933_34,91814.8,iia_1938_39,91800,1.0002
+portugal,wine,production,tonnes,1933,revised,,iia_1933_34,837234.58,iia_1938_39,837200,1.0000
+portugal: madeira,wine,production,tonnes,1933,revised,,iia_1933_34,9114.196,iia_1938_39,9100,1.0016
+portuguese angola,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,25000,iia_1938_39,24600,1.0163
+portuguese guinea,groundnut,production,tonnes,1933,revised,,iia_1933_34,27390.8,iia_1938_39,27400,1.0003
+portuguese mozambique,groundnut,production,tonnes,1933,revised,,iia_1933_34,19241.1,iia_1938_39,19200,1.0021
+portuguese mozambique,sesame,production,tonnes,1933,revised,,iia_1933_34,2148.2,iia_1938_39,2100,1.0230
+portuguese mozambique: company concession,eggs,production,tonnes,1932,revised,,iia_1933_34,64.68,iia_1938_39,53.9,1.2000
+portuguese mozambique: company concession,eggs,production,tonnes,1933,revised,,iia_1933_34,67.1055,iia_1938_39,53.9,1.2450
+portuguese sao tome and principe,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,8979,iia_1938_39,9000,1.0023
+portuguese sao tome and principe,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,751.5,iia_1938_39,800,1.0645
+portuguese timor and kambing,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,965.5,iia_1938_39,1000,1.0357
+romania,cottonseed,area,hectares,1933,revised,,iia_1933_34,2198,iia_1938_39,2000,1.0990
+romania,cottonseed,production,tonnes,1933,revised,,iia_1933_34,900,iia_1938_39,300,3.0000
+romania,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,5205,iia_1938_39,5200,1.0010
+romania,flax: fibre,area,hectares,1933,revised,,iia_1933_34,18774,iia_1938_39,19000,1.0120
+romania,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,6329.8,iia_1938_39,6300,1.0047
+romania,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,47874,iia_1938_39,48000,1.0026
+romania,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,26034.9,iia_1938_39,26000,1.0013
+romania,hempseed,area,hectares,1933,revised,,iia_1933_34,47874,iia_1938_39,48000,1.0026
+romania,hempseed,production,tonnes,1933,revised,,iia_1933_34,18934.2,iia_1938_39,18900,1.0018
+romania,hops,area,hectares,1933,revised,,iia_1933_34,2,iia_1938_39,1000,500.0000
+romania,hops,production,tonnes,1933,revised,,iia_1933_34,9.5,iia_1938_39,900,94.7368
+romania,linseed,area,hectares,1933,revised,,iia_1933_34,18774,iia_1938_39,19000,1.0120
+romania,linseed,production,tonnes,1933,revised,,iia_1933_34,10674.3,iia_1938_39,10700,1.0024
+romania,rapeseed,area,hectares,1933,revised,,iia_1933_34,38718,iia_1938_39,39000,1.0073
+romania,rapeseed,production,tonnes,1920,revised,,iia_1909_21,23669.2,iia_1925_26,19644.6,1.2049
+romania,rapeseed,production,tonnes,1933,revised,,iia_1933_34,26855.9,iia_1938_39,26900,1.0016
+romania,rye,area,hectares,1933,revised,,iia_1933_34,387545,iia_1938_39,388000,1.0012
+romania,rye,production,tonnes,1933,revised,,iia_1933_34,445918.7,iia_1938_39,445900,1.0000
+romania,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,161196,iia_1938_39,105100,1.5337
+romania,tobacco,area,hectares,1933,revised,,iia_1933_34,10103,iia_1938_39,10000,1.0103
+romania,wine,production,tonnes,1933,revised,,iia_1933_34,683771.634,iia_1938_39,683774,1.0000
+spain,blackberries,production,tonnes,1933,revised,,iia_1933_34,24834.7,iia_1938_39,24800,1.0014
+spain,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,59427.8,iia_1938_39,59400,1.0005
+spain,citrus fruits: oranges,production,tonnes,1933,revised,,iia_1933_34,967185.5,iia_1938_39,967200,1.0000
+spain,cottonseed,area,hectares,1933,revised,,iia_1933_34,7500,iia_1938_39,8000,1.0667
+spain,cottonseed,production,tonnes,1933,revised,,iia_1933_34,1720,iia_1938_39,1700,1.0118
+spain,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,12203,iia_1938_39,12200,1.0002
+spain,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,966653,iia_1938_39,966700,1.0000
+spain,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,14507,iia_1938_39,14500,1.0005
+spain,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,403,iia_1938_39,400,1.0075
+spain,groundnut,production,tonnes,1933,revised,,iia_1933_34,21184.8,iia_1938_39,21200,1.0007
+spain,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,3711,iia_1938_39,3700,1.0030
+spain,hempseed,production,tonnes,1933,revised,,iia_1933_34,973.4,iia_1938_39,1000,1.0273
+spain,linseed,production,tonnes,1933,revised,,iia_1933_34,233.8,iia_1938_39,200,1.1690
+spain,meslin,area,hectares,1933,revised,,iia_1933_34,46980,iia_1938_39,30000,1.5660
+spain,meslin,production,tonnes,1933,revised,,iia_1933_34,24295.2,iia_1938_39,21700,1.1196
+spain,olive grove,production,tonnes,1933,revised,,iia_1933_34,1647151,iia_1938_39,1647200,1.0000
+spain,olive: oil,production,tonnes,1933,revised,,iia_1933_34,310168.3,iia_1938_39,310200,1.0001
+spain,rye,production,tonnes,1933,revised,,iia_1933_34,525866.9,iia_1938_39,525900,1.0001
+spain,spelt,area,hectares,1933,revised,,iia_1933_34,29935,iia_1938_39,47000,1.5701
+spain,spelt,production,tonnes,1933,revised,,iia_1933_34,21728.7,iia_1938_39,24300,1.1183
+spain,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,220000,iia_1938_39,215800,1.0195
+spain,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,14000,iia_1938_39,15700,1.1214
+spain,tobacco,area,hectares,1933,revised,,iia_1933_34,5000,iia_1938_39,4000,1.2500
+spain,wine,production,tonnes,1933,revised,,iia_1933_34,1798500.704,iia_1938_39,1753570,1.0256
+spanish fernando po,cacao: raw,area,hectares,1933,revised,,iia_1933_34,36000,iia_1938_39,35000,1.0286
+spanish fernando po,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,11726.6,iia_1938_39,10300,1.1385
+spanish spanish guinea,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,660.3,iia_1938_39,700,1.0601
+sweden,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,219030,iia_1938_39,219000,1.0001
+sweden,rye,production,tonnes,1933,revised,,iia_1933_34,460471,iia_1938_39,462700,1.0048
+sweden,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,304792,iia_1938_39,274500,1.1104
+switzerland,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,909,iia_1938_39,900,1.0100
+switzerland,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,3152,iia_1938_39,3200,1.0152
+switzerland,meslin,area,hectares,1933,revised,,iia_1933_34,5505,iia_1938_39,12000,2.1798
+switzerland,meslin,production,tonnes,1933,revised,,iia_1933_34,13995.8,iia_1938_39,28600,2.0435
+switzerland,rye,area,hectares,1933,revised,,iia_1933_34,18603,iia_1938_39,17000,1.0943
+switzerland,rye,production,tonnes,1933,revised,,iia_1933_34,39249.8,iia_1938_39,35800,1.0964
+switzerland,spelt,area,hectares,1933,revised,,iia_1933_34,12756,iia_1938_39,7000,1.8223
+switzerland,spelt,production,tonnes,1933,revised,,iia_1933_34,31365.4,iia_1938_39,15200,2.0635
+switzerland,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,8970,iia_1938_39,8100,1.1074
+switzerland,wine,production,tonnes,1933,revised,,iia_1933_34,21844.459,iia_1938_39,21840,1.0002
+total,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,45000,iia_1938_39,58000,1.2889
+total,cottonseed,area,hectares,1933,revised,,iia_1933_34,1595000,iia_1938_39,1795000,1.1254
+total,cottonseed,production,tonnes,1933,revised,,iia_1933_34,975500,iia_1938_39,911000,1.0708
+total,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,731000,iia_1938_39,607200,1.2039
+total,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,1145000,iia_1938_39,1133900,1.0098
+total,"fertilizers: guano, natural",production,tonnes,1933,revised,,iia_1933_34,95500,iia_1938_39,103000,1.0785
+total,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,696000,iia_1938_39,718600,1.0325
+total,flax: fibre,area,hectares,1933,revised,,iia_1933_34,156500,iia_1938_39,164500,1.0511
+total,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,63650,iia_1938_39,61100,1.0417
+total,groundnut,area,hectares,1933,revised,,iia_1933_34,551000,iia_1938_39,425000,1.2965
+total,groundnut,production,tonnes,1933,revised,,iia_1933_34,416000,iia_1938_39,322000,1.2919
+total,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,115500,iia_1938_39,119000,1.0303
+total,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,86350,iia_1938_39,91400,1.0585
+total,hempseed,area,hectares,1933,revised,,iia_1933_34,117000,iia_1938_39,124000,1.0598
+total,hempseed,production,tonnes,1933,revised,,iia_1933_34,50700,iia_1938_39,51000,1.0059
+total,hops,area,hectares,1933,revised,,iia_1933_34,22000,iia_1938_39,130000,5.9091
+total,hops,production,tonnes,1933,revised,,iia_1933_34,23300,iia_1938_39,1880000,80.6867
+total,linseed,area,hectares,1933,revised,,iia_1933_34,461500,iia_1938_39,467500,1.0130
+total,linseed,production,tonnes,1933,revised,,iia_1933_34,158650,iia_1938_39,160500,1.0117
+total,olive: oil,production,tonnes,1933,revised,,iia_1933_34,79000,iia_1938_39,85000,1.0759
+total,rapeseed,area,hectares,1933,revised,,iia_1933_34,1324000,iia_1938_39,1325000,1.0008
+total,rapeseed,production,tonnes,1933,revised,,iia_1933_34,621400,iia_1938_39,620500,1.0015
+total,rye,area,hectares,1933,revised,,iia_1933_34,1187000,iia_1938_39,1215000,1.0236
+total,rye,production,tonnes,1933,revised,,iia_1933_34,643300,iia_1938_39,650100,1.0106
+total,soybean,area,hectares,1933,revised,,iia_1933_34,5444000,iia_1938_39,5340000,1.0195
+total,soybean,production,tonnes,1933,revised,,iia_1933_34,6364100,iia_1938_39,2880800,2.2091
+total,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,884000,iia_1938_39,1549000,1.7523
+total,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,1746000,iia_1938_39,2132000,1.2211
+total,sulphur,production,tonnes,1933,revised,,iia_1933_34,414000,iia_1938_39,412600,1.0034
+total,tobacco,area,hectares,1933,revised,,iia_1933_34,168000,iia_1938_39,149000,1.1275
+total,tobacco,production,tonnes,1933,revised,,iia_1933_34,102850,iia_1938_39,8750000,85.0754
+total,wine,production,tonnes,1933,revised,,iia_1933_34,888660.5,iia_1938_39,1058330,1.1909
+total general,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,580000,iia_1938_39,602000,1.0379
+total general,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,1600000,iia_1938_39,2574000,1.6087
+total general,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,4131000,iia_1938_39,4016200,1.0286
+total general,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,11804000,iia_1938_39,12009000,1.0174
+total general,"fertilizers: guano, natural",production,tonnes,1933,revised,,iia_1933_34,196000,iia_1938_39,210700,1.0750
+total general,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,8155000,iia_1938_39,8779000,1.0765
+total general,groundnut,area,hectares,1933,revised,,iia_1933_34,6090000,iia_1938_39,6170000,1.0131
+total general,groundnut,production,tonnes,1933,revised,,iia_1933_34,5620000,iia_1938_39,5770000,1.0267
+total general,olive: oil,production,tonnes,1933,revised,,iia_1933_34,779000,iia_1938_39,789000,1.0128
+total general,rapeseed,production,tonnes,1933,revised,,iia_1933_34,1243000,iia_1938_39,1241000,1.0016
+total general,slag: basic,production,tonnes,1933,revised,,iia_1933_34,3340000,iia_1938_39,3389700,1.0149
+total general,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,16880000,iia_1938_39,14910000,1.1321
+total general,sulphur,production,tonnes,1933,revised,,iia_1933_34,1980000,iia_1938_39,1980500,1.0003
+total general,tea,area,hectares,1933,revised,,iia_1933_34,850000,iia_1938_39,840000,1.0119
+total general,tea,production,tonnes,1933,revised,,iia_1933_34,413000,iia_1938_39,412600,1.0010
+total general,wine,production,tonnes,1933,revised,,iia_1933_34,15288000,iia_1938_39,15652000,1.0238
+total general excluding the ussr,cottonseed,area,hectares,1933,revised,,iia_1933_34,28220000,iia_1938_39,28590000,1.0131
+total general excluding the ussr,cottonseed,production,tonnes,1933,revised,,iia_1933_34,11033000,iia_1938_39,10970000,1.0057
+total general excluding the ussr,flax: fibre,area,hectares,1933,revised,,iia_1933_34,314000,iia_1938_39,330000,1.0510
+total general excluding the ussr,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,128000,iia_1938_39,123000,1.0407
+total general excluding the ussr,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,231000,iia_1938_39,238000,1.0303
+total general excluding the ussr,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,173000,iia_1938_39,183000,1.0578
+total general excluding the ussr,hempseed,area,hectares,1933,revised,,iia_1933_34,118000,iia_1938_39,135000,1.1441
+total general excluding the ussr,hempseed,production,tonnes,1933,revised,,iia_1933_34,51000,iia_1938_39,53700,1.0529
+total general excluding the ussr,linseed,area,hectares,1933,revised,,iia_1933_34,4400000,iia_1938_39,4390000,1.0023
+total general excluding the ussr,linseed,production,tonnes,1933,revised,,iia_1933_34,2250000,iia_1938_39,2415000,1.0733
+total general excluding the ussr,rye,production,tonnes,1933,revised,,iia_1933_34,26760000,iia_1938_39,26650000,1.0041
+total general excluding the ussr,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,7790000,iia_1938_39,7060000,1.1034
+total general including the ussr,cottonseed,area,hectares,1933,revised,,iia_1933_34,30270000,iia_1938_39,30640000,1.0122
+total general including the ussr,cottonseed,production,tonnes,1933,revised,,iia_1933_34,11904000,iia_1938_39,11840000,1.0054
+total general including the ussr,flax: fibre,area,hectares,1933,revised,,iia_1933_34,2710000,iia_1938_39,2720000,1.0037
+total general including the ussr,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,688000,iia_1938_39,671000,1.0253
+total general including the ussr,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,327000,iia_1938_39,339000,1.0367
+total general including the ussr,hempseed,area,hectares,1933,revised,,iia_1933_34,870000,iia_1938_39,850000,1.0235
+total general including the ussr,linseed,area,hectares,1933,revised,,iia_1933_34,7130000,iia_1938_39,7100000,1.0042
+total general including the ussr,linseed,production,tonnes,1933,revised,,iia_1933_34,3030000,iia_1938_39,3159000,1.0426
+total general including the ussr,rye,area,hectares,1933,revised,,iia_1933_34,44150000,iia_1938_39,44140000,1.0002
+total general including the ussr,rye,production,tonnes,1933,revised,,iia_1933_34,50950000,iia_1938_39,50840000,1.0022
+total general including the ussr,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,8873000,iia_1938_39,8050000,1.1022
+total general including the ussr,tobacco,area,hectares,1933,revised,,iia_1933_34,2360000,iia_1938_39,2390000,1.0127
+total north hemisphere aggregated,groundnut,area,hectares,1933,revised,,iia_1933_34,5540000,iia_1938_39,5610000,1.0126
+total north hemisphere aggregated,groundnut,production,tonnes,1933,revised,,iia_1933_34,5130000,iia_1938_39,5230000,1.0195
+total north hemisphere aggregated,tea,area,hectares,1933,revised,,iia_1933_34,655000,iia_1938_39,647000,1.0124
+total north hemisphere aggregated,tea,production,tonnes,1933,revised,,iia_1933_34,335800,iia_1938_39,335400,1.0012
+total north hemisphere aggregated,wine,production,tonnes,1933,revised,,iia_1933_34,13913900,iia_1938_39,14469000,1.0399
+total north hemisphere aggregated excluding the ussr,rye,area,hectares,1933,revised,,iia_1933_34,18300000,iia_1938_39,18410000,1.0060
+total north hemisphere aggregated excluding the ussr,rye,production,tonnes,1933,revised,,iia_1933_34,26467000,iia_1938_39,26430000,1.0014
+total north hemisphere aggregated excluding the ussr,tobacco,area,hectares,1933,revised,,iia_1933_34,1800000,iia_1938_39,1820000,1.0111
+total south hemisphere aggregated,groundnut,area,hectares,1933,revised,,iia_1933_34,550000,iia_1938_39,560000,1.0182
+total south hemisphere aggregated,groundnut,production,tonnes,1933,revised,,iia_1933_34,490000,iia_1938_39,540000,1.1020
+total south hemisphere aggregated,linseed,production,tonnes,1933,revised,,iia_1933_34,1515000,iia_1938_39,1665000,1.0990
+total south hemisphere aggregated,rye,area,hectares,1933,revised,,iia_1933_34,450000,iia_1938_39,350000,1.2857
+total south hemisphere aggregated,rye,production,tonnes,1933,revised,,iia_1933_34,290000,iia_1938_39,225000,1.2889
+total south hemisphere aggregated,tobacco,production,tonnes,1933,revised,,iia_1933_34,250000,iia_1938_39,21800000,87.2000
+total south hemisphere aggregated,wine,production,tonnes,1933,revised,,iia_1933_34,10465000,iia_1938_39,1221220,8.5693
+turkey,cottonseed,area,hectares,1933,revised,,iia_1933_34,161950,iia_1938_39,162000,1.0003
+turkey,cottonseed,production,tonnes,1933,revised,,iia_1933_34,55380,iia_1938_39,64800,1.1701
+turkey,linseed,area,hectares,1933,revised,,iia_1933_34,34300,iia_1938_39,8000,4.2875
+turkey,linseed,production,tonnes,1933,revised,,iia_1933_34,5201,iia_1938_39,6900,1.3267
+turkey,olive grove,area,hectares,1933,revised,,iia_1933_34,665952,iia_1938_39,694000,1.0421
+turkey,olive: oil,production,tonnes,1933,revised,,iia_1933_34,19640.9,iia_1938_39,22700,1.1558
+turkey,rye,area,hectares,1933,revised,,iia_1933_34,281800,iia_1938_39,344000,1.2207
+turkey,rye,production,tonnes,1933,revised,,iia_1933_34,341147,iia_1938_39,264300,1.2908
+turkey,sesame,area,hectares,1933,revised,,iia_1933_34,84800,iia_1938_39,71000,1.1944
+turkey,sesame,production,tonnes,1933,revised,,iia_1933_34,39960,iia_1938_39,26700,1.4966
+turkey,spelt,area,hectares,1933,revised,,iia_1933_34,92900,iia_1938_39,31000,2.9968
+turkey,spelt,production,tonnes,1933,revised,,iia_1933_34,114656,iia_1938_39,47100,2.4343
+turkey,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,73097,iia_1938_39,65500,1.1160
+turkey,tobacco,area,hectares,1933,revised,,iia_1933_34,51032,iia_1938_39,51000,1.0006
+turkey,tobacco,production,tonnes,1933,revised,,iia_1933_34,35367.1,iia_1938_39,4014800,113.5179
+uk,eggs,production,tonnes,1929,revised,,iia_1929_30,136906,iia_1933_34,160622,1.1732
+uk,eggs,production,tonnes,1932,revised,,iia_1933_34,209185.9,iia_1938_39,209239.8,1.0003
+uk,eggs,production,tonnes,1933,revised,,iia_1933_34,219265.2,iia_1938_39,219480.8,1.0010
+uk,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,571018,iia_1938_39,571000,1.0000
+uk,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,382034,iia_1938_39,382000,1.0001
+uk,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,41165,iia_1938_39,41200,1.0009
+uk,hops,production,tonnes,1920,revised,,iia_1909_21,14275.4,iia_1925_26,15291.4,1.0712
+uk,rye,area,hectares,1933,revised,,iia_1933_34,5804,iia_1938_39,6000,1.0338
+uk,rye,production,tonnes,1933,revised,,iia_1933_34,10058.9,iia_1938_39,10100,1.0041
+uk,slag: basic,production,tonnes,1933,revised,,iia_1933_34,194065,iia_1938_39,194100,1.0002
+uk,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,506029,iia_1938_39,462600,1.0939
+uk: england and wales,eggs,production,tonnes,1929,revised,,iia_1929_30,100469.6,iia_1933_34,123808.3,1.2323
+uk: england and wales,eggs,production,tonnes,1933,revised,,iia_1933_34,169892.8,iia_1938_39,170000.6,1.0006
+uk: great britain,flax: fibre,area,hectares,1933,revised,,iia_1933_34,226,iia_1938_39,1000,4.4248
+uk: northern ireland,eggs,production,tonnes,1929,revised,,iia_1929_30,23392.6,iia_1933_34,23769.9,1.0161
+uk: northern ireland,eggs,production,tonnes,1932,revised,,iia_1933_34,25872,iia_1938_39,25925.9,1.0021
+uk: northern ireland,eggs,production,tonnes,1933,revised,,iia_1933_34,27542.9,iia_1938_39,27650.7,1.0039
+uk: northern ireland,flax: fibre,area,hectares,1933,revised,,iia_1933_34,3959,iia_1938_39,4000,1.0104
+uk: northern ireland,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,2207.9,iia_1938_39,2200,1.0036
+union of south africa,cottonseed,production,tonnes,1933,revised,,iia_1933_34,990,iia_1938_39,800,1.2375
+union of south africa,"fertilizers: guano, natural",production,tonnes,1933,revised,,iia_1933_34,6460,iia_1938_39,5100,1.2667
+union of south africa,groundnut,production,tonnes,1933,revised,,iia_1933_34,9729.4,iia_1938_39,11000,1.1306
+union of south africa,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,354866.3,iia_1938_39,354900,1.0001
+union of south africa,tobacco,production,tonnes,1933,revised,,iia_1933_34,6894.6,iia_1938_39,634900,92.0866
+union of south africa,wine,production,tonnes,1933,revised,,iia_1933_34,82906.551,iia_1938_39,105014,1.2667
+uruguay,linseed,area,hectares,1933,revised,,iia_1933_34,104988,iia_1938_39,105000,1.0001
+uruguay,linseed,production,tonnes,1933,revised,,iia_1933_34,73059.9,iia_1938_39,73100,1.0005
+uruguay,wine,production,tonnes,1933,revised,,iia_1933_34,50050,iia_1938_39,53053,1.0600
+us philippines,eggs,production,tonnes,1932,revised,,iia_1933_34,5898.5465,iia_1938_39,5875.1,1.0040
+us philippines,eggs,production,tonnes,1933,revised,,iia_1933_34,6330.1777,iia_1938_39,6198.5,1.0212
+us philippines,groundnut,area,hectares,1933,revised,,iia_1933_34,6535,iia_1938_39,7000,1.0712
+us philippines,groundnut,production,tonnes,1933,revised,,iia_1933_34,5978.4,iia_1938_39,6000,1.0036
+us philippines,hemp: manila,area,hectares,1933,revised,,iia_1933_34,447170,iia_1938_39,447000,1.0004
+us philippines,hemp: manila,production,tonnes,1933,revised,,iia_1933_34,134456.3,iia_1938_39,134500,1.0003
+us philippines,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,715000,iia_1938_39,749600,1.0484
+us philippines,tobacco,area,hectares,1933,revised,,iia_1933_34,74610,iia_1938_39,75000,1.0052
+us puerto rico,coffee: raw,area,hectares,1933,revised,,iia_1933_34,80900,iia_1938_39,62000,1.3048
+us puerto rico,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,50.8,iia_1938_39,4100,80.7087
+us puerto rico,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,890057.1,iia_1938_39,947000,1.0640
+us puerto rico,tobacco,area,hectares,1933,revised,,iia_1933_34,10239,iia_1938_39,10000,1.0239
+us virgin islands,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,4800,iia_1938_39,3100,1.5484
+usa,citrus fruits: grapefruits,production,tonnes,1933,revised,,iia_1933_34,453304.8,iia_1938_39,498000,1.0986
+usa,citrus fruits: lemons,production,tonnes,1933,revised,,iia_1933_34,228250,iia_1938_39,251500,1.1019
+usa,cottonseed,area,hectares,1933,revised,,iia_1933_34,12131800,iia_1938_39,11891000,1.0203
+usa,cottonseed,production,tonnes,1933,revised,,iia_1933_34,5264390,iia_1938_39,5264800,1.0001
+usa,eggs,production,tonnes,1932,revised,,iia_1933_34,1741401.2,iia_1938_39,1956462.2,1.1235
+usa,eggs,production,tonnes,1933,revised,,iia_1933_34,1714720.7,iia_1938_39,1914204.6,1.1163
+usa,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,201981,iia_1938_39,190650,1.0594
+usa,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,2444746,iia_1938_39,2444700,1.0000
+usa,fertilizers: copper(ii) sulfate,production,tonnes,1933,revised,,iia_1933_34,25378,iia_1938_39,22200,1.1432
+usa,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,2346326,iia_1938_39,2397500,1.0218
+usa,groundnut,area,hectares,1933,revised,,iia_1933_34,544308,iia_1938_39,594000,1.0913
+usa,groundnut,production,tonnes,1933,revised,,iia_1933_34,410821,iia_1938_39,438900,1.0683
+usa,hops,production,tonnes,1920,revised,,iia_1909_21,15549.1,iia_1925_26,12584.4,1.2356
+usa,linseed,area,hectares,1933,revised,,iia_1933_34,537428,iia_1938_39,543000,1.0104
+usa,linseed,production,tonnes,1933,revised,,iia_1933_34,176460.7,iia_1938_39,175400,1.0060
+usa,olive grove,production,tonnes,1933,revised,,iia_1933_34,12700.6,iia_1938_39,12700,1.0000
+usa,rye,area,hectares,1933,revised,,iia_1933_34,950617,iia_1938_39,979000,1.0299
+usa,rye,production,tonnes,1933,revised,,iia_1933_34,537231.1,iia_1938_39,544000,1.0126
+usa,soybean,area,hectares,1933,revised,,iia_1933_34,330600,iia_1938_39,403000,1.2190
+usa,soybean,production,tonnes,1933,revised,,iia_1933_34,304200,iia_1938_39,357800,1.1762
+usa,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,1601700,iia_1938_39,1489600,1.0753
+usa,sulphur,production,tonnes,1933,revised,,iia_1933_34,1428626,iia_1938_39,1428600,1.0000
+usa,tobacco,area,hectares,1933,revised,,iia_1933_34,710878,iia_1938_39,704000,1.0098
+usa: hawaii,eggs,production,tonnes,1929,revised,,iia_1929_30,1034.88,iia_1933_34,1028.1964,1.0065
+usa: hawaii,eggs,production,tonnes,1932,revised,,iia_1933_34,1098.9132,iia_1938_39,1078,1.0194
+usa: hawaii,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,933493.4,iia_1938_39,813400,1.1476
+ussr,cottonseed,area,hectares,1933,revised,,iia_1933_34,2051600,iia_1938_39,2052000,1.0002
+ussr,cottonseed,production,tonnes,1933,revised,,iia_1933_34,871200,iia_1938_39,868200,1.0035
+ussr,fertilizers: ammonium sulfate,production,tonnes,1933,revised,,iia_1933_34,140000,iia_1938_39,138400,1.0116
+ussr,fertilizers: calcium superphosphate,production,tonnes,1933,revised,,iia_1933_34,688800,iia_1938_39,690200,1.0020
+ussr,"fertilizers: phosphate, natural",production,tonnes,1933,revised,,iia_1933_34,487000,iia_1938_39,370800,1.3134
+ussr,flax: fibre,area,hectares,1933,revised,,iia_1933_34,2399100,iia_1938_39,2395000,1.0017
+ussr,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,560000,iia_1938_39,548000,1.0219
+ussr,groundnut,area,hectares,1933,revised,,iia_1933_34,2600,iia_1938_39,3000,1.1538
+ussr,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,755000,iia_1938_39,711000,1.0619
+ussr,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,154100,iia_1938_39,156500,1.0156
+ussr,hempseed,area,hectares,1933,revised,,iia_1933_34,755000,iia_1938_39,711000,1.0619
+ussr,hempseed,production,tonnes,1933,revised,,iia_1933_34,280000,iia_1938_39,276900,1.0112
+ussr,linseed,area,hectares,1933,revised,,iia_1933_34,2734600,iia_1938_39,2711000,1.0087
+ussr,linseed,production,tonnes,1933,revised,,iia_1933_34,780000,iia_1938_39,744400,1.0478
+ussr,rapeseed,area,hectares,1933,revised,,iia_1933_34,20400,iia_1938_39,20000,1.0200
+ussr,rye,area,hectares,1933,revised,,iia_1933_34,25400000,iia_1938_39,25382000,1.0007
+ussr,rye,production,tonnes,1933,revised,,iia_1933_34,24190000,iia_1938_39,24185700,1.0002
+ussr,sesame,area,hectares,1933,revised,,iia_1933_34,23200,iia_1938_39,23000,1.0087
+ussr,sesame,production,tonnes,1933,revised,,iia_1933_34,8110,iia_1938_39,8100,1.0012
+ussr,soybean,area,hectares,1933,revised,,iia_1933_34,163600,iia_1938_39,164000,1.0024
+ussr,soybean,production,tonnes,1933,revised,,iia_1933_34,105580,iia_1938_39,105600,1.0002
+ussr,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,1083500,iia_1938_39,995300,1.0886
+ussr,tobacco,area,hectares,1933,revised,,iia_1933_34,188100,iia_1938_39,196000,1.0420
+ussr,tobacco,production,tonnes,1933,revised,,iia_1933_34,169170,iia_1938_39,14821000,87.6101
+ussr: transcaucasian sfsr,tea,area,hectares,1933,revised,,iia_1933_34,33325,iia_1938_39,33000,1.0098
+ussr: transcaucasian sfsr,tea,production,tonnes,1933,revised,,iia_1933_34,748,iia_1938_39,792,1.0588
+venezuela,cacao: raw,production,tonnes,1933,revised,,iia_1933_34,11441,iia_1938_39,14000,1.2237
+venezuela,coffee: raw,production,tonnes,1933,revised,,iia_1933_34,57000,iia_1938_39,48100,1.1850
+venezuela,sugar: cane,production,tonnes,1933,revised,,iia_1933_34,20320,iia_1938_39,20300,1.0010
+yugoslavia,cottonseed,area,hectares,1933,revised,,iia_1933_34,820,iia_1938_39,1000,1.2195
+yugoslavia,cottonseed,production,tonnes,1933,revised,,iia_1933_34,160,iia_1938_39,200,1.2500
+yugoslavia,flax: fibre,area,hectares,1933,revised,,iia_1933_34,11129,iia_1938_39,11000,1.0117
+yugoslavia,flax: fibre,production,tonnes,1933,revised,,iia_1933_34,9927.7,iia_1938_39,9900,1.0028
+yugoslavia,hemp: fibre,area,hectares,1933,revised,,iia_1933_34,30394,iia_1938_39,30000,1.0131
+yugoslavia,hemp: fibre,production,tonnes,1933,revised,,iia_1933_34,27863.3,iia_1938_39,27900,1.0013
+yugoslavia,hempseed,production,tonnes,1933,revised,,iia_1933_34,1503.8,iia_1938_39,1500,1.0025
+yugoslavia,linseed,production,tonnes,1933,revised,,iia_1933_34,997.5,iia_1938_39,1000,1.0025
+yugoslavia,meslin,area,hectares,1933,revised,,iia_1933_34,54584,iia_1938_39,17000,3.2108
+yugoslavia,meslin,production,tonnes,1933,revised,,iia_1933_34,55573,iia_1938_39,14400,3.8592
+yugoslavia,olive: oil,production,tonnes,1933,revised,,iia_1933_34,4253.2,iia_1938_39,4300,1.0110
+yugoslavia,rapeseed,area,hectares,1933,revised,,iia_1933_34,3383,iia_1938_39,3000,1.1277
+yugoslavia,rapeseed,production,tonnes,1933,revised,,iia_1933_34,2776.8,iia_1938_39,2800,1.0084
+yugoslavia,rye,area,hectares,1933,revised,,iia_1933_34,256200,iia_1938_39,256000,1.0008
+yugoslavia,rye,production,tonnes,1933,revised,,iia_1933_34,245348.7,iia_1938_39,245300,1.0002
+yugoslavia,spelt,area,hectares,1933,revised,,iia_1933_34,16716,iia_1938_39,55000,3.2903
+yugoslavia,spelt,production,tonnes,1933,revised,,iia_1933_34,14415.2,iia_1938_39,55600,3.8570
+yugoslavia,sugar: beet,production,tonnes,1933,revised,,iia_1933_34,74466.9,iia_1938_39,67100,1.1098
+yugoslavia,tobacco,area,hectares,1933,revised,,iia_1933_34,11144,iia_1938_39,11000,1.0131
+yugoslavia,wine,production,tonnes,1933,revised,,iia_1933_34,259596.155,iia_1938_39,259623,1.0001
+austria,hemp: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,310,iia_1938_39,0,inf
+austria,hempseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,78,iia_1938_39,0,inf
+austria,hempseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,36.6,iia_1938_39,0,inf
+austria,meslin,area,hectares,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,8588,iia_1938_39,0,inf
+austria,meslin,production,tonnes,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,11582.5,iia_1938_39,0,inf
+austria,soybean,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,240,iia_1938_39,0,inf
+belgian ruanda-urundi,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,450,iia_1938_39,0,inf
+belgium,hemp: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,17,iia_1938_39,0,inf
+belgium,hemp: fibre,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,16.7,iia_1938_39,0,inf
+belgium,hempseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,17,iia_1938_39,0,inf
+belgium,hempseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,13.1,iia_1938_39,0,inf
+belgium,rapeseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,70,iia_1938_39,0,inf
+british antigua,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,26,iia_1938_39,0,inf
+british antigua,cottonseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,3,iia_1938_39,0,inf
+british barbados,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,25,iia_1938_39,0,inf
+british barbados,cottonseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,2,iia_1938_39,0,inf
+british borneo,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,303,iia_1938_39,0,inf
+british cyprus,hemp: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,71,iia_1938_39,0,inf
+british cyprus,hemp: fibre,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,42.8,iia_1938_39,0,inf
+british cyprus,hempseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,71,iia_1938_39,0,inf
+british cyprus,hempseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,13.4,iia_1938_39,0,inf
+british cyprus,sesame,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,35.8,iia_1938_39,0,inf
+british cyprus,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,387,iia_1938_39,0,inf
+british dominica,citrus fruits: limes,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,400,iia_1938_39,0,inf
+british guiana,citrus fruits: limes,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,352,iia_1938_39,0,inf
+british malta,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,25,iia_1938_39,0,inf
+british malta,cottonseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,17,iia_1938_39,0,inf
+british mauritius,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,40,iia_1938_39,0,inf
+british mauritius,tea,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,40,iia_1938_39,0,inf
+british montserrat,citrus fruits: limes,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,200,iia_1938_39,0,inf
+british nyasaland,coffee: raw,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,490,iia_1938_39,0,inf
+british nyasaland,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,41,iia_1938_39,0,inf
+british nyasaland,groundnut,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,39.2,iia_1938_39,0,inf
+british saint christopher and nevis,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,154,iia_1938_39,0,inf
+british saint vincent,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,60,iia_1938_39,0,inf
+british saint vincent,groundnut,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,21.5,iia_1938_39,0,inf
+british sierra leone,sesame,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,14.2,iia_1938_39,0,inf
+british trinidad and tobago,coffee: raw,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,490,iia_1938_39,0,inf
+british uganda,tea,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,346,iia_1938_39,0,inf
+bulgaria,flax: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,474,iia_1938_39,0,inf
+bulgaria,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,463,iia_1938_39,0,inf
+bulgaria,linseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,474,iia_1938_39,0,inf
+czechoslovakia,meslin,area,hectares,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,6610,iia_1938_39,0,inf
+french algeria,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,20,iia_1938_39,0,inf
+french algeria,cottonseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,9,iia_1938_39,0,inf
+french annam,jute,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,200,iia_1938_39,0,inf
+french cochinchina,coffee: raw,production,tonnes,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,100,iia_1938_39,0,inf
+french cochinchina,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,100,iia_1938_39,0,inf
+french cochinchina,cottonseed,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,18,iia_1938_39,0,inf
+french dahomey,cacao: raw,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,100,iia_1938_39,0,inf
+french guadeloupe,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,300,iia_1938_39,0,inf
+french india,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,178,iia_1938_39,0,inf
+french laos,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,180,iia_1938_39,0,inf
+french madagascar,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,70,iia_1938_39,0,inf
+french mauritania,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,70,iia_1938_39,0,inf
+french morocco,cottonseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,150,iia_1938_39,0,inf
+french morocco,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,160,iia_1938_39,0,inf
+french niger,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,400,iia_1938_39,0,inf
+french oceania,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,30,iia_1938_39,0,inf
+french saint pierre and miquelon,eggs,production,tonnes,1932,zero_contradicted,grid_explains,iia_1933_34,7.7616,iia_1938_39,0,inf
+french tonkin,jute,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,90,iia_1938_39,0,inf
+french tunisia,linseed,area,hectares,1933,zero_contradicted,at_grid_boundary,iia_1933_34,500,iia_1938_39,0,inf
+french tunisia,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,392,iia_1938_39,0,inf
+germany,hemp: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,210,iia_1938_39,0,inf
+guatemala,groundnut,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,28,iia_1938_39,0,inf
+guatemala,groundnut,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,39.1,iia_1938_39,0,inf
+ireland,flax: fibre,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,379,iia_1938_39,0,inf
+italian eritrea,sesame,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,40,iia_1938_39,0,inf
+italian eritrea,sesame,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,36,iia_1938_39,0,inf
+italian eritrea,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,50,iia_1938_39,0,inf
+italian libya: tripolitania,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,221,iia_1938_39,0,inf
+japan: kwantung leased territory,sesame,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,126,iia_1938_39,0,inf
+japanese taiwan,rapeseed,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,308,iia_1938_39,0,inf
+netherlands,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,21,iia_1938_39,0,inf
+new zealand,rye,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,105,iia_1938_39,0,inf
+sweden,flax: fibre,area,hectares,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,535,iia_1938_39,0,inf
+sweden,linseed,area,hectares,1933,zero_contradicted,grid_cannot_explain,iia_1933_34,535,iia_1938_39,0,inf
+sweden,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,282,iia_1938_39,0,inf
+union of south africa,fertilizers: ammonium sulfate,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,38,iia_1938_39,0,inf
+uruguay,rye,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,97,iia_1938_39,0,inf
+uruguay,rye,production,tonnes,1933,zero_contradicted,grid_explains,iia_1933_34,42.1,iia_1938_39,0,inf
+us samoa,tobacco,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,61,iia_1938_39,0,inf
+yugoslavia,sesame,area,hectares,1933,zero_contradicted,grid_explains,iia_1933_34,350,iia_1938_39,0,inf

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -4877,9 +4877,13 @@ WRITABLE = {
     "validate_series_collapses.py": (
         "pipelines/polity-autoimprove/state/series_collapses.csv",
     ),
-    # The case rewrites edition_conflicts.csv in place (it reclassifies rows), so a real copy.
+    # The cases rewrite edition_conflicts.csv in place (they reclassify rows), so a real copy. The
+    # GENERATOR is staged too, not because a case mutates it, but because the gate now imports its
+    # zero_grid_verdict() to re-derive the grid/blank split -- without it the gate dies on the import
+    # and still exits 1, which made two unrelated cases "pass" while checking nothing.
     "validate_edition_conflicts.py": (
         "pipelines/polity-autoimprove/state/edition_conflicts.csv",
+        "pipelines/polity-autoimprove/26_edition_conflicts.py",
     ),
     # The case appends a row to cell_attribution.csv; the gate imports the generator and reads both
     # item_provenance.csv and item_equivalences.csv, so all four are staged.

--- a/scripts/validate_edition_conflicts.py
+++ b/scripts/validate_edition_conflicts.py
@@ -45,15 +45,32 @@ Usage:
 from __future__ import annotations
 
 import csv
+import importlib.util
 import os
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/edition_conflicts.csv")
+GENERATOR = os.path.join(REPO, "pipelines/polity-autoimprove/26_edition_conflicts.py")
+
+
+def load_generator():
+    """The zero/grid verdict is re-derived by importing the generator's own classifier, so a
+    hand-edited verdict cannot stand while its own values refute it."""
+    spec = importlib.util.spec_from_file_location("edition_conflicts", GENERATOR)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 # Measured 2026-08-19 on the first run. BIDIRECTIONAL: setting false zeros to missing must lower
 # ZERO_CONTRADICTED with a note saying which cells were repaired.
 BASELINE_ZERO_CONTRADICTED = 83
+# The zero_contradicted rows split by whether the LATE volume's reporting grid can produce the zero
+# (issue 414, using the grids recorded for issue 446). A blank read as 0 does not correlate with the
+# magnitude of the value the other volume prints; rounding to a coarse grid can only produce 0 below
+# HALF the grid. So these three numbers are the split between "resolution floor" and "recoverable
+# blank", and they are what anyone acting on 414 would act on.
+BASELINE_ZERO_GRID = {"grid_explains": 76, "grid_cannot_explain": 6, "at_grid_boundary": 1}
 BASELINE_REVISED = 959
 # Measured 2026-08-19 (issue 424). 99 revisions differ by a clean power of ten, and 98 of the 99 hold
 # the SMALLER value in iia_1933_34. The control is what makes that significant rather than a property
@@ -88,6 +105,29 @@ def main() -> int:
           f"revised {len(rev)}/{BASELINE_REVISED})")
 
     problems = []
+    tool = load_generator()
+
+    # --- the zero/grid split, RE-DERIVED rather than trusted ---
+    import collections as _c
+    seen = _c.Counter()
+    for r in zc:
+        want = tool.zero_grid_verdict(
+            r["variable"],
+            float(r["value_a"]) if float(r["value_b"]) == 0 else float(r["value_b"]),
+            r["volume_b"] if float(r["value_b"]) == 0 else r["volume_a"])
+        seen[r["zero_grid_verdict"]] += 1
+        if r["zero_grid_verdict"] != want:
+            problems.append(
+                f"{r['label']}/{r['product']}/{r['variable']}/{r['year']}: zero_grid_verdict is "
+                f"{r['zero_grid_verdict']!r}, but the row's own values give {want!r}")
+    for k, n in sorted(BASELINE_ZERO_GRID.items()):
+        if seen.get(k, 0) != n:
+            problems.append(
+                f"zero_grid_verdict {k!r} is {seen.get(k, 0)}, baseline {n}. This split is what "
+                f"separates a resolution floor from a recoverable blank on issue 414; if a rebuild "
+                f"moves it, say which cells moved and update the baseline in the same commit")
+    for k in sorted(set(seen) - set(BASELINE_ZERO_GRID) - {""}):
+        problems.append(f"unexpected zero_grid_verdict {k!r} on {seen[k]} row(s)")
 
     # --- B: ceilings ---
     if len(zc) > BASELINE_ZERO_CONTRADICTED:


### PR DESCRIPTION
*PR by Claude.* 82 gates, 11 `--check` modes, selftest (113 cases) all green.

#414's flagship class is 83 zeros in `iia_1938_39` contradicted by a positive value in `iia_1933_34`, offered as
proof that the late volume reads blanks as 0. **Most are something else**: values correctly rounded to zero on
the late volume's own reporting grid.

```
late-volume grids (state/source_value_precision.csv, #528)
  iia from 1934    ha 96.3% on a 1000-grid    tonnes 86.4% on a 100-grid

zero_grid_verdict    grid_explains 76    grid_cannot_explain 6    at_grid_boundary 1
```

## The two explanations are separable per cell

A blank read as 0 has no reason to correlate with the magnitude of the value the other volume prints. Rounding to
a coarse grid can only produce 0 when the true value is **below half the grid**. On these 83 they separate
sharply:

```
area        57 of 62 under 500   against a 1,000 ha step    median contradicting value 178 ha
production  19 of 21 under  50   against a   100 t  step    median 21.5 t
```

`belgium` hemp fibre is **17 ha**. Against a 1000-hectare grid, 17 *is* zero.

## This strengthens #414's asymmetry rather than weakening it

Its best evidence is 83 contradicted zeros one way and **0** the other across 1,219 same-year pairs. A grid
difference predicts exactly that one-wayness, because the coarseness is one-way too — and it makes a **second**
prediction a misread blank does not: that the contradicting values be *small*. What changes is the reading of the
cells: most are a resolution floor, which #446 owns and which needs no repair, not an extraction fault needing
recovery.

## The 6 that remain are the recoverable ones

`austria` meslin **8,588 ha** rounds to 9,000, not 0. Three of the six are `meslin` — the item already entangled
in #375 (`wheat` is spelt and meslin) and #426's meslin↔spelt crossover between these same two volumes — so they
may belong there instead. The single `at_grid_boundary` row is exactly **500 ha**, where the rounding direction is
a convention rather than arithmetic, and is separated out rather than forced either way.

## One wiring trap, the second time today

The gate now imports the generator to re-derive the verdict, and `selftest_gates.py` does not stage generators by
default — so it died on the import and still exited 1, making **two unrelated, pre-existing cases "pass" while
checking nothing**. The message assertion caught it. The generator is now in that gate's `WRITABLE` tuple with the
reason recorded, the same fix as `validate_label_hierarchy_identity.py` needed earlier.