### PR TITLE
lookup_known_defect now reads the tool source — the place that held the answer three times today

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ python3 scripts/validate_trade_direction_tiebreak.py  # and the direction: each 
 # specific label/item/year live in the free-text summary. It answers MATCH / INDETERMINATE / no
 # match, and an INDETERMINATE is not a pass.
 python3 scripts/lookup_known_defect.py --source iia --label serbia --item rye --year 1931
+# (it also greps the pipeline and gate SOURCE for the label and item, because a convention, swap or
+#  exclusion list is written where it is re-tested and no state table indexes that -- lines naming
+#  both the label and the item are shown first)
 
 # and the one that asks whether the checks above can fail at all -- it also self-checks its own
 # registries: no duplicate WRITABLE key, and any gate that IMPORTS its generator must have that

--- a/scripts/lookup_known_defect.py
+++ b/scripts/lookup_known_defect.py
@@ -109,6 +109,55 @@ def covers_year(lo, hi, year):
     return lo_i <= year <= hi_i
 
 
+
+# Directories whose SOURCE documents established mechanisms. A convention, a swap, a scope rule or an
+# exclusion is written where it is RE-TESTED, in a docstring or a constant block, and no state table
+# indexes that.
+MECHANISM_DIRS = ("pipelines/polity-autoimprove", "scripts")
+
+# Labels this common match everything and their hits carry no information.
+TOO_COMMON = frozenset({"total", "world", "other", "all", "none"})
+
+
+def mechanism_hits(needles: list) -> list:
+    """Where in the TOOL SOURCE is this label or item already discussed?
+
+    WHY THIS ARM EXISTS. On 2026-08-21 the same mistake was made three times in one day: a mechanism was
+    published as a finding when it was already written down -- and each time the record was in a place
+    this tool did not read. The worst was `austria`'s meslin false zero, documented in
+    `11_retest_conventions.py`'s RATIO_ONLY_SWAP_LABELS comment with the same cell, the same 0.15% match
+    and an explicit attribution to issue 414, while data_errors.csv and the provenance tables (which this
+    tool did read) said nothing. A grep would have found it in one second.
+
+    So this reports FILE AND LINE for every mention of the queried label or item in the pipeline and gate
+    source. It is deliberately dumb -- a substring match on comments, docstrings and constants alike --
+    because the exclusion lists that matter (RATIO_ONLY_SWAP_LABELS, SWAPPED_PAIRS, BASELINE,
+    SOURCE_NOTES) are literals, and a smarter parser would miss the prose around them.
+
+    Hits are NOT evidence that a finding is already recorded; they are places to read before claiming it
+    is not. The distinction matters because a common label appears in dozens of unrelated files.
+    """
+    out = []
+    for d in MECHANISM_DIRS:
+        base = os.path.join(REPO, d)
+        if not os.path.isdir(base):
+            continue
+        for name in sorted(os.listdir(base)):
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(base, name)
+            try:
+                lines = open(path, encoding="utf-8").read().splitlines()
+            except OSError:
+                continue
+            for i, line in enumerate(lines, 1):
+                low = line.lower()
+                hit = [n for n in needles if n in low]
+                if hit:
+                    out.append((os.path.join(d, name), i, hit, line.strip()[:130]))
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -200,6 +249,35 @@ def main() -> int:
         print("  NOTE `raw_label` is a CANONICAL territory name, not the raw extract's label (it matches")
         print("  the extract in only 32% of rows). `dominant` IS the extract's label -- 100% of rows --")
         print("  so join on that: e.g. canonical `cyprus` is `british cyprus` in the extract.")
+
+    # --- mechanisms documented in tool source, which no state table indexes ---
+    needles = [n for n in (str(a.label or "").strip().lower(), str(a.item or "").strip().lower())
+               if n and n not in TOO_COMMON and len(n) >= 4]
+    if needles:
+        hits = mechanism_hits(needles)
+        if hits:
+            byfile = {}
+            for f, ln, needle, text in hits:
+                byfile.setdefault(f, []).append((ln, needle, text))
+            print(f"\nMECHANISMS IN TOOL SOURCE -- {len(hits)} mention(s) across {len(byfile)} file(s). "
+                  f"These are NOT")
+            print("  proof the finding is recorded, but they are where a convention, swap, scope rule or")
+            print("  exclusion list would be written, and no state table indexes them. READ THEM FIRST:")
+            for f in sorted(byfile, key=lambda k: -len(byfile[k]))[:8]:
+                # A LINE MENTIONING EVERY NEEDLE COMES FIRST. That ranking is the whole point: the line
+                # this tool was written for -- 11_retest_conventions.py's
+                # "austria  iia_1938_39 prints meslin = 0.0 for 1933, a false zero of issue 414's class"
+                # -- names BOTH the label and the item, while the 19 other `austria` mentions in that file
+                # name only one. Showing hits in line order buried it under a docstring.
+                rows = sorted(byfile[f], key=lambda r: (-len(r[1]), r[0]))
+                print(f"  {f}  ({len(rows)} mention(s))")
+                for ln, hit, text in rows[:3]:
+                    print(f"    :{ln}  [{'+'.join(hit)}]  {text}")
+                if len(rows) > 3:
+                    print(f"    ... and {len(rows) - 3} more in this file")
+        else:
+            print(f"\nMECHANISMS IN TOOL SOURCE -- no mention of {needles} in the pipeline or gate "
+                  f"source.")
 
     if not matches and not indet:
         print("no entry can cover this query on the dimensions given.")


### PR DESCRIPTION
*PR by Claude.* 82 gates, 11 `--check` modes, selftest (113 cases) all green. Not a gate, so no CI wiring.

Three times today I published a mechanism as a finding when it was already written down, and each time the record
was somewhere this tool does not read. The worst:

> `austria`'s meslin false zero, documented in `11_retest_conventions.py`'s `RATIO_ONLY_SWAP_LABELS` comment with
> the **same cell**, the **same 0.15% match** on 11,582.5 against 11,600, and an explicit attribution to **issue
> 414** — while `data_errors.csv` and the provenance tables, which this tool *does* read, said nothing.

A convention, a swap, a scope rule or an exclusion list is written **where it is re-tested** — in a docstring or a
constant block — and no state table indexes that. So the tool now greps the pipeline and gate source for the
queried label and item and reports file and line.

## The ranking is the point, not the grep

Lines matching **every** needle come first:

```
pipelines/polity-autoimprove/11_retest_conventions.py  (20 mention(s))
  :658  [austria+meslin]  #   austria  iia_1938_39 prints meslin = 0.0 for 1933, a false zero of
                          issue 414's class, so the
  :377  [austria]         def check_iia_austria(d):
```

That is exactly the line I missed. In line order it sat 19 mentions deep behind a docstring about Cisleithania;
ranked by needles matched, it is first. `austria` appears 20 times in that file and **once** with `meslin`.

Verified on two more of the day's cases: `russian federation`+`rye` surfaces `validate_series_collapses.py`'s
pinned 1918 rows (the Karafuto cells, #422), and `nauru`+`phosphate` surfaces `check_iia_australia_phosphate`.

## Deliberately dumb

Substring matching over comments, docstrings and constants alike, because the exclusion lists that matter
(`RATIO_ONLY_SWAP_LABELS`, `SWAPPED_PAIRS`, `BASELINE`, `SOURCE_NOTES`) are literals and a smarter parser would
miss the prose around them. Needles under 4 characters and the too-common labels (`total`, `world`, `other`,
`all`, `none`) are skipped.

The output states that hits are **not** proof a finding is recorded — they are places to read before claiming it
is not. That distinction is why this is a helper and not a gate.