### PR TITLE
Re-test the Czech rye orphan — pinning the pre-1919 row count, not just the 3.0 (#431)

### DIFF
--- a/pipelines/polity-autoimprove/35_retest_data_errors.py
+++ b/pipelines/polity-autoimprove/35_retest_data_errors.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import pandas as pd
 import csv
 import os
 import sys
@@ -598,6 +599,35 @@ def check_nigeria_cotton_area_zero(ctx):
             "the surviving tonnage is what refutes the zeros; the zeros alone prove nothing")
 
 
+def check_cze_1910_rye_orphan(ctx):
+    """A 3-hectare rye area in 1910, and the pre-1919 row count that convicts it without a magnitude
+    argument.
+
+    THE ROW COUNT IS THE ARGUMENT, not the size of the number. Raw `czechoslovakia` carries exactly THREE
+    rows dated before 1919 -- this rye area of 3.0 ha at 1910, a 1918 sugar-beet production of 640,816.1 t
+    and a 1918 potato export of 0.1 t -- and the state was founded in October 1918. A label with three
+    pre-existence rows is not reporting a country's 1910 rye crop; the 1918 sugar beet is defensible as
+    the harvest of a territory that became Czechoslovakia weeks later, and the 1910 row has no such
+    reading.
+
+    So the check pins the COUNT (3) as well as the cell, because the count is what makes this an orphan
+    rather than a small value. It also pins the next observation, 732,970 ha at 1919: the gap is what
+    rules out 3.0 being a plausible early figure on the same series.
+    """
+    raw, lb = ctx["raw"], ctx["panel"]
+    r = raw[(raw["_c"] == "czechoslovakia") & raw["value"].notna()]
+    yn = pd.to_numeric(r["year"], errors="coerce")
+    pre = r[yn < 1919]
+    g = lb[(lb["source"] == "iia") & (lb["country"] == "czech republic") & (lb["item"] == "rye")
+           & (lb["unit"] == "ha") & lb["value"].notna() & lb["year"].notna()].sort_values("year")
+    first = round(float(g["value"].iloc[0]), 6) if len(g) else None
+    nxt = round(float(g["value"].iloc[1]), 6) if len(g) > 1 else None
+    return ([("raw `czechoslovakia` rows dated before 1919", len(pre), 3),
+             ("layer-B czech rye ha, earliest cell", first, 3.0),
+             ("its next observation", nxt, 732970.0)],
+            "three pre-existence rows is the argument; the 3.0 is only the cell")
+
+
 # Only entries with a reproducible figure appear here. See the docstring on why the rest cannot.
 CHECKS = {
     "iia-corrupted-country-labels": check_corrupted_country_labels,
@@ -616,6 +646,7 @@ CHECKS = {
     "iia-flax-fibre-item-is-mostly-linseed": check_iia_flax_is_mostly_linseed,
     "fao1952-malaya-female-agric-1937-is-total": check_malaya_female_agric_is_total,
     "nga-1941-1945-cotton-area-zero": check_nigeria_cotton_area_zero,
+    "cze-1910-rye-area-orphan-3ha": check_cze_1910_rye_orphan,
 }
 
 


### PR DESCRIPTION
*PR by Claude.* 82 gates, 11 `--check` modes, selftest (113 cases) all green.

`cze-1910-rye-area-orphan-3ha` convicts a 3-hectare rye area at 1910 **without a magnitude argument**, and the
re-test pins the reason rather than the number:

```
raw `czechoslovakia` rows dated before 1919        3
layer-B czech rye ha, earliest cell              3.0
its next observation                         732,970
```

**The row count is the argument.** Czechoslovakia was founded in October 1918, and the label carries exactly three
pre-existence rows: this rye area, a 1918 sugar-beet production of 640,816.1 t and a 1918 potato export of 0.1 t.
The 1918 sugar beet is defensible as the harvest of a territory that became Czechoslovakia weeks later; the 1910
row has no such reading. A check pinning only the `3.0` would survive the count changing — and the count is the
half that makes this an orphan rather than a small value.

Verified to fail when the pre-1919 count moves.

## One entry left unpinned deliberately

`iia-1933-x10-wrong-volume-cells` claims **14** confirmed cells from a *provenance-linked* test: the layer-B label
carrying the value must be the one `item_provenance.csv` attributes to that raw label. Approximating it loosely
from `edition_conflicts.csv` gives 33 rows at ratio ~10, 32 with `iia_1933_34` holding the smaller value, and
**19** whose smaller value appears anywhere in layer-B `iia`.

The entry's own text names **two of my 19 as coincidences it discarded** (`spanish spanish guinea` 600 and
`total general` 45,000) — so the stricter test is doing real work and my loose one is not a substitute. Pinning 19
would record a number the entry does not claim. Replicating the provenance link properly is the right way to cover
it, and is not this commit.

```
before  16 entries re-tested over 60 claims
after   17 entries re-tested over 63 claims   (15 of 32 out of scope by design)
```