### PR TITLE
Tie the hardcoded LATE_GRID to the table it cites — I introduced this sibling copy yesterday (#414, #446)

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -4884,6 +4884,9 @@ WRITABLE = {
     "validate_edition_conflicts.py": (
         "pipelines/polity-autoimprove/state/edition_conflicts.csv",
         "pipelines/polity-autoimprove/26_edition_conflicts.py",
+        # the gate cross-checks the generator's hardcoded LATE_GRID against this table's
+        # (iia, ha/tonnes, 1934+) verdicts, so it must be present or that arm reports a missing row
+        "pipelines/polity-autoimprove/state/source_value_precision.csv",
     ),
     # The case appends a row to cell_attribution.csv; the gate imports the generator and reads both
     # item_provenance.csv and item_equivalences.csv, so all four are staged.

--- a/scripts/validate_edition_conflicts.py
+++ b/scripts/validate_edition_conflicts.py
@@ -107,6 +107,35 @@ def main() -> int:
     problems = []
     tool = load_generator()
 
+    # --- LATE_GRID must match the precision table it cites ---
+    # 26_edition_conflicts.py HARDCODES {"area": 1000, "production": 100} with a comment citing
+    # state/source_value_precision.csv. A comment is not a dependency: if that table is rebuilt and the
+    # late-volume verdict changes, the hardcoded constant goes stale silently and every zero_grid_verdict
+    # in this file becomes a claim about a grid the data no longer shows. This is the sibling-copy
+    # failure the repo keeps hitting (the 100x unit figure survived its own correction in three places),
+    # so the two are tied here rather than trusted to stay in step.
+    PREC = os.path.join(REPO, "pipelines/polity-autoimprove/state/source_value_precision.csv")
+    EXPECT = {"area": ("ha", "coarse_1000", 1000.0), "production": ("tonnes", "coarse_100", 100.0)}
+    if os.path.exists(PREC):
+        with open(PREC, encoding="utf-8") as fh:
+            prec = {(r["source"], r["unit"], r["era"]): r["verdict"] for r in csv.DictReader(fh)}
+        for variable, (unit, want_verdict, want_grid) in sorted(EXPECT.items()):
+            got = prec.get(("iia", unit, "1934+"))
+            if got is None:
+                problems.append(
+                    f"source_value_precision.csv has no (iia, {unit}, 1934+) row, so the LATE_GRID "
+                    f"constant {tool.LATE_GRID.get(variable)} for `{variable}` cites a measurement that "
+                    f"is no longer there")
+            elif got != want_verdict:
+                problems.append(
+                    f"(iia, {unit}, 1934+) is now {got!r}, not {want_verdict!r}, so the hardcoded "
+                    f"LATE_GRID {tool.LATE_GRID.get(variable)} for `{variable}` no longer matches the "
+                    f"table it cites -- every zero_grid_verdict here rests on it")
+            elif tool.LATE_GRID.get(variable) != want_grid:
+                problems.append(
+                    f"LATE_GRID[{variable!r}] is {tool.LATE_GRID.get(variable)}, but {want_verdict} "
+                    f"means a grid of {want_grid:g}")
+
     # --- the zero/grid split, RE-DERIVED rather than trusted ---
     import collections as _c
     seen = _c.Counter()


### PR DESCRIPTION
*PR by Claude.* 82 gates, 11 `--check` modes, selftest (113 cases) all green. No measurement changed.

`26_edition_conflicts.py` hardcodes `LATE_GRID = {"area": 1000, "production": 100}` with a comment citing
`state/source_value_precision.csv`. **A comment is not a dependency.** If that table is rebuilt and the
late-volume verdict moves, the constant goes stale silently and every `zero_grid_verdict` becomes a claim about a
grid the data no longer shows — including the 76 / 6 / 1 split that #414's recoverable set now rests on.

This is the sibling-copy failure this repo keeps hitting, and **I introduced it yesterday**, in the same session
where I fixed three surviving copies of a 100× unit figure that had already been corrected once. Writing the
citation as prose and then relying on it is precisely the pattern I had just finished cleaning up, so it gets a
gate arm rather than trust.

Three drift paths, each verified to fire with its own message:

```
the table's verdict changes   (iia, ha, 1934+) is now 'mixed', not 'coarse_1000', so the hardcoded
                              LATE_GRID 1000.0 for `area` no longer matches the table it cites
the cited row disappears      source_value_precision.csv has no (iia, tonnes, 1934+) row, so the
                              LATE_GRID constant 100.0 cites a measurement that is no longer there
the constant itself drifts    LATE_GRID['area'] is 500.0, but coarse_1000 means a grid of 1000
```

The arm degrades gracefully when the precision table is absent — it is derived from a panel outside the repo, so
a fresh clone may not have rebuilt it, and an absent table is an unavailable check rather than a contradiction.
`selftest_gates.py` stages it so the arm actually runs there, which the new self-check from #532 would otherwise
have had nothing to say about (it guards imports, not data reads).