### PR TITLE
Enforce #503's last finding: an agreement can corroborate by accident

### DIFF
--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -4300,6 +4300,39 @@ def mutate_constantrun_witness_is_cross_era(root, gpd, make_valid, affinity):
             f"with its {hit['year_first']}-{hit['year_last']} run")
 
 
+def mutate_arearevision_second_coincidental_agreement(root, gpd, make_valid, affinity):
+    """Give a SECOND polity both verdicts, so one of its agreements is coincidental.
+
+    DZA-1919-1962 is the live case and is understood: `ALGERIE` 1921->1932 spans it while `algerie`
+    1913->1929 "agrees" with it -- one scope change seen through two edition year-pairs, where the
+    1919 boundary explains neither. That pairing is the only signal in this table distinguishing a
+    boundary that EXPLAINS a revision from one that merely sits inside the interval.
+
+    The mutation moves `roumanie`'s year_before from 1913 to 1921, putting both its years inside
+    ROU-1920-1940, and sets the verdict the span now implies. Every other arm stays quiet by
+    construction: the areas and step_pct are untouched (arm A), the new verdict is exactly the one
+    the span requires (arm B), the years still ascend, and the (label, footnote, source, years) key
+    stays unique (arm D). Only the both-verdicts pairing changes.
+    """
+    import csv as _csv
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/area_revision_boundaries.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    hit = [r for r in rows if r["label"] == "roumanie"]
+    assert hit, "the `roumanie` row moved -- pick another ROU row"
+    assert hit[0]["verdict"] == "our_boundary_falls_between", "unexpected starting verdict"
+    assert hit[0]["polity_code"] == "ROU-1920-1940", "unexpected polity"
+    hit[0]["year_before"] = "1921"
+    hit[0]["verdict"] = "one_polity_spans_the_revision"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=fields, lineterminator="\n")
+        w.writeheader()
+        w.writerows(rows)
+    return ("moved `roumanie` inside ROU-1920-1940 so that polity now carries BOTH verdicts, making "
+            "its surviving agreement corroborate by accident rather than by explaining the revision")
+
+
 def mutate_arearevision_verdict_contradicts_span(root, gpd, make_valid, affinity):
     """Flip a revision's verdict so it contradicts its own polity span.
 
@@ -4584,6 +4617,13 @@ CASES = (
         "read as two estimates of one territory",
     ),
     (
+        "validate_area_revision_boundaries.py",
+        mutate_arearevision_second_coincidental_agreement,
+        "corroborating by accident",
+        "a second polity carrying both verdicts — the same revision seen through two edition "
+        "year-pairs, where the agreeing row corroborates by accident of which years its edition "
+        "tabulates rather than because the boundary explains the step",
+    ),    (
         "validate_area_revision_boundaries.py",
         mutate_arearevision_verdict_contradicts_span,
         "must follow from the span",

--- a/scripts/validate_area_revision_boundaries.py
+++ b/scripts/validate_area_revision_boundaries.py
@@ -57,6 +57,17 @@ VERDICTS = {"one_polity_spans_the_revision", "our_boundary_falls_between"}
 MIN_STEP_PCT = 50.0     # restated, not imported
 MIN_AGREEING = 6        # arm D: 11 today; a floor well below it, so a real change is a finding
 
+# Arm F. A polity carrying BOTH verdicts is reporting one scope change through two different pairs of
+# data years, and only one of those pairs happens to straddle a span boundary. DZA-1919-1962 is the
+# case: `ALGERIE` 1921->1932 spans it, `algerie` 1913->1929 "agrees" with it -- same revision, and the
+# 1919 boundary explains neither, because nothing territorial happened. The Southern Territories were
+# attached in 1902; the yearbook simply began counting them, between editions rather than at a year.
+#
+# So `our_boundary_falls_between` establishes that a boundary EXISTS in the interval, never that it
+# explains the revision -- and this pairing is the only signal in the table that can tell the
+# difference. Pinned rather than forbidden: the one live case is understood and is not a defect.
+BASELINE_SELF_REFUTING_POLITIES = 1
+
 
 def main() -> int:
     if not os.path.exists(TABLE):
@@ -159,6 +170,28 @@ def main() -> int:
                 f"years. A footnote can carry the unit's identity — `INDE BRITANNIQUE:` splits into "
                 f"the directly administered provinces and the princely states that way — so two such "
                 f"rows are one unit reported twice or two units compared against each other")
+
+    both = sorted(
+        code for code in {r["polity_code"] for r in rows}
+        if {r["verdict"] for r in rows if r["polity_code"] == code}
+        == {"one_polity_spans_the_revision", "our_boundary_falls_between"}
+    )
+    print(f"  polities carrying BOTH verdicts (agreement is coincidental): {len(both)} "
+          f"(expected {BASELINE_SELF_REFUTING_POLITIES})"
+          + (f" -- {', '.join(both)}" if both else ""))
+    print(f"  agreements that are independent of a known coincidence: {n_agree - len(both)}")
+    if len(both) > BASELINE_SELF_REFUTING_POLITIES:                                 # F
+        problems.append(
+            f"{len(both)} polity/polities carry both verdicts ({', '.join(both)}), above the expected "
+            f"{BASELINE_SELF_REFUTING_POLITIES}. The same revision seen through two edition year-pairs "
+            f"cannot both span a boundary and be explained by it, so the agreeing row is corroborating "
+            f"by accident of which years its edition tabulates"
+        )
+    elif len(both) < BASELINE_SELF_REFUTING_POLITIES:
+        problems.append(
+            f"only {len(both)} polity/polities carry both verdicts, below the expected "
+            f"{BASELINE_SELF_REFUTING_POLITIES} -- lower it so the improvement is held"
+        )
 
     if n_agree < MIN_AGREEING:                                                     # E
         problems.append(


### PR DESCRIPTION
*PR by Claude.* #503's worklist is closed by analysis and its gate is green. Its **closing comment** established one thing the screen still does not check, so this turns that written insight into an enforced one.

## `our_boundary_falls_between` proves less than it looks like

It establishes that a boundary **exists** in the interval between the source's two figures. It does **not** establish that the boundary explains the revision. Algeria is the proof, and it is its own control — the only label in the table carrying both verdicts:

```
ALGERIE   1921->1932   DZA-1919-1962   one_polity_spans_the_revision
algerie   1913->1929   DZA-1919-1962   our_boundary_falls_between
```

One scope change, seen through two edition year-pairs. Nothing territorial happened at 1919 or anywhere else in that interval — the Southern Territories were attached in **1902**, and the yearbook simply began counting them, *between editions* rather than at a year. The 1929 edition prints **both** figures: 576,000 for data-year 1913 and 2,195,097 for data-year 1929.

So the agreeing row corroborates by accident of which years its edition happens to tabulate, and the headline count of 11 agreements contains one that establishes nothing.

## Arm F

Pinned rather than forbidden — the one live case is understood and is not a defect. The gate now also reports the count **net** of it:

```
our boundary falls between the figures: 11 (corroboration, floor 6)
polities carrying BOTH verdicts:         1 (expected 1) -- DZA-1919-1962
agreements independent of a known coincidence: 10
```

Bidirectional, like the other ceilings here. A second such polity means a second revision whose agreement is an artefact of edition tabulation — and **nothing else in the table can distinguish that from real corroboration**, because both verdicts are individually correct. Arm B checks each verdict follows from its polity's span, and it stays quiet on exactly this pattern.

## Selftest case 25

Moves `roumanie`'s `year_before` from 1913 to 1921, putting both years inside `ROU-1920-1940`, and sets the verdict the span then requires. Every other arm stays quiet **by construction**:

- areas and `step_pct` untouched → arm A quiet
- the new verdict is exactly the one the span demands → arm B quiet
- years still ascend; the `(label, footnote, source, years)` key stays unique → arm D quiet

Only the both-verdicts pairing changes, which is what makes it a test of arm F rather than of the gate in general. Verified the expected string appears **only** on the failure path — a passing run prints "carrying BOTH verdicts", never "corroborating by accident".

## Verification

- 83 `validate_*` gates pass; all `--check` modes pass
- `selftest_gates.py` **130/130** (was 129)

## What this does not do

It does not move `ALGÉRIE`. Whether `DZA-1919-1962` should break at the reporting-scope change remains #503's open decision — and #583's neighbouring work reinforces the reason to leave it: the polygon already agrees with the *later* figure (`2,195,696` stated vs `2,318,386`, ratio 1.056) while `DZA-1902-1919` carries the earlier one at 4.24×, both recorded in `source_stated_area_basis.csv`. The spanning verdict is a true negative, and this PR only stops its sibling from being counted as independent evidence.