### PR TITLE
32 lexicon targets route nowhere, and 11 gates had no selftest case

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -97,6 +97,7 @@ import argparse
 import csv
 import json
 import math
+import glob
 import os
 import re
 import shutil
@@ -2315,6 +2316,32 @@ def mutate_provenance_raw_product_erased(root, gpd, make_valid, affinity):
             f"was")
 
 
+def mutate_lexicon_entry_routes_nowhere(root, gpd, make_valid, affinity):
+    """Add a lexicon entry whose English target names no polity, pushing the inert count past its
+    ceiling.
+
+    The lexicon's only purpose is to turn a source's own label into something the matcher can route,
+    so an entry that resolves to nothing is inert by construction -- it cannot contribute a
+    resolution, and every other number this gate prints is unchanged by it. That is what makes the
+    ceiling the only thing that can notice: statements stay at 2,225, resolved pairs stay put, and no
+    polygon moves.
+    """
+    import csv as _csv
+    path = os.path.join(root, "data/final/source_label_lexicon.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    # reuse a label the statements actually carry, so the entry is exercised rather than ignored
+    rows.append({"normalised_form": "groenland", "english_label": "Erewhon Crown Colony",
+                 "note": "selftest: target names no polity"})
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return ("added a lexicon entry mapping `groenland` to `Erewhon Crown Colony`, a target no polity "
+            "carries, so the entry can never contribute a resolution")
+
+
 def mutate_lookup_prints_unmaintained_column_bare(root, gpd, make_valid, affinity):
     """Strip the UNMAINTAINED marker from `lookup_known_defect.py`'s provenance line.
 
@@ -4375,6 +4402,13 @@ CASES = (
         "distinctness filter all stay identical",
     ),
     (
+        "validate_stated_areas.py",
+        mutate_lexicon_entry_routes_nowhere,
+        "resolve to no polity",
+        "a lexicon entry whose target routes nowhere — inert by construction, and invisible in every "
+        "other figure this gate prints, so only the ceiling on inert targets can catch it",
+    ),
+    (
         "validate_iia_label_provenance.py",
         mutate_lookup_prints_unmaintained_column_bare,
         "UNMAINTAINED",
@@ -5013,6 +5047,19 @@ WRITABLE = {
         "pipelines/polity-autoimprove/state/verdicts_applied.jsonl",
         "pipelines/polity-autoimprove/state/assertions.json",
     ),
+    # This gate SKIPs unless it can read the geometry, the database, the statements, the lexicon
+    # AND import matchlib off `pipelines/polity-autoimprove` -- which is why it had no case for as
+    # long as it has existed. A SKIP exits 0, so a case that did not stage all five would report
+    # "gate PASSED a mutation it claims to catch" and look like a gate defect rather than a staging
+    # one.
+    "validate_stated_areas.py": (
+        "polities_database.csv",
+        "polities_database.gpkg",
+        "source_stated_areas.csv",
+        "source_label_lexicon.csv",
+        "pipelines/polity-autoimprove/matchlib.py",
+        "pipelines/polity-autoimprove/state/applied_aliases.csv",
+    ),
     "validate_iia_label_provenance.py": (
         "pipelines/polity-autoimprove/state/iia_assertion_provenance.csv",
         "pipelines/polity-autoimprove/state/iia_label_provenance.csv",
@@ -5418,6 +5465,27 @@ WRITABLE = {
 
 
 
+# How many `validate_*.py` gates have NO case in this harness. Not zero, and this harness used to
+# imply it was: its final line reads "N gate(s) fail on an injected defect and name it, and every
+# gate runs in CI", which is true of the CASES entries and of CI registration, and says nothing
+# about gates the mutation harness never exercises. Those gates can be green on real data forever
+# without anyone having shown they can go red.
+#
+# The ceiling is what makes the gap visible rather than implied: a NEW gate landing without a case
+# pushes it up, and covering one pushes it down and demands the ceiling follow.
+BASELINE_GATES_WITHOUT_A_CASE = 10
+
+
+def _gates_without_a_case() -> list:
+    """`validate_*.py` scripts that no CASES entry exercises."""
+    have = {c[0] for c in CASES}
+    return sorted(
+        os.path.basename(p)
+        for p in glob.glob(os.path.join(REPO, "scripts", "validate_*.py"))
+        if os.path.basename(p) not in have
+    )
+
+
 def check_every_gate_runs_in_ci() -> list:
     """Every gate script must appear in the workflow that claims to run them all.
 
@@ -5504,10 +5572,24 @@ def check_every_gate_runs_in_ci() -> list:
                 f"README.md: {undocumented}"
             )
 
+    uncovered = _gates_without_a_case()
+    if len(uncovered) > BASELINE_GATES_WITHOUT_A_CASE:
+        problems.append(
+            f"{len(uncovered)} gate(s) have no case in this harness, above the ceiling of "
+            f"{BASELINE_GATES_WITHOUT_A_CASE} -- a gate nothing mutates has never been shown able "
+            f"to fail: {', '.join(uncovered)}"
+        )
+    elif len(uncovered) < BASELINE_GATES_WITHOUT_A_CASE:
+        problems.append(
+            f"only {len(uncovered)} gate(s) now lack a case, below the ceiling of "
+            f"{BASELINE_GATES_WITHOUT_A_CASE} -- lower it so the coverage is held"
+        )
+
     if not problems:
         print(
             f"every gate runs in CI and is named in the README "
-            f"({len(scripts)} scripts)"
+            f"({len(scripts)} scripts); {len(uncovered)} have no case here and are NOT "
+            f"exercised by this harness: {', '.join(g.replace('validate_', '') for g in uncovered)}"
         )
     return problems
 

--- a/scripts/validate_stated_areas.py
+++ b/scripts/validate_stated_areas.py
@@ -409,6 +409,14 @@ _NATIONALITY = re.compile(
 )
 
 
+# Lexicon targets that resolve to no polity at any year their source states a figure for. Not zero,
+# and not reachable while 11 of them (`Karafuto`, `Kwantung`, `Tibet`, `Memel`, `Rio de Oro`,
+# `Socotra`, `Svalbard` among them) name territories this database has no polity for -- issue 400.
+# The ceiling holds the rest: a new entry pointing nowhere, or a polity rename stranding an old one,
+# both push it up.
+BASELINE_INERT_LEXICON = 32
+
+
 def normalise_label(raw: str) -> str:
     text = unicodedata.normalize("NFKD", str(raw)).encode("ascii", "ignore").decode().lower()
     text = re.sub(r"-\s+", "", text)          # OCR hyphenation across a line break
@@ -469,6 +477,7 @@ def analyse():
     )
 
     lexicon = load_lexicon()
+    lex_tried, lex_live = {}, set()
     with open(STATED_PATH, encoding="utf-8") as fh:
         statements = list(csv.DictReader(fh))
 
@@ -539,6 +548,21 @@ def analyse():
                 code = None
             if code:
                 break
+        # INERT LEXICON ENTRIES. The lexicon exists for exactly one purpose -- to turn IIA's French
+        # label into something the matcher can route -- so an entry whose English target resolves to
+        # NOTHING at any year the source states, under either source string, can never contribute a
+        # resolution. Three failure shapes are demonstrable and they need different fixes, which is
+        # why this arm counts rather than repairs: the target names a polity whose SPAN excludes the
+        # stated years (`Basutoland` -> LSO-1868-1886, while statements run 1911-1951); the territory
+        # has a polity under a longer name (`Zanzibar` vs `Zanzibar Protectorate`, `Bechuanaland` vs
+        # `Bechuanaland Protectorate`); or no polity exists at all (`Karafuto`, `Kwantung` -- both
+        # blocked on issue 400). Retargeting an entry is an established remedy here: the `saint marin`,
+        # `terre neuve` and `macao` entries were each retargeted under issue 195.
+        target = lexicon.get(normalise_label(row["label"]))
+        if target:
+            lex_tried.setdefault(target, set()).add((row["source"], year))
+            if code:
+                lex_live.add(target)
         if not code or code not in ours or stated <= 0:
             continue
         pairs[(code, row["source"], year)] = ours[code] / stated
@@ -598,6 +622,7 @@ def analyse():
         "names": names,
         "statements": statements,
         "lexicon": lexicon,
+        "lex_inert": sorted(t for t in lex_tried if t not in lex_live),
         "pairs": pairs,
         "allstated": allstated,
         "per_source": per_source,
@@ -613,6 +638,7 @@ def main() -> int:
         return 0
     ours = result["ours"]
     statements, lexicon, pairs = result["statements"], result["lexicon"], result["pairs"]
+    lex_inert = result["lex_inert"]
     allstated, suspect, diverged = result["allstated"], result["suspect"], result["diverged"]
 
     problems = []
@@ -634,8 +660,27 @@ def main() -> int:
                 f"{TOLERANCE:.0%} -- remove its entry"
             )
 
+    # A count, with a ceiling rather than a target of zero: 11 of these name territories with no
+    # polity at all, so zero is not reachable until issue 400 is decided. What the ceiling protects
+    # against is the number GROWING -- a new lexicon entry that routes nowhere, or a polity rename
+    # that quietly strands an existing one.
+    if len(lex_inert) > BASELINE_INERT_LEXICON:
+        problems.append(
+            f"{len(lex_inert)} lexicon target(s) resolve to no polity at any year their source "
+            f"states, above the ceiling of {BASELINE_INERT_LEXICON}. An entry that routes nowhere "
+            f"cannot contribute a resolution, which is the lexicon's only purpose: "
+            f"{', '.join(lex_inert[:6])}"
+        )
+    elif len(lex_inert) < BASELINE_INERT_LEXICON:
+        problems.append(
+            f"only {len(lex_inert)} lexicon target(s) are inert, below the ceiling of "
+            f"{BASELINE_INERT_LEXICON} -- lower it so the improvement is held"
+        )
+
     within10 = sum(1 for r in pairs.values() if abs(r - 1) <= 0.10)
     print(f"stated-area statements: {len(statements):,}   lexicon entries: {len(lexicon)}")
+    print(f"  lexicon targets that resolve to NOTHING at any stated year: {len(lex_inert)} "
+          f"(ceiling {BASELINE_INERT_LEXICON})")
     print(f"(polity, source, year) pairs resolved: {len(pairs)}   polities: {len({k[0] for k in pairs})}")
     print(f"  within 10%: {within10}   within {TOLERANCE:.0%}: "
           f"{sum(1 for r in pairs.values() if abs(r - 1) <= TOLERANCE)}")


### PR DESCRIPTION
*PR created by Claude.*

Two gaps that read as coverage because nothing counted them.

## 1. Inert lexicon entries

`data/final/source_label_lexicon.csv` exists for exactly one purpose — to turn a source's own
label into something `matchlib` can route. **32 of its 149 distinct English targets resolve to no
polity at any year their source states a figure for**, under the source string the statement
actually carries. Such an entry cannot contribute a resolution; it is inert by construction.

The gate printed `lexicon entries: 192` and never asked how many of them work.

Three failure shapes, which need different fixes and are therefore **counted rather than
repaired**:

| shape | example |
|---|---|
| target names a polity whose **span** excludes the stated years | `Basutoland` → `LSO-1868-1886`, while statements run 1911–1951 |
| the territory has a polity under a **longer name** | `Zanzibar` vs *Zanzibar Protectorate*; `Bechuanaland` vs *Bechuanaland Protectorate*; `Swaziland`, whose polity is *Eswatini* |
| **no polity exists** | `Karafuto`, `Kwantung`, `Tibet`, `Memel`, `Rio de Oro`, `Socotra`, `Svalbard` — blocked on #400 |

That last group is why the ceiling is **32 and not 0**. Retargeting an entry is an established
remedy here — the `saint marin`, `terre neuve` and `macao` entries were each retargeted under
#195, and this gate's own comments record it.

I did **not** publish a classification of the 32. A fuzzy name match produced
`Swaziland`→Thailand and `Western Samoa`→Western Sahara, so the trustworthy output is the count
and the test, and the list is for triage.

## 2. Eleven gates had no selftest case

`validate_stated_areas.py` was one, and *why* it never got one is the interesting part: it SKIPs
unless it can read the geometry, the database, the statements and the lexicon **and** import
`matchlib` off `pipelines/polity-autoimprove`. **A SKIP exits 0**, so a case staging less than all
of that would have reported *"gate PASSED a mutation it claims to catch"* — a staging failure
dressed up as a gate defect. Its case now stages all six inputs, and I verified what the runner
does not:

```
UNMUTATED staged gate exit=0   <- must be 0, else the case is vacuous
  stated-area statements: 2,225   lexicon entries: 192
  lexicon targets that resolve to NOTHING at any stated year: 32 (ceiling 32)
```

The harness also implied coverage it did not have. Its final line read *"N gate(s) fail on an
injected defect and name it, and every gate runs in CI"* — true of the `CASES` entries and of CI
registration, and silent about gates it never exercises. Now:

```
every gate runs in CI and is named in the README (84 scripts); 10 have no case here and are
NOT exercised by this harness: citations.py, constants.py, cow_codes.py, cross_family_names.py,
iso_codes.py, iso_collisions.py, period_gaps.py, polygon_validity.py, succession_geography.py,
unranged_aliases.py
```

A gate nothing mutates has never been shown able to go red.

Both new baselines are **bidirectional** — each arm fails if the count *drops*, so covering a gate
or fixing a lexicon entry has to be banked rather than silently absorbed.

114 → **115 cases**; 11 → **10** gates with no case. 82 gates and 11 `--check` modes green locally.