### PR TITLE
Never print the unmaintained `mixing_observed` without its marker

### DIFF
--- a/scripts/lookup_known_defect.py
+++ b/scripts/lookup_known_defect.py
@@ -240,12 +240,23 @@ def main() -> int:
         for field, r in prov[:6]:
             print(f"  matched on {field}: raw_label={r.get('raw_label')!r} -> "
                   f"layer_b={r.get('layer_b_label')!r} (assigned {r.get('assigned_modern')!r})")
+            # `mixing_observed` is printed with its status attached, never bare. No tool maintains it
+            # -- `15_label_provenance.py --write` refreshes only territory_signal, fingerprint_note,
+            # dominant_raw_label and dominant_share -- so it is whatever was last written by hand and
+            # is never re-derived when the panel moves. Citing it as corroboration has already gone
+            # wrong twice (libya in the wiki notes, kwantung on issue 483, both times because it read
+            # `no` while `territory_signal` read something else). validate_iia_label_provenance.py
+            # says so in its own report; this tool is where the pre-check happens, so it says so here.
             print(f"    kind={r.get('kind')!r} territory_signal={r.get('territory_signal')!r} "
-                  f"mixing_observed={r.get('mixing_observed')!r}")
+                  f"[STRONGER] mixing_observed={r.get('mixing_observed')!r} "
+                  f"[UNMAINTAINED -- never cite]")
             print(f"    fingerprint: {r.get('fingerprint_note')!r} "
                   f"dominant={r.get('dominant_raw_label')!r} @ {r.get('dominant_share')!r}")
         print("  A classification here means the ROUTING is known. It does NOT quantify how many cells")
         print("  are affected, so a measured count can still be new -- but say what was already recorded.")
+        print("  NOTE `mixing_observed` is maintained by NOTHING and is never re-derived when the panel")
+        print("  moves; `territory_signal` is the stronger measure. Where the two disagree, the stale")
+        print("  one is not evidence -- citing it has already produced two wrong conclusions.")
         print("  NOTE `raw_label` is a CANONICAL territory name, not the raw extract's label (it matches")
         print("  the extract in only 32% of rows). `dominant` IS the extract's label -- 100% of rows --")
         print("  so join on that: e.g. canonical `cyprus` is `british cyprus` in the extract.")

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -2315,6 +2315,25 @@ def mutate_provenance_raw_product_erased(root, gpd, make_valid, affinity):
             f"was")
 
 
+def mutate_lookup_prints_unmaintained_column_bare(root, gpd, make_valid, affinity):
+    """Strip the UNMAINTAINED marker from `lookup_known_defect.py`'s provenance line.
+
+    Arm E's whole point is that the marker cannot be quietly removed. The mutation is the exact
+    regression it guards: printing `mixing_observed` bare, beside `territory_signal`, which is the
+    juxtaposition behind both recorded misreadings (libya in the wiki notes, kwantung on issue 483).
+    Nothing about the file's behaviour changes -- it still runs, still prints a provenance block --
+    so no other gate and no test can see it."""
+    path = os.path.join(root, "scripts", "lookup_known_defect.py")
+    src = open(path, encoding="utf-8").read()
+    old = ("f\"[STRONGER] mixing_observed={r.get('mixing_observed')!r} \"\n"
+           "                  f\"[UNMAINTAINED -- never cite]\")")
+    assert old in src, "anchor gone -- re-read the emitting line before trusting this mutator"
+    new = "f\"mixing_observed={r.get('mixing_observed')!r}\")"
+    open(path, "w", encoding="utf-8").write(src.replace(old, new))
+    return ("removed the `[UNMAINTAINED -- never cite]` marker from lookup_known_defect.py's "
+            "provenance line, so the column nothing maintains prints bare beside the one that governs")
+
+
 def mutate_label_provenance_hides_mixing(root, gpd, make_valid, affinity):
     """Mark a span whose values come from ONE territory as coming from two.
 
@@ -4357,6 +4376,14 @@ CASES = (
     ),
     (
         "validate_iia_label_provenance.py",
+        mutate_lookup_prints_unmaintained_column_bare,
+        "UNMAINTAINED",
+        "a consumer printing the unmaintained `mixing_observed` beside the governing "
+        "`territory_signal` with no marker — the file still runs and still prints, so nothing "
+        "else in this harness or in CI can see the annotation go missing",
+    ),
+    (
+        "validate_iia_label_provenance.py",
         mutate_label_provenance_hides_mixing,
         "verified_equal",
         "a per-SPAN provenance row that hides an observed whole-plus-parts merge, so equality "
@@ -4794,6 +4821,12 @@ ARGS = {
 # FileNotFoundError -- exit 1 for entirely the wrong reason. The "must name the defect"
 # half of this script is what caught that; exit-code alone would have passed it.
 EXTRA_SCRIPTS = {
+    # Arm E of this gate reads `lookup_known_defect.py`'s SOURCE to require that the unmaintained
+    # `mixing_observed` column is never printed without its marker. Staged without the file, the arm
+    # reports "no longer exists -- repoint it" on every run, so the gate would exit 1 unconditionally
+    # and its case would pass whether or not the mutation bit. The runner only checks post-mutation
+    # exit != 0, so nothing else here would have caught that.
+    "validate_iia_label_provenance.py": ("lookup_known_defect.py",),
     "validate_polygon_binding_determinism.py": ("sources.yaml",),
     # The s2 gate imports s2_failure()/geodesic_area_km2() from the repair script, so the two
     # cannot disagree about what "s2 can measure this" means. Staged without it the gate dies on

--- a/scripts/validate_iia_label_provenance.py
+++ b/scripts/validate_iia_label_provenance.py
@@ -261,6 +261,36 @@ def main() -> int:
           f"(ceiling {BASELINE_VERIFIED_EQUAL_ON_MIXED})")
 
     problems = []
+
+    # E. ANY TOOL THAT SURFACES `mixing_observed` MUST SAY IT IS UNMAINTAINED.
+    # This report says so (arm above), but the report is not where the column gets cited -- the
+    # pre-check is. `lookup_known_defect.py` prints the provenance row for a queried label, and it
+    # printed `mixing_observed` bare, on the same line as `territory_signal`, for as long as it has
+    # existed. That is the exact juxtaposition behind both recorded misreadings (libya, kwantung
+    # on #483): the stale column reads `no`, the governing one disagrees, and the reader cites the
+    # one that agrees with them. Annotating the value is only durable if something forbids removing
+    # the annotation, so this arm reads the consumer's source and requires the marker beside it.
+    for rel in ("scripts/lookup_known_defect.py",):
+        consumer = os.path.join(REPO, rel)
+        if not os.path.exists(consumer):
+            problems.append(f"{rel} no longer exists; this arm is checking nothing -- repoint it")
+            continue
+        src = open(consumer, encoding="utf-8").read()
+        emitting = [ln for ln in src.splitlines()
+                    if "mixing_observed=" in ln and "print" in ln or
+                    ("mixing_observed" in ln and "f\"" in ln and "get(" in ln)]
+        for ln in emitting:
+            if "UNMAINTAINED" not in ln and "UNMAINTAINED" not in src[src.index(ln):src.index(ln) + 400]:
+                problems.append(
+                    f"{rel} prints `mixing_observed` without the UNMAINTAINED marker beside it: "
+                    f"{ln.strip()[:80]}. No tool maintains that column and territory_signal is the "
+                    f"governing measure; printing it bare next to territory_signal is what produced "
+                    f"the libya and kwantung misreadings")
+        if not emitting:
+            problems.append(
+                f"{rel} no longer prints `mixing_observed` at all -- if that is intended, drop this "
+                f"arm; otherwise the marker check has silently stopped applying")
+
     if len(offenders) > BASELINE_VERIFIED_EQUAL_ON_MIXED:
         for key, code in sorted(offenders):
             print(f"   {key:40} -> {code}")


### PR DESCRIPTION
*PR created by Claude.*

`validate_iia_label_provenance.py` already documents that **nothing maintains
`mixing_observed`** — `15_label_provenance.py --write` refreshes only `territory_signal`,
`fingerprint_note`, `dominant_raw_label` and `dominant_share` — and its report annotates
the column. But the report is not where the column gets cited. **The pre-check is.**

`lookup_known_defect.py` printed it bare, on the same line as the governing measure, for
as long as it has existed:

```
kind='shares_target' territory_signal='redirected' mixing_observed='no'
```

That juxtaposition *is* the mechanism behind both misreadings the gate's own comments
record — libya in the wiki notes, kwantung on #483 — each time the stale column reading
`no` while `territory_signal` disagreed, and the reader citing the one that agreed with
them.

**It caught me again today.** Working #483's china/Kwantung aggregation I read
`mixing_observed='no'` for `china, mainland` *while proving that label mixes*, and the only
thing that stopped me was a note kept outside the repo. A field that needs external
knowledge to interpret safely is not annotated.

```
territory_signal='redirected' [STRONGER] mixing_observed='no' [UNMAINTAINED -- never cite]
```

An annotation is only durable if something forbids removing it, so **arm E** reads the
consumer's source and requires the marker beside the emitting line. It fails loudly — not
skips — if the file stops existing or stops printing the column, since either would make
the check inert while looking fine.

## Wiring the arm exposed a harness gap

`stage()` copies only the gate under test, so the arm found no consumer in the scratch root
and appended *"no longer exists — repoint it"* on **every** run. The gate would then exit 1
unconditionally, and since the runner only checks post-mutation `exit != 0`, **case 55 would
have passed whether or not its mutation bit**. Fixed by adding the consumer to
`EXTRA_SCRIPTS`, and verified the way the runner does not:

```
staged: ['lookup_known_defect.py', 'validate_iia_label_provenance.py']
UNMUTATED staged gate exit=0   <-- must be 0 for case 55 to mean anything
```

This is the same staging trap as the `spec_from_file_location` one that `#532`'s
`_assert_imported_generators_are_staged()` covers, reached by a different route: that guard
only inspects `pipelines/*.py` paths passed to an importer, and this arm `open()`s a file
under `scripts/`.

New **case 55** mutates the marker away and requires the gate to name `UNMAINTAINED`. The
mutated file still runs and still prints its provenance block, so nothing else in the harness
or in CI could see the annotation go missing.

113 → **114 selftest cases**. 82 gates and 11 `--check` modes green locally; no data files
touched.