### PR TITLE
Correct 12 OCR-damaged fao1952 labels by normalisation, routing 25 rows (closes #552)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -705,6 +705,10 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_stated_areas.py
 
+      - name: Tabled OCR label corrections are still needed and still route
+        if: '!cancelled()'
+        run: python3 scripts/validate_ocr_corrections.py
+
       - name: Wiki pages only name things that exist
         if: '!cancelled()'
         run: python3 scripts/validate_references.py

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ python3 scripts/validate_polygons.py
 python3 scripts/validate_polygon_validity.py
 python3 scripts/validate_simplification_loss.py  # shipped geometry vs the source it was cut from
 python3 scripts/validate_stated_areas.py
+python3 scripts/validate_ocr_corrections.py  # tabled OCR label fixes are still needed, and still route
 python3 scripts/validate_shared_polygons.py
 python3 scripts/validate_coexisting_overlaps.py   # partial overlap: every substantial one classified, the sliver tail pinned
 python3 scripts/validate_polygon_period_fit.py

--- a/data/final/source_label_ocr_corrections.csv
+++ b/data/final/source_label_ocr_corrections.csv
@@ -1,0 +1,13 @@
+source,ocr_label,correct_label,note
+fao1952,Afghaniscan,Afghanistan,"OCR t->c. 1 row, 1951."
+fao1952,Anglo-Eg Sudan,Anglo-Egypt Sudan,"Truncated word. 1 row, 1949."
+fao1952,Bricish Guiana,British Guiana,"OCR t->c. 3 rows, 1949. Routes to GUY-1800-2025, confirmed by running the pipeline. I first recorded the opposite here: a standalone probe said `British Guiana` resolves to nothing, so I nearly published that issue 552 was wrong about this pair. The probe was wrong -- it built `matchlib.Matcher` WITHOUT `common_names_csv`, which the pipeline passes. Same label, same source, same year, different matcher configuration."
+fao1952,British Solomon,British Solomon Is,"Truncated word. 2 rows, 1949-1950."
+fao1952,Crechoslovakia,Czechoslovakia,"OCR z->c. 2 rows, 1947-1948. Deliberately NOT an alias: the correct spelling routes per year across F51-1918-1938, F51-1938-1945 and F51-1947-1993, so an alias would have to hard-code a span the year-resolution machinery already gets right."
+fao1952,French Equat Airica,French Equat Africa,"OCR f->i. 2 rows, 1950."
+fao1952,Guatemal,Guatemala,"Dropped final letter. 2 rows, 1949 and one 1934-1938 period row."
+fao1952,Madagascar 4,Madagascar,"Footnote marker read as text. 1 row, 1951."
+fao1952,Mauritius a,Mauritius,"Footnote marker read as text. 3 rows, 1949-1951."
+fao1952,Portuguese Timor a,Portuguese Timor,"Footnote marker read as text. 3 rows, 1949-1950 and one 1934-1938 period row."
+fao1952,Sho Tomé and Principe,São Tomé and Principe,"OCR ao->ho. 3 rows, 1949-1950 and one 1934-1938 period row."
+fao1952,São Tomé & Principe,São Tomé and Principe,"Ampersand for `and`. 2 rows, 1937 and 1951."

--- a/pipelines/polity-autoimprove/01_match_and_findings.py
+++ b/pipelines/polity-autoimprove/01_match_and_findings.py
@@ -55,6 +55,21 @@ df = pd.read_parquet(LB)
 valid_codes = set(pol["polity_code"])
 df = extdata.rename_layer_b_misnamed(df, polity_codes=valid_codes, where="layer B")
 work = df[~df.is_aggregate].copy()
+
+# OCR SPELLING CORRECTIONS (issue 552). A dozen fao1952 labels are misreadings of a label the
+# same source also prints correctly -- `Afghaniscan`, `Crechoslovakia`, `Madagascar 4`. Applied
+# as a RENAME rather than as aliases, deliberately: `Czechoslovakia` routes per year across
+# three F51 periods, so an alias would have to hard-code a span that the year-resolution
+# machinery below already gets right. Correcting the spelling defers that decision instead of
+# duplicating it. The corrected cells are disjoint from their correctly-spelled sibling's on
+# (item, unit, year) in every pair, so this adds observations rather than double-counting them.
+_ocr = extdata.load_ocr_corrections()
+_before = work["country"].copy()
+for (_src, _bad), _good in _ocr.items():
+    _hit = (work["source"] == _src) & (work["country"] == _bad)
+    work.loc[_hit, "country"] = _good
+_n_ocr = int((work["country"] != _before).sum())
+print(f"OCR label corrections applied: {_n_ocr:,} row(s) across {len(_ocr)} tabled spelling(s)")
 # trust a prior code ONLY if it is a real period-specific WHEP polity_code. Bare-iso
 # stubs (deu, gbr, jpn) carry no period/territory -> do NOT trust them; send them to
 # the resolver so iso+year-containment resolves each to its period polity. Measured

--- a/pipelines/polity-autoimprove/extdata.py
+++ b/pipelines/polity-autoimprove/extdata.py
@@ -31,6 +31,7 @@ copes with a renamed column is how the rename goes unnoticed; the point is to st
 """
 from __future__ import annotations
 
+import csv
 import os
 
 # --------------------------------------------------------------------------------------
@@ -357,6 +358,39 @@ def refuse_orphan_codes(counts, what: str, fix: str, path: str | None = None) ->
         print(f"  {code}  {n:,} row(s)  [{why}]")
     print(f"  refusing to write. {fix}")
     raise SystemExit(1)
+
+
+# Tracked in this repo, unlike LAYER_B/WHEP_CROPS above -- these corrections ARE repo data.
+OCR_CORRECTIONS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "data/final/source_label_ocr_corrections.csv",
+)
+
+
+def load_ocr_corrections(path: str | None = None):
+    """Load the tabled OCR spelling corrections as {(source, ocr_label): correct_label}.
+
+    These are source labels that a yearbook extraction misread -- `Afghaniscan`, `Crechoslovakia`,
+    `Madagascar 4` -- where the SAME source also prints the correct spelling. They are corrected
+    rather than aliased so that year resolution, not a hand-picked alias window, decides which
+    period polity each row lands on (issue 552).
+
+    Raises if the file is missing: it is tracked, and silently skipping the corrections would
+    quietly restore 25 unresolved rows while every count still looked plausible.
+    """
+    path = path or OCR_CORRECTIONS
+    if not os.path.exists(path):
+        raise ExternalDataError(f"tracked OCR correction table missing: {path}")
+    out = {}
+    with open(path, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            key = (row["source"], row["ocr_label"])
+            if key in out:
+                raise ExternalDataError(f"duplicate OCR correction key: {key}")
+            if row["ocr_label"] == row["correct_label"]:
+                raise ExternalDataError(f"OCR correction is a no-op: {key}")
+            out[key] = row["correct_label"]
+    return out
 
 
 def rename_layer_b_misnamed(df, polity_codes=None, where: str = "layer B"):

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -2697,6 +2697,36 @@ def mutate_source_files_two_territories_as_one(root, gpd, make_valid, affinity):
             "statements of about 2,385,120, so one polity's iia basis now spans two territories")
 
 
+def mutate_ocr_correction_target_routes_nowhere(root, gpd, make_valid, affinity):
+    """Point a tabled OCR correction at a spelling that resolves to nothing.
+
+    This is the failure the table can actually have, and it is invisible everywhere else: the
+    entry stays well-formed, the count stays at 12, the OCR label still gets rewritten -- and the
+    row lands on a DIFFERENT unresolved label instead of the one it started on. Nothing in the
+    pipeline's output distinguishes "unresolved because the spelling was wrong" from "unresolved
+    because the correction was wrong", so only a check on the target can see it.
+
+    Mutates `Guatemal`, whose target `Guatemala` resolves to GTM-1821-2025 -- deliberately NOT
+    `Bricish Guiana`, the one entry whose target is already expected not to resolve from CI.
+    Mutating that one would raise the count to 2 and fire the same arm for the wrong reason.
+    """
+    import csv as _csv
+    path = os.path.join(root, "data/final/source_label_ocr_corrections.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    hit = [r for r in rows if r["ocr_label"] == "Guatemal"]
+    assert hit, "the `Guatemal` correction moved -- pick another live target"
+    assert hit[0]["correct_label"] == "Guatemala", "unexpected target"
+    hit[0]["correct_label"] = "Guatemalia"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=fields, lineterminator="\n")
+        w.writeheader()
+        w.writerows(rows)
+    return ("retargeted the `Guatemal` OCR correction to `Guatemalia`, a spelling no polity "
+            "carries, so its two rows would be rewritten onto a label that still routes nowhere")
+
+
 def mutate_lexicon_entry_routes_nowhere(root, gpd, make_valid, affinity):
     """Add a lexicon entry whose English target names no polity, pushing the inert count past its
     ceiling.
@@ -4860,6 +4890,12 @@ CASES = (
         "pointing at a real polity, and invisible to every other figure the gate prints",
     ),
     (
+        "validate_ocr_corrections.py",
+        mutate_ocr_correction_target_routes_nowhere,
+        "resolve to no polity",
+        "an OCR correction pointing at a spelling that routes nowhere — the table stays well-formed "
+        "and the right size, and the row simply lands on a different unresolved label",
+    ),    (
         "validate_stated_areas.py",
         mutate_source_files_two_territories_as_one,
         "collapse raw labels whose stated areas differ",
@@ -5551,6 +5587,14 @@ WRITABLE = {
     # long as it has existed. A SKIP exits 0, so a case that did not stage all five would report
     # "gate PASSED a mutation it claims to catch" and look like a gate defect rather than a staging
     # one.
+    # Needs the polities DB and matchlib to decide whether each target routes; the correction
+    # table itself is what the mutation rewrites.
+    "validate_ocr_corrections.py": (
+        "polities_database.csv",
+        "source_label_ocr_corrections.csv",
+        "pipelines/polity-autoimprove/matchlib.py",
+        "pipelines/polity-autoimprove/state/applied_aliases.csv",
+    ),
     "validate_stated_areas.py": (
         "polities_database.csv",
         "polities_database.gpkg",

--- a/scripts/validate_ocr_corrections.py
+++ b/scripts/validate_ocr_corrections.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Guard `data/final/source_label_ocr_corrections.csv` (issue 552).
+
+A dozen fao1952 source labels are misreadings of a label the SAME source also prints correctly
+-- `Afghaniscan`, `Crechoslovakia`, `Madagascar 4`. `01_match_and_findings.py` rewrites them to
+the correct spelling before matching, which routes 25 otherwise-unresolved rows.
+
+WHY A RENAME AND NOT TWELVE ALIASES. `Czechoslovakia` routes per year across F51-1918-1938,
+F51-1938-1945 and F51-1947-1993. An alias maps a label to ONE polity, so aliasing `Crechoslovakia`
+would hard-code a span decision that year resolution already makes correctly -- and the modal
+destination of the correct spelling (F51-1918-1938, which ends in 1938) is the WRONG one for its
+1947-1948 rows. Correcting the spelling defers the decision instead of duplicating it.
+
+WHAT THIS GATE CAN AND CANNOT SEE. Layer B is not redistributable and is absent in CI, so the
+arms that need it degrade rather than vanish -- and the arms that do NOT need it are the ones
+that catch the failure that matters: a correction that has become redundant, or a table that has
+silently shrunk. Both are checkable from the polities database alone.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "data/final/source_label_ocr_corrections.csv")
+POLDB = os.path.join(REPO, "data/final/polities_database.csv")
+ALIASES = os.path.join(REPO, "pipelines/polity-autoimprove/state/applied_aliases.csv")
+
+# Bidirectional, like every other ceiling here: the count dropping means a correction was deleted
+# and 25 rows quietly stopped resolving, which no other number in this repo would show.
+BASELINE_CORRECTIONS = 12
+
+# `British Guiana` resolves only when the matcher is built with `common_names_csv`, which the
+# pipeline passes and this gate cannot -- that file lives outside the repo. So one entry is
+# expected to look unresolvable from here. Pinning the count keeps that honest instead of letting
+# it hide a second one.
+BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES = 1
+
+
+def main() -> int:
+    problems = []
+    if not os.path.exists(TABLE):
+        print(f"FAIL: {os.path.relpath(TABLE, REPO)} is missing")
+        return 1
+    with open(TABLE, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    seen = set()
+    for r in rows:
+        key = (r["source"], r["ocr_label"])
+        if key in seen:
+            problems.append(f"duplicate correction key {key}")
+        seen.add(key)
+        if not r["source"].strip():
+            problems.append(f"{r['ocr_label']!r}: empty source -- a correction must name the source "
+                            "it applies to, or it rewrites labels in tables that spell them correctly")
+        if r["ocr_label"] == r["correct_label"]:
+            problems.append(f"{key}: correction is a no-op")
+        if not r.get("note", "").strip():
+            problems.append(f"{key}: no note -- the note is where the OCR mechanism is named")
+
+    print(f"OCR spelling corrections: {len(rows)} (ceiling {BASELINE_CORRECTIONS})")
+    if len(rows) > BASELINE_CORRECTIONS:
+        problems.append(f"{len(rows)} corrections, above the ceiling of {BASELINE_CORRECTIONS} -- "
+                        "raise it deliberately, with the new pair's evidence in its note")
+    elif len(rows) < BASELINE_CORRECTIONS:
+        problems.append(f"only {len(rows)} corrections, below the ceiling of {BASELINE_CORRECTIONS} "
+                        "-- an entry was deleted and its rows have stopped resolving")
+
+    sys.path.insert(0, os.path.join(REPO, "pipelines/polity-autoimprove"))
+    try:
+        import matchlib
+    except ImportError:
+        print("SKIP: matchlib unavailable -- structural arms only")
+        for p in problems:
+            print("  " + p)
+        return 1 if problems else 0
+
+    matcher = matchlib.Matcher(POLDB, ALIASES, verbose=False)
+
+    def resolves(label, source):
+        for year in (1937, 1948, 1949, 1950, 1951):
+            try:
+                if matcher.assign(label, None, source, year)[0]:
+                    return True
+            except Exception:
+                pass
+        return False
+
+    redundant = [r for r in rows if resolves(r["ocr_label"], r["source"])]
+    if redundant:
+        problems.append(
+            f"{len(redundant)} OCR label(s) already resolve WITHOUT correction, so the entry is "
+            f"redundant and hides whatever now routes them: "
+            + ", ".join(f"{r['ocr_label']!r}" for r in redundant[:5])
+        )
+
+    unresolvable = [r for r in rows if not resolves(r["correct_label"], r["source"])]
+    print(f"  correct spellings that do not resolve from here: {len(unresolvable)} "
+          f"(expected {BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES}, the common_names case)")
+    if len(unresolvable) > BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES:
+        problems.append(
+            f"{len(unresolvable)} correct spelling(s) resolve to no polity: "
+            + ", ".join(f"{r['correct_label']!r}" for r in unresolvable[:5])
+            + f". Above the expected {BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES} -- a correction "
+            "whose target routes nowhere moves a row from one unresolved label to another"
+        )
+    elif len(unresolvable) < BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES:
+        problems.append(
+            f"only {len(unresolvable)} correct spelling(s) fail to resolve, below the expected "
+            f"{BASELINE_UNRESOLVABLE_WITHOUT_COMMON_NAMES} -- lower it so the improvement is held"
+        )
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)\n")
+        for p in problems:
+            print("  " + p)
+        return 1
+    print("\nPASS: every tabled OCR correction is needed, and its target routes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
*PR by Claude.* Implements #552's own prescribed remedy — *"the fix is normalisation not aliasing"* — which #18 had also concluded ("upstream in consolidation") without an outcome being recorded.

## Why a rename and not twelve aliases

#552 made this argument and it holds up. `Czechoslovakia` routes **per year** across three polities:

```
Czechoslovakia   NA/1937 -> F51-1918-1938     1939 -> F51-1938-1945     1947-51 -> F51-1947-1993
```

An alias maps a label to **one** polity. So aliasing `Crechoslovakia` would hard-code a span decision that year resolution already makes correctly — and the obvious alias is the **wrong** one: the modal destination of the correct spelling is `F51-1918-1938`, which *ends* in 1938, while the OCR rows are 1947 and 1948. Correcting the spelling defers the decision instead of duplicating it.

## Measured end to end, not argued

Re-verified against layer B before building anything — all 12 labels present, 25 rows exactly, matching #552's count:

```
OCR label corrections applied:   25 rows across 12 tabled spellings
resolved rows                    189,946 -> 189,971    (+25)
newly resolved cells                  23    LOST cells        0
```

Every pair's cells are **disjoint** from its correctly-spelled sibling's on `(item, unit, year)` — overlap 0 in all 12, over sibling sets of 7 to 165 cells. Routing them adds observations rather than restating ones the source already publishes.

## A correction I nearly published, and didn't

A standalone probe told me `British Guiana` resolves to nothing, which would have made `Bricish Guiana` a pair that *cannot* route and #552's table wrong on that row. I wrote that into the note. Then the pipeline run showed all 76 `British Guiana` rows landing on `GUY-1800-2025` via `match_method: alias`.

The probe was wrong: it built `matchlib.Matcher` **without** `common_names_csv`, which `01_match_and_findings.py` passes. Same label, same source, same year, different matcher configuration. **#552 was right and I was not**; the entry's note now records the trap rather than the false finding.

Worth knowing separately: that same gap costs `validate_stated_areas.py` exactly **one** statement (`British Guiana` again), measured. Not worth closing, since `common_names.csv` lives outside the repo and the gate would gain an untracked dependency for one row — but it is now written down rather than rediscovered.

## Wired as a gate, not left as data

`scripts/validate_ocr_corrections.py` checks the two things that can actually go wrong, both from the polities database alone so CI sees them without layer B:

- **no tabled OCR label already resolves on its own** — a redundant entry hides whatever now routes it;
- **each target does resolve**, with the single `common_names` case pinned rather than waved through, so a *second* one cannot hide behind it.

Plus the bidirectional count: the table shrinking means an entry was deleted and 25 rows quietly stopped resolving, which no other number in this repo would show.

Selftest **case 66** retargets `Guatemal` to `Guatemalia`. That is the failure mode that is invisible everywhere else — the table stays well-formed and the right size, the label still gets rewritten, and the row simply lands on a *different* unresolved label. Deliberately not `Bricish Guiana`, which would have fired the same arm for the wrong reason.

## Verification

- **83** `validate_*` gates pass (was 82); all `--check` modes pass
- `selftest_gates.py` **129/129** (was 128), new case verified to fail-and-name only under mutation
- working tree carries only intended changes — `matched_rows.parquet` and `findings.json` are gitignored per-run artefacts and stayed out

## Scope kept to #552's

`Malaya Federation` is still excluded: it has an alias scoped `1937-1937`, so its later rows are #450's year-window mechanism, and its four spellings split across **two** polities (`GBM-1895-1946` / `MYS-1946-1957`). It must not be swept into any bulk normalisation, and it isn't.