### PR TITLE
Two final lexicon entries, and the mechanically-findable seam is exhausted

### DIFF
--- a/data/final/polities_manifest.json
+++ b/data/final/polities_manifest.json
@@ -201,7 +201,7 @@
  },
  "stated_area_basis": {
   "path": "data/final/source_stated_area_basis.csv",
-  "bases": 349,
+  "bases": 350,
   "polities": 247,
   "sources": [
    "fao",

--- a/data/final/source_label_lexicon.csv
+++ b/data/final/source_label_lexicon.csv
@@ -45,6 +45,7 @@ congo belge,Belgian Congo,
 coree,Korea,
 coree jap,Korea,
 cote de l or,Ghana (1898-1957),"was 'Gold Coast', which is not a polity_name"
+cote de l or: togoland,British Togoland (1920-1957),"Added 2026-08-24 (#195): sub-label with no lexicon entry. COTE DE L'OR: TOGOLAND is the Togoland mandate administered WITH the Gold Coast, i.e. British Togoland -- not GCT-1919-1956, which is the combined Gold-Coast-plus-Togoland reporting unit. Stated 33,770-33,776 against a 26,545 polygon: British Togoland was about 33,800 km2, so the SOURCE looks right and the 21% gap is a question about our geometry. Inside tolerance, and surfacing it is the point. Territory read from the name (whole-word match on the child segment, which is what keeps `guinee` off New Guinea), area used only as the check -- worst deviation 0.224, span covers every stated year."
 cote de lor,Gold Coast,OCR: lost space
 cote des somalis,French Somaliland,
 curacao et dependences,Dutch Caribbean (colonial),"Added 2026-08-24 (#195): colonial sub-label with no lexicon entry, so its stated area reached no polity. Territory read from the French name, then corroborated by area against ANT-1816-1961 -- worst deviation 0.172 across the whole stated range, span covers every stated year. Area was not used to FIND the destination."
@@ -94,6 +95,8 @@ honduras britannique,British Honduras,
 hongrie,Hungary,NOT retargeted to 'Kingdom of Hungary (Transleithania)': same year-dependence as `allemagne`. Right for 1911-1913 but trades HUN-1920-1938 (6 statements) for HUN-1800-1918 (3).
 iles de l egee,Dodecanese,
 iles du pacifique: fidji ou viti,Fiji,"Added 2026-08-24 (#195): a colonial SUB-label with no lexicon entry, so its stated area reached no polity. Identified from the French name and then corroborated by area against FJI-1800-2025 (worst ratio deviation 0.032 across the whole stated range, span covers every stated year). Area was NOT used to find the destination -- searching by area pairs PESCADORES with Saint Helena and BAHREIN with Guam."
+iles du pacifique: nauru,Nauru,"Added 2026-08-24 (#195): sub-label with no lexicon entry. stated 22-26 km2 against a 21 km2 polygon. Territory read from the name (whole-word match on the child segment, which is what keeps `guinee` off New Guinea), area used only as the check -- worst deviation 0.153, span covers every stated year."
+iles du pacifique: nauru terr sous,Nauru,"Added 2026-08-24 (#195): sub-label with no lexicon entry. stated 22-26 km2 against a 21 km2 polygon. Territory read from the name (whole-word match on the child segment, which is what keeps `guinee` off New Guinea), area used only as the check -- worst deviation 0.153, span covers every stated year."
 iles italiennes de l egee,Dodecanese,
 iles italiennes de legee,Dodecanese,OCR: lost space
 iles nouvelles hebrides,Vanuatu,"Retargeted 2026-08-24 (#195): the Anglo-French condominium is today VUT-1800-2025. Area 14,800 vs 12,182, ratio 0.823 -- inside tolerance, and the gap is a basis question worth surfacing."

--- a/data/final/source_stated_area_basis.csv
+++ b/data/final/source_stated_area_basis.csv
@@ -49,7 +49,7 @@ BRN-1888-2025,Brunei Darussalam,fao,5770,1,1952,British Borneo Brunei,5685,0.985
 BSS-1884-1960,British Somaliland Protectorate (1884-1960),iia,176000,9,1909;1925;1929;1932;1933;1938,SOMALIE BRITANNIQUE;SOMALIE BRITANNIQUE british;somalie britannique,171627,0.975,agrees,"A SINGLE-EDITION OUTLIER, in the other direction. `SOMALIE BRITANNIQUE` reads 176,000 km2 in 1913 and 86,000 in 1925; our polygon is 171,627, which is 2% from the EARLIER figure and 100% from the later. British Somaliland was about 176,000 km2, so here it is the 1925 edition that is wrong -- which is why this class cannot be handled by preferring later editions."
 BSW-1841-1963,Sarawak (Brooke Raj / Crown Colony),fao,121910,1,1952,British Borneo Sarawak,124230,1.019,agrees,
 BSW-1841-1963,Sarawak (Brooke Raj / Crown Colony),iia,129498,9,1909;1925;1929;1932;1933;1938,BORNEO BRITANNIQUE: SARAWAK;BORNÉO BRITANNIQUE: SARAWAK;borneo britannique: sarawak,124230,0.959,agrees,
-BTL-1920-1957,British Togoland (1920-1957),iia,34200,1,1925,TOGOLAND british,26545,0.776,agrees,
+BTL-1920-1957,British Togoland (1920-1957),iia,33988,4,1925;1929;1932;1938,CÔTE DE L'OR: TOGOLAND br;CôTE DE L'OR: TOGOLAND br;TOGOLAND british;côte de l'or: togoland br,26545,0.781,agrees,
 BTN-1800-2025,Bhutan,fao,46600,1,1952,Bhutan,39799,0.854,agrees,
 BTN-1800-2025,Bhutan,iia,51800,9,1909;1925;1929;1932;1933;1938,BOUTAN;boutan,39799,0.768,agrees,
 CAN-1886-1949,Canada (to the Newfoundland accession),iia,9659653,9,1909;1925;1929;1932;1933;1938,CANADA;canada,9551195,0.989,agrees,
@@ -257,6 +257,7 @@ NPL-1816-2025,Nepal,iia,140000,9,1909;1925;1929;1932;1933;1938,NEPAL;NÉPAL;NÉP
 NRH-1911-1953,Northern Rhodesia (1911-1953),fao,746240,1,1952,Northern Rhodesia,752073,1.008,agrees,
 NRH-1911-1953,Northern Rhodesia (1911-1953),iia,745777,3,1932;1933;1938,RHODESIE SEPTENTRIONALE;RHODÉSIE SEPTENTRIONALE,752073,1.008,agrees,
 NRU-1888-2025,Nauru,fao,20,1,1952,Nauru,22,1.101,agrees,
+NRU-1888-2025,Nauru,iia,22,6,1909;1925;1929;1932;1933;1938,ILES DU PACIFIQUE: NAURU;ILES DU PACIFIQUE: NAURU (terr sous;ILES DU PACIFIQUE: NAURU br;ILES DU PACIFIQUE: NAURU british;iles du pacifique: nauru,22,1.001,agrees,
 NZL-1840-2025,New Zealand,fao,268670,1,1952,New Zealand,268690,1.000,agrees,
 NZL-1840-2025,New Zealand,iia,268998,9,1909;1925;1929;1932;1933;1938,NOCVELLE-ZÉLANDE british;NOUVELLE-ZELANDE;NOUVELLE-ZÉLANDE;nouvelle-zélande,268690,0.999,agrees,
 PAK-1947-1949,Pakistan (1947-1949),fao,976360,1,1952,Pakistan,932577,0.955,agrees,


### PR DESCRIPTION
*PR created by Claude.*

| French sub-label | → destination | worst deviation |
|---|---|---|
| `iles du pacifique: nauru` | Nauru (`NRU-1888-2025`) | 0.153 |
| `cote de l or: togoland` | British Togoland (`BTL-1920-1957`) | 0.224 |

**Superset: 0 lost, 9 gained.** 1,375 → **1,384 pairs**.

The Togoland entry is worth its note: `COTE DE L'OR: TOGOLAND` is the Togoland mandate administered
*with* the Gold Coast — i.e. British Togoland, **not** `GCT-1919-1956`, which is the combined
Gold-Coast-plus-Togoland reporting unit and a different territory. Stated 33,770–33,776 against a 26,545
polygon: British Togoland was about 33,800 km², so **the source looks right and the 21% gap is a question
about our geometry**. Inside tolerance, and surfacing it is the point.

## The seam is exhausted for mechanically-findable cases

A whole-word match on the child segment of every remaining parent-prefixed label — requiring the
destination's span to cover **every** stated year and its polygon to agree within 25% — returns exactly
these two. The whole-word requirement is what keeps `guinee` off *Territory of New Guinea*, and
tightening to it is precisely why the yield fell to two.

## What is left, stated rather than implied

```
statements still reaching no basis row        681 of 2,225   (was 923)
  label has NO lexicon entry                 588
  label HAS an entry but still fails          93

no-entry residue by top-level parent:
  iles du pacifique 38   afrique occidentale francaise 38
  indes occidentales britanniques 36   etats malais federes 24
  indes britanniques 23   etats malais proteges 20   indochine 17
  inde britannique 12   lybie 12   australie 10
```

Those are sub-units of federations and empires — the nine Malay States, the British Indian provinces,
Indochina's five, AOF's colonies, the Pacific island groups. **Each needs a polity that does not exist
rather than a translation that does**, which is #400's question and not this one's.

## The seam, end to end (#561–#568)

```
                        start      now
inert lexicon entries      32       21
lexicon entries           192      227
polities with a basis     226      247
resolved pairs          1,163    1,384
statements compared         —      221
statements LOST             —        0
```

Along the way: one baselined divergence resolved, one `SOURCE_NOTES` comment falsified,
`BASELINE_AVOIDABLE_SELF_REF` 32 → 34 (more option-B candidates for #195), and three of my own claims
corrected — an area-ranked search that paired Pescadores with Saint Helena, a label-shape inference that
wrongly wrote off Sarawak and North Borneo, and a token-search miss that wrongly listed German East
Africa as having no polity.

82 gates, 11 `--check` modes, 125 selftest cases green locally.