### PR TITLE
Re-test the mitchell flax/linseed entry — 55:1 against its control, and nothing had drifted (#431, #360)

### DIFF
--- a/pipelines/polity-autoimprove/35_retest_data_errors.py
+++ b/pipelines/polity-autoimprove/35_retest_data_errors.py
@@ -441,6 +441,43 @@ def check_item_product_switches(ctx):
             "the exhibit carries two mechanisms; the 1925 cell is australia administered islands")
 
 
+def check_mitchell_flax_is_linseed(ctx):
+    """55 mitchell flax-fibre values equal a juan LINSEED value; 1 equals a juan flax-fibre value.
+
+    THE CONTROL IS HALF THE EVIDENCE and it is why this entry is `confirmed` rather than suggestive. That
+    55 of 204 values match another source's linseed series exactly would be interesting on its own; that
+    only ONE matches the same source's flax-fibre series is what rules out coincidence, because a
+    coincidence has no reason to prefer one item over the other by 55 to 1. So both counts are pinned,
+    and a rise in the control would undo the conclusion even with the 55 intact.
+
+    Needs the panel only -- no raw extract -- because the proof is one source's series against another's.
+    """
+    lb = ctx["panel"]
+
+    def index(src, item):
+        g = lb[(lb["source"] == src) & (lb["item"] == item) & (lb["unit"] == "ha")
+               & lb["value"].notna()]
+        out = collections.defaultdict(set)
+        for c, v in zip(g["country"], g["value"]):
+            out[str(c).strip().lower()].add(round(float(v), 6))
+        return g, out
+
+    m, _ = index("mitchell", "flax fibre and tow")
+    _, juan_linseed = index("juan", "linseed")
+    _, juan_flax = index("juan", "flax fibre and tow")
+    lin = flax = 0
+    for c, v in zip(m["country"], m["value"]):
+        c, v = str(c).strip().lower(), round(float(v), 6)
+        if v in juan_linseed.get(c, ()):
+            lin += 1
+        if v in juan_flax.get(c, ()):
+            flax += 1
+    return ([("mitchell flax-fibre (ha) values", len(m), 204),
+             ("equal to a juan LINSEED value, same country", lin, 55),
+             ("equal to a juan FLAX-FIBRE value (the CONTROL)", flax, 1)],
+            "the control is what rules out coincidence: 55 against 1, not 55 alone")
+
+
 # Only entries with a reproducible figure appear here. See the docstring on why the rest cannot.
 CHECKS = {
     "iia-corrupted-country-labels": check_corrupted_country_labels,
@@ -455,6 +492,7 @@ CHECKS = {
     "iia-hops-x100": check_hops_x100_and_area_x10,
     "fao1952-hemp-germany-label-glued": check_hemp_germany_glued,
     "iia-item-series-switch-raw-products": check_item_product_switches,
+    "mitchell-flax-fibre-area-is-linseed": check_mitchell_flax_is_linseed,
 }
 
 


### PR DESCRIPTION
*PR by Claude.* 82 gates, 11 `--check` modes, selftest (113 cases) all green.

`mitchell-flax-fibre-area-is-linseed` resolves #360's two largest source seams by showing that mitchell's
`flax fibre and tow` **area is linseed area**. Its figures reproduce exactly:

```
mitchell flax-fibre (ha) values                        204
  equal to a juan LINSEED value, same country           55
  equal to a juan FLAX-FIBRE value (the CONTROL)         1
```

## The control is half the evidence

That 55 of 204 values match another source's linseed series exactly would be interesting on its own. That **only
one** matches the same source's *flax-fibre* series is what rules out coincidence — a coincidence has no reason to
prefer one item over the other 55 to 1. So both counts are pinned: a rise in the control would undo the conclusion
with the 55 still intact, which is exactly the failure a single-figure re-test cannot see. That makes this the
second entry in this thread whose control needed pinning beside its finding, after the hops tobacco-area control.

Verified to fail when the control rises. Needs the panel only — the proof is one source's series against
another's.

## The first entry in five whose figures had not moved

```
#536  falsified          #539  undercounted by half
#537  wrong population   #540  two mechanisms as one
#541  exact on all three counts
```

Worth recording explicitly: the drift is **not** universal, and the re-tests are not merely re-deriving whatever
they happen to find. Four entries were wrong in four different ways and this one was right — which is what makes
the other four findings credible rather than an artefact of re-measuring with a slightly different method.

```
before  12 entries re-tested over 44 claims
after   13 entries re-tested over 47 claims   (19 of 32 out of scope by design)
```