### PR TITLE
Compare the published wiki page copies against their sources (site drift, arm D)

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -867,6 +867,26 @@ def mutate_partial_territory_claimed_twice(root, gpd, make_valid, affinity):
     )
 
 
+def mutate_site_page_copy_drifts(root, gpd, make_valid, affinity):
+    """Edit a published page copy so it no longer matches the wiki page it was copied from.
+
+    `site/build_wiki.sh` `cp`s `wiki/polities/*.md` into `site/wiki/polities/` and `pages.yml`
+    publishes `site/**`, so the copies ARE published output. Arms A-C compared the CSV and the geojson
+    and nothing looked at the pages -- which is how 45 of them served text from before 9dc37c0
+    (2026-08-18) for six days while every gate stayed green.
+
+    The mutation appends a comment rather than changing anything semantic, deliberately: the page still
+    parses, still has valid frontmatter, and still passes `validate_citations`. Only a byte comparison
+    against its source can see it, which is exactly the arm under test.
+    """
+    src = os.path.join(root, "site/wiki/polities/atg-1800-2025.md")
+    assert os.path.exists(src), "the staged site page copy is missing -- check WRITABLE"
+    with open(src, "a", encoding="utf-8") as fh:
+        fh.write("\n<!-- selftest: published copy edited without rebuilding -->\n")
+    return ("appended a comment to site/wiki/polities/atg-1800-2025.md so the published copy no "
+            "longer matches wiki/polities/atg-1800-2025.md")
+
+
 def mutate_site_shows_withdrawn(root, gpd, make_valid, affinity):
     """Put a retired polity back into site/polities.geojson, which is how the site
     drew Argentina twice.
@@ -4996,6 +5016,13 @@ CASES = (
     ),
     (
         "validate_site_outputs.py",
+        mutate_site_page_copy_drifts,
+        "differ from",
+        "a published wiki page copy that no longer matches its source — the page still parses and "
+        "still passes the citation gate, so only a byte comparison against the repository sees it",
+    ),
+    (
+        "validate_site_outputs.py",
         mutate_site_shows_withdrawn,
         "ARG-1800-2025",
         "a withdrawn polity drawn on the published map, over the rows that replaced it",
@@ -5769,6 +5796,10 @@ WRITABLE = {
     # duplicate-key self-check below now makes that impossible. Its declaration lives above, beside
     # the case that needs it.
     "validate_site_outputs.py": (
+        # arm D byte-compares the published page copies against their sources, so BOTH trees
+        # must be staged -- the site copy to mutate, the wiki page to compare it against.
+        "wiki/polities",
+        "site/wiki/polities",
         "polities_database.csv",
         "polities_database.gpkg",
         "site/polities.csv",

--- a/scripts/validate_site_outputs.py
+++ b/scripts/validate_site_outputs.py
@@ -205,6 +205,52 @@ def main() -> int:
             f"that replaced it"
         )
 
+    # D ------------------------------------------------------------------------------------
+    # THE PAGE COPIES DRIFTED FOR SIX DAYS WITHOUT THIS ARM (added 2026-08-24, issue 554).
+    # `site/build_wiki.sh` copies `wiki/polities/*.md` and `wiki/sources/*.md` into `site/wiki/`
+    # verbatim, and `pages.yml` publishes `site/**`. So the copies are published output and the
+    # same argument as arm A applies to them: a straight copy that differs means the site is
+    # describing a different wiki.
+    #
+    # Arms A-C compared the CSV and the geojson and nothing looked at the pages, so when
+    # 9dc37c0 (2026-08-18) added prose to 45 polity pages, the site kept serving the old text
+    # and every gate stayed green. It surfaced only because adding two polities forced a site
+    # rebuild, which then showed 45 unrelated files changing.
+    #
+    # Byte comparison rather than mtime: the copy is `cp`, so equality is the whole contract,
+    # and an mtime check would fire on any checkout.
+    for sub in ("polities", "sources"):
+        src_dir = os.path.join(REPO, "wiki", sub)
+        dst_dir = os.path.join(REPO, "site", "wiki", sub)
+        if not os.path.isdir(src_dir):
+            continue
+        if not os.path.isdir(dst_dir):
+            problems.append(f"site/wiki/{sub}/ is missing entirely -- run bash site/build_wiki.sh")
+            continue
+        src = {n for n in os.listdir(src_dir) if n.endswith(".md")}
+        dst = {n for n in os.listdir(dst_dir) if n.endswith(".md")}
+        for n in sorted(src - dst):
+            problems.append(f"wiki/{sub}/{n} has no copy in site/wiki/{sub}/ -- the site is behind")
+        for n in sorted(dst - src):
+            problems.append(f"site/wiki/{sub}/{n} has no source page -- the site is ahead, or a "
+                            f"page was renamed and the old copy left behind")
+        stale = []
+        for n in sorted(src & dst):
+            with open(os.path.join(src_dir, n), encoding="utf-8") as fh:
+                a = fh.read().replace("\r\n", "\n")
+            with open(os.path.join(dst_dir, n), encoding="utf-8") as fh:
+                b = fh.read().replace("\r\n", "\n")
+            if a != b:
+                stale.append(n)
+        if stale:
+            problems.append(
+                f"{len(stale)} page(s) in site/wiki/{sub}/ differ from wiki/{sub}/, e.g. "
+                f"{', '.join(stale[:5])} -- the copies are `cp`d verbatim, so any difference "
+                f"means the published page is not the one in the repository"
+            )
+        print(f"site/wiki/{sub}: {len(src & dst)} copies compared, {len(stale)} stale, "
+              f"{len(src - dst)} missing, {len(dst - src)} orphaned")
+
     if problems:
         print(f"\nFAIL: {len(problems)} problem(s)\n")
         for p in problems:


### PR DESCRIPTION
*PR created by Claude.* Follow-on to #571, which found this by accident.

`site/build_wiki.sh` `cp`s `wiki/polities/*.md` and `wiki/sources/*.md` into `site/wiki/`, and
`pages.yml` publishes `site/**`. So the copies are **published output**, and this gate's own thesis
applies to them — its docstring says *"`site/` is published output — and until this gate existed,
nothing compared it to the database at all."*

Arms A–C compared `site/polities.csv` and `site/polities.geojson`. **Nothing looked at the pages.**

## The measured consequence

When `9dc37c0` (2026-08-18) added prose to 45 polity pages, `site/wiki/polities/` kept serving the old
text for **six days** and every gate stayed green. It surfaced only because #571 added two polities,
which forced a site rebuild, which then showed 45 *unrelated* files changing — i.e. it was found from
the wrong direction, by accident.

## Arm D

Byte-compares every page against its source, and reports three distinct failures rather than one:

- **stale content** — the copy differs from the page
- **missing copy** — a source page with nothing published for it
- **orphaned copy** — a published page with no source, which is the *rename* case: the old copy is
  left behind and keeps being served

```
site/wiki/polities: 782 copies compared, 0 stale, 0 missing, 0 orphaned
site/wiki/sources:   32 copies compared, 0 stale, 0 missing, 0 orphaned
```

Byte comparison rather than mtime, for the same reason arm A uses it: the copy is `cp`, so equality
**is** the contract, and an mtime check would fire on any checkout.

## The selftest case

It appends a **comment** rather than changing anything semantic, deliberately — the mutated page still
parses, still has valid frontmatter, and still passes `validate_citations`. Only a byte comparison
against its source can see it, which is precisely the arm under test.

I verified the staged gate exits **0 before** the mutation, so the case is not vacuous:

```
validate_site_outputs.py UNMUTATED exit=0   PASS: site/ shows exactly the live polities…
   site/wiki/polities: 782 copies compared, 0 stale, 0 missing, 0 orphaned
```

Both trees are staged through `WRITABLE` — the site copy to mutate, the wiki page to compare against.

125 → **126 selftest cases**. 82 gates and 11 `--check` modes green locally; no data files touched.