### PR TITLE
State which area convention this repo means, and hold the published figures to it (closes #569)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -705,6 +705,10 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_stated_areas.py
 
+      - name: Polygon areas keep to one convention, and it stays the published one
+        if: '!cancelled()'
+        run: python3 scripts/validate_area_convention.py
+
       - name: Tabled OCR label corrections are still needed and still route
         if: '!cancelled()'
         run: python3 scripts/validate_ocr_corrections.py

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ python3 scripts/validate_polygons.py
 python3 scripts/validate_polygon_validity.py
 python3 scripts/validate_simplification_loss.py  # shipped geometry vs the source it was cut from
 python3 scripts/validate_stated_areas.py
+python3 scripts/validate_area_convention.py  # projected vs geodesic: one convention, and it stays the published one
 python3 scripts/validate_ocr_corrections.py  # tabled OCR label fixes are still needed, and still route
 python3 scripts/validate_shared_polygons.py
 python3 scripts/validate_coexisting_overlaps.py   # partial overlap: every substantial one classified, the sliver tail pinned

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -751,6 +751,53 @@ def mutate_observed_area_backdated_before_the_reporting_era(root, gpd, make_vali
     )
 
 
+def mutate_declared_areas_switch_to_geodesic(root, gpd, make_valid, affinity):
+    """Recompute every declared area on the OTHER convention, the way a maintainer plausibly would.
+
+    Two area conventions coexist here (issue 569): planar `.area` in ESRI:54034, which ~20 scripts and
+    every published ratio use, and s2/geodesic in `repair_s2_polygons.py`. Both are spherical; they
+    disagree monotonically with latitude because one joins vertices with straight lines in the plane
+    and the other with great circles.
+
+    Nothing about a switch looks wrong. Each individual figure stays plausible -- the gap is 0.4% in
+    the median and never more than 0.8% -- so check A's 25% tolerance, the self-referential arm, and
+    every stated-area verdict all stay exactly where they were. What changes is that hundreds of
+    published `polygon_area_km2` and `ratio_polygon_over_stated` values silently move onto a different
+    definition of "the polygon's area". Only a check that measures BOTH can see it.
+
+    Rewrites the geopackage, which is where the gate reads BOTH the declared area and the geometry.
+    That mattered: the gate's first version read declared areas from the CSV and this case passed
+    against it, which is how the split was found.
+    """
+    import sys as _sys
+    _sys.path.insert(0, os.path.join(root, "scripts"))
+    from repair_s2_polygons import geodesic_area_km2
+
+    g = gpd.read_file(GPKG)
+    live = g[g.geometry.notna() & ~g.geometry.is_empty]
+    n = 0
+    for idx, r in live.iterrows():
+        try:
+            dec = float(r["polygon_area_km2"])
+        except (TypeError, ValueError):
+            continue
+        if dec <= 0:
+            continue
+        try:
+            geo = float(geodesic_area_km2(r.geometry))
+        except Exception:
+            continue
+        if geo > 0:
+            # STRING, not float: the column's dtype is str, and newer pandas raises on a numeric
+            # assignment while older pandas accepts it -- the trap a neighbouring mutator records.
+            g.loc[g.polity_code == r["polity_code"], "polygon_area_km2"] = str(round(geo, 1))
+            n += 1
+    assert n > 50, f"only {n} declared areas rewritten -- too few to move the median"
+    write_gpkg(g, root)
+    return (f"recomputed {n} declared areas on the geodesic convention instead of the projected one, "
+            f"which moves no figure by more than 0.8% and changes what they all mean")
+
+
 def mutate_subfloor_assigned_area_diverges(root, gpd, make_valid, affinity):
     """Claim `assigned` on a tiny polygon whose own declared area contradicts it.
 
@@ -5076,6 +5123,12 @@ CASES = (
         "not reach and where the enclave declares no area for check A to notice",
     ),
     (
+        "validate_area_convention.py",
+        mutate_declared_areas_switch_to_geodesic,
+        "no longer track the projected convention",
+        "every declared area recomputed on the other area convention — each figure stays plausible "
+        "and no tolerance anywhere is exceeded, while hundreds of published values change meaning",
+    ),    (
         "validate_polygons.py",
         mutate_subfloor_assigned_area_diverges,
         "the claim is untested rather than true",
@@ -6010,6 +6063,12 @@ WRITABLE = {
     #
     # NOTE FOR THE NEXT AUTHOR: this is the ONLY gate that both stages the GeoPackage and mutates
     # it, and that combination is a trap -- see write_gpkg(). Use that helper, not to_file().
+    # Needs the geopackage (mutated), the CSV it reads declared areas from, and the geodesic
+    # measurement, which lives in a sibling script rather than in the gate.
+    "validate_area_convention.py": (
+        "polities_database.gpkg",
+        "scripts/repair_s2_polygons.py",
+    ),
     "validate_polygons.py": ("polities_database.gpkg",),
     # The GeoPackage is mutated, so it must be a real copy, and write_gpkg() must be used to
     # replace it -- see that helper: `to_file` over an existing .gpkg APPENDS a layer and the

--- a/scripts/validate_area_convention.py
+++ b/scripts/validate_area_convention.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Hold the repo to ONE area convention, and keep the other one measurable (issue 569).
+
+Two ways of measuring a polygon's area coexist here and neither was ever declared canonical:
+
+  PROJECTED  planar `.area` in ESRI:54034, used by ~20 scripts including validate_stated_areas.py
+             and write_stated_area_basis.py, and therefore by every published ratio
+  GEODESIC   spherical area via s2/spherely (`repair_s2_polygons.geodesic_area_km2`), "by the same
+             route sf::st_area() takes", used by the s2 repair/validate tooling
+
+Both are spherical, so they ought to agree. They do not: a cylindrical equal-area projection
+preserves a shape's area, but `.area` joins vertices with STRAIGHT LINES IN THE PLANE while s2 joins
+them with GREAT CIRCLES. Those are different curves and the gap grows with latitude -- which is
+exactly the signature arm B pins.
+
+THIS GATE DOES NOT PREFER EITHER METHOD. It records that the published figures follow the projected
+one and refuses to let that change silently, because switching would move `polygon_area_km2` and
+`ratio_polygon_over_stated` for ~500 rows by up to 0.8% -- a decision about published numbers, not a
+repair, and not one that should arrive as a side effect of editing a script.
+"""
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+import warnings
+
+warnings.filterwarnings("ignore")
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GPKG = os.path.join(REPO, "data/final/polities_database.gpkg")
+
+# Arm A. Measured 2026-08-25 over 758 polygons: median 0.99740, spread 0.99537-1.00772. The envelope
+# is wider than the observation because adding or editing polygons moves the median a little; it is
+# far narrower than the ~0.4% gap between the two conventions, so a switch cannot hide inside it.
+MEDIAN_LO, MEDIAN_HI = 0.9950, 1.0000
+MAX_SPREAD = 0.020
+
+# Arm C. Declared areas follow the PROJECTED convention: median |declared/projected - 1| = 0.00105
+# against 0.00417 for geodesic, and 112 of 232 land within 0.1% against 20. Requiring a factor of two
+# states the choice without pinning the exact numbers, which move as declared areas are corrected.
+MIN_CONVENTION_MARGIN = 2.0
+
+LAT_BANDS = [(0, 10), (10, 20), (20, 30), (30, 40), (40, 50), (50, 60), (60, 90)]
+
+
+def main() -> int:
+    try:
+        import geopandas as gpd
+    except ImportError as exc:
+        print(f"FAIL: geopandas unavailable ({exc})")
+        return 1
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    try:
+        from repair_s2_polygons import geodesic_area_km2
+    except ImportError as exc:
+        print(f"FAIL: the geodesic side is unreachable ({exc}). Both conventions must be measurable "
+              "here, or this gate cannot tell which one the published figures follow")
+        return 1
+
+    frame = gpd.read_file(GPKG)
+    frame = frame[frame.geometry.notna() & ~frame.geometry.is_empty].copy()
+    projected = frame.to_crs("ESRI:54034").geometry.area / 1e6
+    lat = frame.geometry.centroid.y.abs()
+
+    rows = []
+    for idx, r in frame.iterrows():
+        p = float(projected.loc[idx])
+        try:
+            g = float(geodesic_area_km2(r.geometry))
+        except Exception:
+            continue
+        if p > 0 and g > 0:
+            rows.append((float(lat.loc[idx]), p / g, r["polity_code"], p, g))
+    if not rows:
+        print("FAIL: no polygon could be measured both ways")
+        return 1
+
+    problems = []
+    ratios = [x[1] for x in rows]
+    med, lo, hi = statistics.median(ratios), min(ratios), max(ratios)
+    print(f"{len(rows)} polygons measured both ways")
+    print(f"A. projected/geodesic median {med:.5f} (envelope {MEDIAN_LO}-{MEDIAN_HI}), "
+          f"spread {lo:.5f}-{hi:.5f}")
+    if not MEDIAN_LO <= med <= MEDIAN_HI:
+        problems.append(
+            f"projected/geodesic median is {med:.5f}, outside {MEDIAN_LO}-{MEDIAN_HI}. One of the two "
+            f"measurements has changed what it computes -- the gap between the conventions is about "
+            f"0.4% and this envelope is wider than any polygon edit should move it")
+    if hi - lo > MAX_SPREAD:
+        problems.append(f"the two conventions now span {hi - lo:.4f}, above {MAX_SPREAD}")
+
+    print("B. by |centroid latitude| -- the great-circle-versus-straight-line signature:")
+    medians = []
+    for b0, b1 in LAT_BANDS:
+        v = [x[1] for x in rows if b0 <= x[0] < b1]
+        if len(v) < 5:
+            continue
+        m = statistics.median(v)
+        medians.append(((b0, b1), m, len(v)))
+        print(f"     {b0:2}-{b1:2} deg  n={len(v):4}  median {m:.5f}")
+    breaks = [f"{a[0][0]}-{a[0][1]} ({a[1]:.5f}) > {b[0][0]}-{b[0][1]} ({b[1]:.5f})"
+              for a, b in zip(medians, medians[1:]) if a[1] > b[1]]
+    if breaks:
+        problems.append(
+            "the ratio no longer rises monotonically with latitude, which is the signature that "
+            "identifies this as a straight-line-versus-great-circle difference rather than a bug in "
+            "either method: " + "; ".join(breaks[:3]))
+
+    # DECLARED AREAS COME FROM THE GEOPACKAGE, not the CSV. Both numbers in this comparison must
+    # come from the same artefact, or the gate can compare a declared area from one build against a
+    # geometry from another and call the difference a convention. `validate_polygons.py` reads them
+    # from the .gpkg for the same reason. Found by the selftest: the first version read the CSV, the
+    # case rewrote the .gpkg, and the gate passed a mutation that changed every declared area.
+    declared = {}
+    for _, r in frame.iterrows():
+        try:
+            v = float(r.get("polygon_area_km2"))
+        except (TypeError, ValueError):
+            continue
+        if v > 0:
+            declared[r["polity_code"]] = v
+    dp = [abs(declared[c] / p - 1) for _, _, c, p, _ in rows if c in declared]
+    dg = [abs(declared[c] / g - 1) for _, _, c, _, g in rows if c in declared]
+    if not dp:
+        problems.append("no polity declares an area, so which convention they follow cannot be read")
+    else:
+        mp, mg = statistics.median(dp), statistics.median(dg)
+        near_p = sum(1 for x in dp if x <= 0.001)
+        near_g = sum(1 for x in dg if x <= 0.001)
+        print(f"C. {len(dp)} declared areas: median deviation {mp:.5f} from PROJECTED, {mg:.5f} from "
+              f"geodesic; within 0.1% {near_p} vs {near_g}")
+        if mp <= 0 or mg / mp < MIN_CONVENTION_MARGIN:
+            problems.append(
+                f"declared areas no longer track the projected convention by a clear margin "
+                f"({mg:.5f} geodesic vs {mp:.5f} projected, ratio {mg / max(mp, 1e-9):.2f}x, "
+                f"needs {MIN_CONVENTION_MARGIN}x). Either the published figures were recomputed on "
+                f"the other convention -- which moves polygon_area_km2 and ratio_polygon_over_stated "
+                f"for hundreds of rows -- or the convention this repo means by `the polygon's area` "
+                f"is no longer the one its scripts measure")
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)\n")
+        for p in problems:
+            print("  " + p)
+        return 1
+    print("\nPASS: both conventions measurable, their difference is the documented latitude "
+          "signature, and the published areas follow the projected one")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -145,6 +145,14 @@ source files on disk.
   this table against the enforced set.
 - `polygon_area_km2` — optional sanity-check, and it means **the area of the territory this
   polygon represents**, not the area of the geometry this repository happens to ship.
+
+  **Which measurement, when the geometry is measured at all: the PROJECTED one** — planar `.area`
+  in `ESRI:54034`. That is what ~20 scripts use, including `validate_stated_areas.py` and the
+  published `ratio_polygon_over_stated`. The s2/geodesic measurement in `repair_s2_polygons.py` is a
+  different number: both are spherical, but `.area` joins vertices with straight lines in the plane
+  while s2 joins them with great circles, so the two disagree monotonically with latitude — −0.43%
+  at the equator to +0.60% above 60° (issue 569). `validate_area_convention.py` holds the choice,
+  because switching would move ~500 published figures by up to 0.8%.
   Issue 71 asked which, because the two had come apart: `build_database.py` simplifies,
   densifies and repairs before writing, and simplification alone once deleted 42% of the
   Maldives (299.68 km² at source, 172.62 shipped, 791 atolls almost all smaller than the


### PR DESCRIPTION
*PR by Claude.* #569 is not a defect report — it measured two conventions coexisting with nothing declaring one canonical. This makes the choice explicit and enforceable.

## The measurement reproduces exactly

758 polygons, both ways:

```
|centroid lat|     n     median projected/geodesic
  0-10 deg       187          0.99567
 10-20 deg       174          0.99638
 20-30 deg       108          0.99789
 30-40 deg        99          1.00000
 40-50 deg       106          1.00209
 50-60 deg        60          1.00414
 60-90 deg        24          1.00602
overall median 0.99740   spread 0.99537-1.00772
```

Monotone across all seven bands, crossing 1.0 between 30° and 40° — the signature of joining vertices with **straight lines in the plane** versus **great circles**.

## What the gate does, and does not, decide

It does **not** prefer a method. It records that the published figures follow the **projected** one:

```
declared vs PROJECTED  median deviation 0.00105   within 0.1%: 112 of 232
declared vs GEODESIC   median deviation 0.00417   within 0.1%:  20 of 232
```

and refuses to let that change quietly. Switching moves `polygon_area_km2` and `ratio_polygon_over_stated` for hundreds of rows by up to 0.8% — a decision about published numbers, not a repair, and not one that should arrive as a side effect of editing a script.

`wiki/README.md` now states it where `polygon_area_km2` is defined, so the answer is where a reader looks for it.

**Arm B pins the latitude signature, not just the median.** The signature is what identifies this as a straight-line-versus-great-circle difference rather than a bug in either method. If the ratio stops rising with latitude, the explanation in the docstring has stopped being true and someone should find out why.

## The selftest caught a real split in my own gate

Case 76 recomputes every declared area on the geodesic convention — the plausible way this would actually happen, since each figure stays individually reasonable and no tolerance anywhere is exceeded. **The gate passed it.**

It read declared areas from the **CSV** while the case rewrote the **geopackage** — and my mutator's docstring confidently asserted the opposite of what the gate did. Both numbers in this comparison must come from one artefact, or the gate can compare a declared area from one build against a geometry from another and call the difference a convention. `validate_polygons.py` reads them from the `.gpkg` for exactly that reason; now so does this. The harness's "PASSED a mutation it claims to catch" arm is the only thing that would have found it.

## Verification

- **84** `validate_*` gates pass (was 83); all 11 `--check` invocations pass
- `selftest_gates.py` **133/133** (was 132)
- gate runs in 2.8s; `spherely` is already in `requirements-ci.txt`, so both conventions are measurable in CI

## Not done

Nothing is recomputed and no figure moves. #569 explicitly does not claim either method is wrong, and this does not either — it makes the implicit choice explicit and detectable. Whether the repo *should* publish geodesic areas remains open, and is now a change that has to be made deliberately.