### PR TITLE
Close the residual risk validate_component_underselection documented about itself

### DIFF
--- a/pipelines/polity-autoimprove/33_component_underselection.py
+++ b/pipelines/polity-autoimprove/33_component_underselection.py
@@ -85,7 +85,7 @@ UNDERSEL_SHARE = 0.60   # this fraction of attributable cells must be under-sele
 SMALLER_THAN = 0.50     # "under-selected" = the picked product is under half the same-year maximum
 TOL = 0.005             # relative tolerance for matching a layer-B value to a raw one
 
-FIELDS = ("source", "label", "item", "unit", "n_attributable", "n_underselected",
+FIELDS = ("source", "label", "item", "unit", "verdict", "n_attributable", "n_underselected",
           "share_underselected", "worst_ratio", "worst_year", "worst_picked_product",
           "worst_picked_value", "worst_max_value")
 
@@ -143,16 +143,35 @@ def build(matched: str, rawpath: str) -> list[dict]:
                 ratio = mx / picked
                 if worst is None or ratio > worst[0]:
                     worst = (ratio, int(x.year), hit._p.iloc[0], picked, mx)
+        # A CENSUS, NOT A FINDINGS LIST -- every in-scope series gets a row, including the clean
+        # ones. The gate's own note recorded that neither the defect count nor `n_attributable`
+        # could be floored, because a remedy publishing a genuine P2O5 total makes the value match
+        # no raw material and collapses BOTH alongside the fix. That left "a regeneration silently
+        # returning zero rows passes" as a stated residual risk.
+        #
+        # The series themselves survive a remedy: iia still publishes a `p` series for spain, with
+        # different values. So the row count is the one quantity that a correct fix leaves alone and
+        # a broken regeneration destroys, and it can carry a floor.
         if n_attr >= MIN_CELLS and n_under >= n_attr * UNDERSEL_SHARE and worst:
-            rows.append({
-                "source": "iia", "label": label, "item": item, "unit": "tonnes",
-                "n_attributable": n_attr, "n_underselected": n_under,
-                "share_underselected": _n(n_under / n_attr),
-                "worst_ratio": _n(worst[0]), "worst_year": worst[1],
-                "worst_picked_product": worst[2],
-                "worst_picked_value": _n(worst[3]), "worst_max_value": _n(worst[4]),
-            })
-    rows.sort(key=lambda r: (-float(r["worst_ratio"]), r["label"], r["item"]))
+            verdict = "underselects_minor_component"
+        elif n_attr >= MIN_CELLS:
+            verdict = "attributable_no_underselection"
+        else:
+            verdict = "too_few_attributable_cells"
+        rows.append({
+            "source": "iia", "label": label, "item": item, "unit": "tonnes",
+            "verdict": verdict,
+            "n_attributable": n_attr, "n_underselected": n_under,
+            "share_underselected": _n(n_under / n_attr) if n_attr else "",
+            "worst_ratio": _n(worst[0]) if worst else "",
+            "worst_year": worst[1] if worst else "",
+            "worst_picked_product": worst[2] if worst else "",
+            "worst_picked_value": _n(worst[3]) if worst else "",
+            "worst_max_value": _n(worst[4]) if worst else "",
+        })
+    rows.sort(key=lambda r: (r["verdict"] != "underselects_minor_component",
+                             -(float(r["worst_ratio"]) if r["worst_ratio"] else 0),
+                             r["label"], r["item"]))
     return rows
 
 
@@ -186,12 +205,13 @@ def main() -> int:
             return 0
 
     rows = build(a.matched, a.raw)
-    tot = sum(int(r["n_underselected"]) for r in rows)
-    att = sum(int(r["n_attributable"]) for r in rows)
-    print(f"{len(rows)} series publish a minor component as the nutrient category "
-          f"({tot} of {att} attributable non-zero cells; floor {MIN_CELLS} cells, "
-          f"{UNDERSEL_SHARE:.0%} of them under half the same-year maximum)")
-    for r in rows:
+    bad = [r for r in rows if r["verdict"] == "underselects_minor_component"]
+    tot = sum(int(r["n_underselected"]) for r in bad)
+    att = sum(int(r["n_attributable"]) for r in bad)
+    print(f"{len(rows)} iia fertilizer series in scope; {len(bad)} publish a minor component as "
+          f"the nutrient category ({tot} of {att} attributable non-zero cells; floor {MIN_CELLS} "
+          f"cells, {UNDERSEL_SHARE:.0%} of them under half the same-year maximum)")
+    for r in bad:
         print(f"  {r['label'][:18]:19}{r['item']:3}{r['n_underselected']:>4}/"
               f"{r['n_attributable']:<4} worst {float(r['worst_ratio']):>7.0f}x  "
               f"{r['worst_year']}: {r['worst_picked_product'][:34]:36}"

--- a/pipelines/polity-autoimprove/state/component_underselection.csv
+++ b/pipelines/polity-autoimprove/state/component_underselection.csv
@@ -1,9 +1,82 @@
-source,label,item,unit,n_attributable,n_underselected,share_underselected,worst_ratio,worst_year,worst_picked_product,worst_picked_value,worst_max_value
-iia,japan,p,tonnes,8,7,0.875,3138.2262,1930,"fertilizers: phosphate, natural",305,957159
-iia,latvia,p,tonnes,4,4,1,381.4472,1930,slag: basic,123,46918
-iia,spain,p,tonnes,15,15,1,185.1124,1930,"fertilizers: phosphate, natural",5400,999607
-iia,germany,n,tonnes,14,13,0.9286,60.0818,1909,fertilizers: calcium cyanamide,5500,330450
-iia,france,n,tonnes,15,11,0.7333,59.7913,1913,fertilizers: calcium cyanamide,1246,74500
-iia,czech republic,p,tonnes,4,4,1,32.4553,1931,fertilizers: bone superphosphate,3457,112198
-iia,norway,n,tonnes,13,10,0.7692,25.3733,1931,fertilizers: calcium nitrate,14999,380574
-iia,germany,p,tonnes,6,6,1,25.3521,1916,"fertilizers: phosphate, natural",71000,1800000
+source,label,item,unit,verdict,n_attributable,n_underselected,share_underselected,worst_ratio,worst_year,worst_picked_product,worst_picked_value,worst_max_value
+iia,japan,p,tonnes,underselects_minor_component,8,7,0.875,3138.2262,1930,"fertilizers: phosphate, natural",305,957159
+iia,latvia,p,tonnes,underselects_minor_component,4,4,1,381.4472,1930,slag: basic,123,46918
+iia,spain,p,tonnes,underselects_minor_component,15,15,1,185.1124,1930,"fertilizers: phosphate, natural",5400,999607
+iia,germany,n,tonnes,underselects_minor_component,14,13,0.9286,60.0818,1909,fertilizers: calcium cyanamide,5500,330450
+iia,france,n,tonnes,underselects_minor_component,15,11,0.7333,59.7913,1913,fertilizers: calcium cyanamide,1246,74500
+iia,czech republic,p,tonnes,underselects_minor_component,4,4,1,32.4553,1931,fertilizers: bone superphosphate,3457,112198
+iia,norway,n,tonnes,underselects_minor_component,13,10,0.7692,25.3733,1931,fertilizers: calcium nitrate,14999,380574
+iia,germany,p,tonnes,underselects_minor_component,6,6,1,25.3521,1916,"fertilizers: phosphate, natural",71000,1800000
+iia,canada,p,tonnes,too_few_attributable_cells,3,3,1,446.3611,1930,"fertilizers: phosphate, natural",36,16069
+iia,japan,n,tonnes,attributable_no_underselection,13,7,0.5385,186.795,1916,fertilizers: calcium cyanamide,200,37359
+iia,sweden,p,tonnes,attributable_no_underselection,16,3,0.1875,25.0023,1932,slag: basic,7730,193268
+iia,france,p,tonnes,attributable_no_underselection,16,9,0.5625,14,1916,"fertilizers: phosphate, natural",25000,350000
+iia,united states of america,n,tonnes,too_few_attributable_cells,3,3,1,8.4717,1930,fertilizers: ammonium sulfate,88962,753661
+iia,united kingdom,p,tonnes,attributable_no_underselection,16,3,0.1875,4.9268,1913,fertilizers: calcium superphosphate,82000,404000
+iia,poland,n,tonnes,too_few_attributable_cells,3,1,0.3333,4.882,1932,fertilizers: calcium cyanamide,11118,54278
+iia,belgium,p,tonnes,attributable_no_underselection,13,6,0.4615,4.1772,1919,"fertilizers: phosphate, natural",90970,380000
+iia,czech republic,n,tonnes,too_few_attributable_cells,3,2,0.6667,2.9608,1930,fertilizers: calcium cyanamide,27352,80985
+iia,poland,p,tonnes,too_few_attributable_cells,1,1,1,2.5797,1933,fertilizers: bone superphosphate,4923,12700
+iia,sweden,n,tonnes,attributable_no_underselection,10,1,0.1,2.3741,1911,fertilizers: calcium cyanamide,556,1320
+iia,united states of america,p,tonnes,attributable_no_underselection,14,1,0.0714,2.2973,1909,"fertilizers: calcium superphosphate, mixed, unmixed",1089600,2503186
+iia,algeria,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,algeria,p,tonnes,attributable_no_underselection,4,0,0,,,,,
+iia,australia,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,australia,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,austria,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,austria,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,belgium,n,tonnes,too_few_attributable_cells,1,0,0,,,,,
+iia,canada,n,tonnes,attributable_no_underselection,4,0,0,,,,,
+iia,chile,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,denmark,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,denmark,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,egypt,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,egypt,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,estonia,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,finland,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,france,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,french guiana,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,germany,k,tonnes,attributable_no_underselection,4,0,0,,,,,
+iia,greece,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,hungary,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,hungary,p,tonnes,too_few_attributable_cells,1,0,0,,,,,
+iia,india,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,india,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,india,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,indonesia,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,ireland,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,ireland,p,tonnes,too_few_attributable_cells,1,0,0,,,,,
+iia,italy,n,tonnes,attributable_no_underselection,15,0,0,,,,,
+iia,italy,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,japan,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,kiribati,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,lithuania,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,luxembourg,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,madagascar,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,morocco,p,tonnes,attributable_no_underselection,4,0,0,,,,,
+iia,nauru,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,netherlands,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,netherlands,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,new caledonia,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,new zealand,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,norway,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,palau,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,poland,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,portugal,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,portugal,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,romania,n,tonnes,too_few_attributable_cells,2,0,0,,,,,
+iia,romania,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,russian federation,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,russian federation,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,russian federation,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,serbia,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,serbia,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,south africa,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,south korea,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,spain,k,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,spain,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,switzerland,n,tonnes,too_few_attributable_cells,3,0,0,,,,,
+iia,switzerland,p,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,tunisia,p,tonnes,attributable_no_underselection,4,0,0,,,,,
+iia,united kingdom,n,tonnes,too_few_attributable_cells,0,0,,,,,,
+iia,united states of america,k,tonnes,too_few_attributable_cells,0,0,,,,,,

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -4412,6 +4412,34 @@ def mutate_hierarchy_baseline_identity_dropped(root, gpd, make_valid, affinity):
         w.writerows(keep)
 
 
+def mutate_underselection_census_becomes_a_findings_list(root, gpd, make_valid, affinity):
+    """Drop the clean series, leaving only the eight findings -- the table's own previous shape.
+
+    This gate used to record, correctly, that neither the defect count nor `n_attributable` could
+    carry a floor: a remedy publishing a genuine P2O5 total makes the published value match no raw
+    material, so attribution collapses alongside the fix and both counts go to zero. "A regeneration
+    silently returning zero rows passes" was left as a stated residual risk.
+
+    Making the table a CENSUS of in-scope series closes it, because the series survive a remedy while
+    a broken regeneration destroys them. This mutation is the failure that floor exists for, in its
+    most plausible form: every surviving row is still internally consistent, every finding is still
+    present and correct, and the eight defects still print. Only the count of series in scope moves.
+    """
+    import csv as _csv
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/component_underselection.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    keep = [r for r in rows if r["verdict"] == "underselects_minor_component"]
+    assert keep and len(keep) < len(rows), "the table is no longer a census -- this case is obsolete"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=fields, lineterminator="\n")
+        w.writeheader()
+        w.writerows(keep)
+    return (f"dropped the {len(rows) - len(keep)} clean series, leaving only the {len(keep)} "
+            f"findings -- every one still correct, and nothing but the census count changed")
+
+
 def mutate_underselection_picked_is_the_maximum(root, gpd, make_valid, affinity):
     """Record a series whose picked material IS the same-year maximum.
 
@@ -4433,10 +4461,15 @@ def mutate_underselection_picked_is_the_maximum(root, gpd, make_valid, affinity)
     with open(path, newline="", encoding="utf-8") as fh:
         rows = list(csv.DictReader(fh))
         fields = list(rows[0])
-    if not rows:
-        raise AssertionError("the table is empty, so this mutation has nothing to weaken and the "
+    # FLAGGED ROWS ONLY. The table became a CENSUS of in-scope series, so most rows are clean and
+    # carry an empty `worst_ratio`; `max()` over all of them raises on the empty string. The gate was
+    # right and this mutation had simply stopped being able to run -- caught by the harness, not by
+    # anything in the gate.
+    flagged = [r for r in rows if r.get("verdict") == "underselects_minor_component"]
+    if not flagged:
+        raise AssertionError("no flagged series, so this mutation has nothing to weaken and the "
                              "case would pass vacuously")
-    hit = max(rows, key=lambda r: float(r["worst_ratio"]))
+    hit = max(flagged, key=lambda r: float(r["worst_ratio"]))
     hit["worst_picked_value"] = hit["worst_max_value"]
     hit["worst_ratio"] = "1"
     with open(path, "w", newline="", encoding="utf-8") as fh:
@@ -4868,6 +4901,12 @@ CASES = (
         "see because every surviving row stays consistent",
     ),
     (
+        "validate_component_underselection.py",
+        mutate_underselection_census_becomes_a_findings_list,
+        "below the floor of",
+        "the census reduced to its own findings — every remaining row correct and every defect still "
+        "reported, so only a floor on the in-scope count can tell a shrunk table from a clean one",
+    ),    (
         "validate_component_underselection.py",
         mutate_underselection_picked_is_the_maximum,
         "That is the finding itself",

--- a/scripts/validate_component_underselection.py
+++ b/scripts/validate_component_underselection.py
@@ -46,7 +46,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/component_underselection.csv")
 
-FIELDS = ["source", "label", "item", "unit", "n_attributable", "n_underselected",
+FIELDS = ["source", "label", "item", "unit", "verdict", "n_attributable", "n_underselected",
           "share_underselected", "worst_ratio", "worst_year", "worst_picked_product",
           "worst_picked_value", "worst_max_value"]
 
@@ -54,6 +54,19 @@ ITEMS = {"p", "n", "k"}
 MIN_CELLS = 4            # B: restated, not imported
 UNDERSEL_SHARE = 0.60    # B: restated, not imported
 SMALLER_THAN = 0.50      # A: the under-selection condition
+VERDICTS = {"underselects_minor_component", "attributable_no_underselection",
+            "too_few_attributable_cells"}
+
+# THE TABLE IS A CENSUS OF IN-SCOPE SERIES, NOT A LIST OF FINDINGS, and that is what makes a floor
+# possible. This gate previously recorded, correctly, that neither the defect count nor
+# `n_attributable` can be floored: a remedy publishing a genuine P2O5 total makes the published value
+# match no raw material, so attribution collapses alongside the fix and both counts go to zero. That
+# left "a regeneration silently returning zero rows passes" as a stated, unresolved risk.
+#
+# The SERIES survive a remedy -- iia still publishes a `p` series for spain, with different values --
+# so the census row count is the one quantity a correct fix leaves alone and a broken regeneration
+# destroys. 81 today; the floor is well below it because the scope moves when routing changes.
+BASELINE_MIN_SERIES = 65
 
 
 def main() -> int:
@@ -69,14 +82,35 @@ def main() -> int:
         rows = list(rdr)
 
     problems = []
+    bad_rows = [r for r in rows if r.get("verdict") == "underselects_minor_component"]
     for r in rows:
         who = f"{r['source']}/{r['label']}/{r['item']}"
         try:
             na, nu = int(r["n_attributable"]), int(r["n_underselected"])
+        except (TypeError, ValueError) as e:
+            problems.append(f"{who}: unparseable count ({e})")
+            continue
+        flagged = r.get("verdict") == "underselects_minor_component"
+        if r.get("verdict") not in VERDICTS:                                        # D
+            problems.append(f"{who}: verdict {r.get('verdict')!r} not in {sorted(VERDICTS)}")
+        # E. THE VERDICT MUST FOLLOW FROM THE COUNTS. Without this the census could carry a series
+        # that meets every criterion while labelled clean, which is the one way a defect could hide
+        # inside a table whose whole point is to enumerate them.
+        want = ("underselects_minor_component" if na >= MIN_CELLS and nu >= na * UNDERSEL_SHARE
+                else "attributable_no_underselection" if na >= MIN_CELLS
+                else "too_few_attributable_cells")
+        if r.get("verdict") in VERDICTS and r["verdict"] != want:
+            problems.append(
+                f"{who}: verdict {r['verdict']!r} but {nu}/{na} attributable cells make it {want!r}")
+        if not flagged:
+            if nu > na:                                                             # C
+                problems.append(f"{who}: n_underselected {nu} exceeds n_attributable {na}")
+            continue
+        try:
             share, ratio = float(r["share_underselected"]), float(r["worst_ratio"])
             picked, mx = float(r["worst_picked_value"]), float(r["worst_max_value"])
         except (TypeError, ValueError) as e:
-            problems.append(f"{who}: unparseable numeric field ({e})")
+            problems.append(f"{who}: flagged row with unparseable numeric field ({e})")
             continue
 
         if r["source"] != "iia":                                                    # D
@@ -111,12 +145,19 @@ def main() -> int:
                 f"{who}: {nu}/{na} under-selected is below the {UNDERSEL_SHARE:.0%} share this table "
                 f"requires; an occasional small pick is a switch, which issue 379's gate owns")
 
-    tot_u = sum(int(r["n_underselected"]) for r in rows)
-    tot_a = sum(int(r["n_attributable"]) for r in rows)
-    print(f"{len(rows)} series publishing a minor component as the nutrient category "
-          f"({tot_u} of {tot_a} attributable non-zero cells); count printed, NOT pinned — a correct "
-          f"remedy empties this table and collapses its denominator too")
-    for r in rows:
+    tot_u = sum(int(r["n_underselected"]) for r in bad_rows)
+    tot_a = sum(int(r["n_attributable"]) for r in bad_rows)
+    print(f"{len(rows)} iia fertilizer series in scope (floor {BASELINE_MIN_SERIES}); "
+          f"{len(bad_rows)} publish a minor component as the nutrient category "
+          f"({tot_u} of {tot_a} attributable non-zero cells) — that count is printed, NOT pinned, "
+          f"because a correct remedy empties it and collapses its denominator too")
+    if len(rows) < BASELINE_MIN_SERIES:
+        problems.append(
+            f"only {len(rows)} series in scope, below the floor of {BASELINE_MIN_SERIES}. This is a "
+            f"CENSUS of iia p/n/k series, so it shrinks only when routing changes or the "
+            f"regeneration broke -- and it is the one count a correct remedy does NOT move, which is "
+            f"why it can carry a floor where the defect count cannot")
+    for r in bad_rows:
         print(f"  {r['label'][:18]:19}{r['item']:3}{r['n_underselected']:>4}/{r['n_attributable']:<4}"
               f" worst {float(r['worst_ratio']):>7.0f}x  {r['worst_year']}: "
               f"{r['worst_picked_product'][:32]:34}{float(r['worst_picked_value']):>10,.0f}"


### PR DESCRIPTION
*PR by Claude.* #498 gated #490's finding and recorded, in the gate itself, a risk it could not close:

> the table carries no floor and the residual risk — a regeneration silently returning zero rows passes — is stated in the gate rather than hidden

## Why the two obvious fixes don't work

That reasoning was right, and it rules out both:

- **Pinning the defect count** makes a correct remedy fail CI.
- **Flooring `n_attributable`** fails too, less obviously: attribution works by matching a published value to exactly one raw material, so a remedy publishing a genuine P2O5 total makes the value match *nothing* and collapses the denominator alongside the numerator.

Both quantities go to zero on the fix. That is what left the gate with nothing to floor.

## What survives a remedy is the series

iia still publishes a `p` series for spain afterwards — with different values. So the table is now a **census of in-scope iia p/n/k series** rather than a list of findings:

```
81 iia fertilizer series in scope (floor 65); 8 publish a minor component as the
nutrient category (70 of 79 attributable non-zero cells) — that count is printed,
NOT pinned, because a correct remedy empties it and collapses its denominator too
```

The census count is the one quantity a correct fix leaves alone and a broken regeneration destroys, so it can carry the floor where neither of the others could.

## Two arms, both verified before wiring

- **the floor** on in-scope series;
- **verdict-follows-from-the-counts** — without it the census could carry a series meeting every criterion while labelled clean, which is the one way a defect could hide inside a table whose whole purpose is to enumerate them.

I checked both fire by construction before writing the selftest case: truncating the census to its own 8 findings → `exit=1`; relabelling one defective series as clean → `exit=1`; restored → `exit=0`.

The strict arms now apply only to flagged rows; clean rows are still checked for vocabulary, counts and verdict consistency. **No verdict or remedy is recorded** — #490's modelling question (the materials are not additive and differ in P2O5 content) is untouched by this.

## The schema change broke the existing mutator

`mutate_underselection_picked_is_the_maximum` takes `max(rows, key=worst_ratio)`, and census rows leave `worst_ratio` empty — so it raised `ValueError` instead of mutating. The gate was fine; **the mutation had stopped being able to run**, and only the harness could tell those apart. Now scoped to flagged rows, with the reason recorded in its docstring.

That is the third time this session a mutation went stale under a change to what its gate reads — after the lexicon's last-row-wins dependency (#587) and the site-copy staging (#589). Each was invisible to the gate and visible only to the harness.

## Verification

- 85 `validate_*` gates pass; all 11 `--check` invocations pass, plus `33_component_underselection.py --check`
- `selftest_gates.py` **136/136** (was 135)