### PR TITLE
The cross-source key must exclude `indicator`, and that needed proving not assuming

### DIFF
--- a/pipelines/polity-autoimprove/39_cross_source_agreement.py
+++ b/pipelines/polity-autoimprove/39_cross_source_agreement.py
@@ -17,6 +17,21 @@ it is a defect this repo has already recorded: wheat is spelt and meslin, tobacc
 different territorial levels. A cell in the tail with NO entry behind it would be new, and there is
 currently no such cell -- which is what makes zero a usable ceiling rather than an aspiration.
 
+THE KEY DELIBERATELY EXCLUDES `indicator`, and that is not an oversight. The column carries a
+different KIND of value per source: fao1952 and iia use a measurement type (`crops:production`,
+`livestock:production`), while mitchell uses a page reference (`page_12_table_1`). Adding it to the
+key separates iia from mitchell on a field that does not mean the same thing in each, which destroys
+exactly the comparisons this table exists for -- 53 of the 804 cells pair a null indicator against a
+mitchell page string. `unit` already separates production from area, which is what the column would
+otherwise be protecting against.
+
+Two things make that easy to get wrong. 126,631 of 189,578 rows have a NULL indicator, so
+`groupby(..., dropna=True)` -- the default -- silently drops two thirds of the panel and returns ZERO
+multi-source cells, which reads as "the key needs no fixing" for the wrong reason. And `nunique()`
+excludes nulls too, so a check for "does this cell mix indicators" answers 0 when half its rows have
+none. Arm E in the gate tests the thing that WOULD invalidate a comparison -- both sides annotated and
+disagreeing -- rather than the presence of the column.
+
 NO --check MODE, DELIBERATELY. This reads layer B, which is not redistributable and is absent in CI,
 so a check comparing the committed table against a regeneration could only ever run on a developer
 machine -- and would report OK in CI by comparing nothing. That is the failure issue 573 describes.
@@ -42,7 +57,7 @@ OUT = os.path.join(HERE, "state/cross_source_agreement.csv")
 # this" when it means "never tested". Same shape as the one-sided thresholds recorded in the
 # retest registry: the excluded tail was the interesting one.
 BIG_RATIO = 10.0
-COLUMNS = ("polity_code", "item", "unit", "year", "sources", "labels",
+COLUMNS = ("polity_code", "item", "unit", "year", "sources", "labels", "indicators",
            "value_min", "value_max", "ratio", "known_defect")
 
 
@@ -84,11 +99,16 @@ def main() -> int:
     frame["yr"] = frame["year"].astype(str)
     key = ["whep_code", "item", "unit", "yr"]
     multi = frame[frame.groupby(key)["source"].transform("nunique") > 1]
-    agg = multi.groupby(key).agg(
+    # dropna=False on every groupby whose key can hold a null. `indicator` is not in this key, but
+    # `unit` and `item` can be blank, and the default would drop those rows without saying so.
+    agg = multi.groupby(key, dropna=False).agg(
         value_min=("value", "min"),
         value_max=("value", "max"),
         sources=("source", lambda s: ";".join(sorted(set(s)))),
         labels=("country", lambda s: ";".join(sorted({str(x).lower() for x in s}))),
+        # Nulls counted as their own value -- see the docstring on why nunique() would not do.
+        indicators=("indicator", lambda s: ";".join(sorted({
+            "" if pd.isna(x) else str(x) for x in s}))),
     ).reset_index()
     agg = agg[agg.value_min > 0].copy()
     agg["ratio"] = agg.value_max / agg.value_min
@@ -99,7 +119,7 @@ def main() -> int:
     rows = []
     for r in agg.itertuples():
         row = {"polity_code": r.whep_code, "item": r.item, "unit": r.unit, "year": r.yr,
-               "sources": r.sources, "labels": r.labels,
+               "sources": r.sources, "labels": r.labels, "indicators": r.indicators,
                "value_min": f"{r.value_min:.4g}", "value_max": f"{r.value_max:.4g}",
                "ratio": f"{r.ratio:.4f}", "known_defect": ""}
         # Coverage is computed for EVERY cell, not only the large ones, so an empty column always

--- a/pipelines/polity-autoimprove/state/cross_source_agreement.csv
+++ b/pipelines/polity-autoimprove/state/cross_source_agreement.csv
@@ -1,805 +1,805 @@
-polity_code,item,unit,year,sources,labels,value_min,value_max,ratio,known_defect
-F51-1918-1938,wheat,tonnes,1930,iia;juan,czech republic;czechoslovakia,311.9,1.377e+06,4415.7743,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1930,iia;juan,czech republic;czechoslovakia,239,7.95e+05,3326.3598,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1933,iia;juan,czech republic;czechoslovakia,700.2,1.984e+06,2833.3333,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1930,iia;juan,czech republic;czechoslovakia,8,1.75e+04,2187.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1933,iia;juan,czech republic;czechoslovakia,440,9.19e+05,2088.6364,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1931,iia;juan,czech republic;czechoslovakia,553.6,1.122e+06,2027.0051,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1932,iia;juan,czech republic;czechoslovakia,1012,1.462e+06,1444.7101,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1931,iia;juan,czech republic;czechoslovakia,607,8.284e+05,1364.7446,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1932,iia;juan,czech republic;czechoslovakia,829,8.354e+05,1007.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1932,iia;juan,czech republic;czechoslovakia,20,1.91e+04,955.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1925,iia;juan,serbia;yugoslav sfr,2000,1.773e+06,886.7000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1931,iia;juan,czech republic;czechoslovakia,23,1.88e+04,817.3913,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1925,iia;juan,czech republic;czechoslovakia,1615,6.174e+05,382.2910,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1931,iia;juan,serbia;yugoslav sfr,9580,2.689e+06,280.6493,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1939,iia;juan,serbia;yugoslav sfr,1.17e+04,2.876e+06,245.7778,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1938,iia;juan,czech republic;czechoslovakia,9800,1.814e+06,185.1020,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1933,iia;juan,serbia;yugoslav sfr,1.442e+04,2.629e+06,182.3492,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1938,iia;juan,czech republic;czechoslovakia,5000,8.98e+05,179.6000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1930,iia;juan,serbia;yugoslav sfr,1.248e+04,2.186e+06,175.1919,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1935,iia;juan,czech republic;czechoslovakia,9900,1.69e+06,170.7071,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1936,iia;juan,czech republic;czechoslovakia,9100,1.513e+06,166.2308,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1935,iia;juan,czech republic;czechoslovakia,6000,9.63e+05,160.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1937,iia;juan,czech republic;czechoslovakia,8700,1.395e+06,160.3793,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1936,iia;juan,czech republic;czechoslovakia,6000,9.27e+05,154.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1939,iia;juan,serbia;yugoslav sfr,1.5e+04,2.203e+06,146.8667,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1925,iia;juan,serbia;yugoslav sfr,1.482e+04,2.14e+06,144.4226,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1943,iia;juan,czech republic;czechoslovakia,1.09e+04,1.561e+06,143.2110,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1937,iia;juan,czech republic;czechoslovakia,6000,8.49e+05,141.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1934,iia;juan,czech republic;czechoslovakia,9800,1.361e+06,138.8980,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1934,iia;juan,czech republic;czechoslovakia,7000,9.31e+05,133.0000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1931,iia;juan,serbia;yugoslav sfr,1.652e+04,2.14e+06,129.5467,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1932,iia;juan,serbia;yugoslav sfr,1.138e+04,1.455e+06,127.8359,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1922,iia;juan,serbia;yugoslav sfr,9489,1.21e+06,127.5508,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1933,iia;juan,serbia;yugoslav sfr,1.672e+04,2.079e+06,124.3719,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1932,iia;juan,serbia;yugoslav sfr,1.639e+04,1.95e+06,119.0345,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1930,iia;juan,serbia;yugoslav sfr,1.843e+04,2.123e+06,115.1730,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1934,iia;mitchell,korea;south korea,1.5e+04,1.54e+06,102.6933,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1943,iia;juan,czech republic;czechoslovakia,9000,9.1e+05,101.1111,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1941,iia;mitchell,korea;south korea,3.5e+04,3.512e+06,100.3429,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1939,iia;mitchell,korea;south korea,3.1e+04,3.102e+06,100.0613,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1935,iia;juan,serbia;yugoslav sfr,1891,1.891e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1936,iia;juan,serbia;yugoslav sfr,1962,1.962e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1937,iia;juan,serbia;yugoslav sfr,2132,2.132e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1938,iia;juan,serbia;yugoslav sfr,1600,1.6e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1939,iia;juan,serbia;yugoslav sfr,1815,1.815e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1934,iia;juan,serbia;yugoslav sfr,6049,6.049e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1935,iia;juan,serbia;yugoslav sfr,9249,9.249e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1936,iia;juan,serbia;yugoslav sfr,1.662e+04,1.662e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1937,iia;juan,serbia;yugoslav sfr,2.078e+04,2.078e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1938,iia;juan,serbia;yugoslav sfr,1.471e+04,1.471e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1939,iia;juan,serbia;yugoslav sfr,1.543e+04,1.543e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,serbia;yugoslav sfr,1.27e+04,1.27e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1934,iia;juan,czech republic;czechoslovakia,7074,7.074e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1935,iia;juan,czech republic;czechoslovakia,7619,7.619e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1936,iia;juan,czech republic;czechoslovakia,1.208e+04,1.208e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1937,iia;juan,czech republic;czechoslovakia,1.216e+04,1.216e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1934,iia;juan,czech republic;czechoslovakia,1.368e+04,1.368e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1935,iia;juan,czech republic;czechoslovakia,1.363e+04,1.363e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1936,iia;juan,czech republic;czechoslovakia,1.507e+04,1.507e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1937,iia;juan,czech republic;czechoslovakia,1.404e+04,1.404e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1940,iia;juan,czech republic;czechoslovakia,4576,4.576e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1941,iia;juan,czech republic;czechoslovakia,3527,3.527e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1942,iia;juan,czech republic;czechoslovakia,3107,3.107e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1943,iia;juan,czech republic;czechoslovakia,3152,3.152e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1939,iia;juan,czech republic;czechoslovakia,9330,9.33e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1941,iia;juan,czech republic;czechoslovakia,6914,6.914e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1942,iia;juan,czech republic;czechoslovakia,7468,7.468e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1943,iia;juan,czech republic;czechoslovakia,5429,5.429e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1944,iia;juan,czech republic;czechoslovakia,3928,3.928e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hops,tonnes,1945,iia;juan,czech republic;czechoslovakia,3721,3.721e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,czech republic;czechoslovakia,2500,2.5e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1939,iia;juan,czech republic;czechoslovakia,7635,7.634e+05,99.9869,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1940,iia;juan,czech republic;czechoslovakia,7803,7.8e+05,99.9616,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1938,iia;mitchell,korea;south korea,2.8e+04,2.798e+06,99.9429,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1935,iia;mitchell,korea;south korea,2.2e+04,2.192e+06,99.6409,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1934,iia;juan,serbia;yugoslav sfr,1455,1.433e+05,98.4880,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1936,iia;mitchell,korea;south korea,2.1e+04,2.063e+06,98.2190,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1937,iia;mitchell,korea;south korea,2.7e+04,2.649e+06,98.1037,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1924,iia;juan,serbia;yugoslav sfr,1.604e+04,1.572e+06,97.9986,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1944,iia;juan,czech republic;czechoslovakia,1.26e+04,1.21e+06,96.0317,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1923,iia;juan,serbia;yugoslav sfr,1.828e+04,1.662e+06,90.9181,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,wheat,tonnes,1945,iia;juan,czech republic;czechoslovakia,1.29e+04,1.122e+06,86.9380,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,wheat,ha,1945,iia;juan,czech republic;czechoslovakia,1e+04,8.43e+05,84.3000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1944,iia;juan,czech republic;czechoslovakia,1.1e+04,9.12e+05,82.9091,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1924,iia;juan,serbia;yugoslav sfr,2.209e+04,1.717e+06,77.7270,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1942,iia;juan,czech republic;czechoslovakia,1.96e+04,1.451e+06,74.0102,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1939,iia;juan,czech republic;czechoslovakia,2.18e+04,1.572e+06,72.1147,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1922,iia;juan,serbia;yugoslav sfr,2.108e+04,1.48e+06,70.2296,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1923,iia;juan,serbia;yugoslav sfr,2.295e+04,1.555e+06,67.7648,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1939,iia;juan,czech republic;czechoslovakia,1.4e+04,8.5e+05,60.7143,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1942,iia;juan,czech republic;czechoslovakia,1.6e+04,8.71e+05,54.4375,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1936,iia;juan,serbia;yugoslav sfr,5.48e+04,2.924e+06,53.3504,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1940,iia;juan,czech republic;czechoslovakia,2.17e+04,1.111e+06,51.1797,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1938,iia;juan,serbia;yugoslav sfr,6.05e+04,3.03e+06,50.0810,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1924,iia;juan,czech republic;czechoslovakia,1.777e+04,8.774e+05,49.3851,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1925,iia;juan,czech republic;czechoslovakia,2.246e+04,1.07e+06,47.6231,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1940,iia;juan,czech republic;czechoslovakia,1.7e+04,7.46e+05,43.8824,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1943,iia;juan,czech republic;czechoslovakia,3.6e+04,1.536e+06,42.6667,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1935,iia;juan,serbia;yugoslav sfr,4.67e+04,1.99e+06,42.6017,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1942,iia;juan,czech republic;czechoslovakia,2.95e+04,1.231e+06,41.7288,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1923,iia;juan,czech republic;czechoslovakia,2.376e+04,9.859e+05,41.4924,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1937,iia;juan,serbia;yugoslav sfr,5.77e+04,2.347e+06,40.6759,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1941,iia;juan,czech republic;czechoslovakia,2.96e+04,1.16e+06,39.1993,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1924,iia;juan,czech republic;czechoslovakia,1.578e+04,6.057e+05,38.3938,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1922,iia;juan,czech republic;czechoslovakia,2.398e+04,9.15e+05,38.1618,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1934,iia;juan,serbia;yugoslav sfr,4.93e+04,1.86e+06,37.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1944,iia;juan,czech republic;czechoslovakia,3.25e+04,1.214e+06,37.3538,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1923,iia;juan,czech republic;czechoslovakia,1.687e+04,6.097e+05,36.1497,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1936,iia;juan,serbia;yugoslav sfr,6.2e+04,2.211e+06,35.6613,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1943,iia;juan,czech republic;czechoslovakia,2.6e+04,9.26e+05,35.6154,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1935,iia;juan,serbia;yugoslav sfr,6.1e+04,2.15e+06,35.2459,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rye,tonnes,1945,iia;juan,czech republic;czechoslovakia,2.8e+04,9.81e+05,35.0357,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1934,iia;juan,serbia;yugoslav sfr,5.8e+04,2.024e+06,34.8966,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1922,iia;juan,czech republic;czechoslovakia,1.8e+04,6.179e+05,34.3278,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1937,iia;juan,serbia;yugoslav sfr,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1938,iia;juan,serbia;yugoslav sfr,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1941,iia;juan,czech republic;czechoslovakia,2.8e+04,8e+05,28.5714,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1938,iia;juan,czech republic;czechoslovakia,5000,7.2e+04,14.4000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sunflower seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,1900,2.73e+04,14.3684,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1937,iia;juan,czech republic;czechoslovakia,6000,8.3e+04,13.8333,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1944,iia;juan,czech republic;czechoslovakia,3461,4.61e+04,13.3198,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1934,iia;juan,serbia;yugoslav sfr,800,1.06e+04,13.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1934,iia;juan,czech republic;czechoslovakia,4500,5.59e+04,12.4222,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1935,iia;juan,czech republic;czechoslovakia,8600,1.022e+05,11.8837,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1935,iia;juan,czech republic;czechoslovakia,6000,7e+04,11.6667,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1935,iia;juan,serbia;yugoslav sfr,900,1.01e+04,11.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1936,iia;juan,czech republic;czechoslovakia,8400,9.39e+04,11.1786,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1932,iia;juan,czech republic;czechoslovakia,6671,7.418e+04,11.1193,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1942,iia;juan,czech republic;czechoslovakia,4000,4.3e+04,10.7500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1936,iia;juan,czech republic;czechoslovakia,7000,7.5e+04,10.7143,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1945,iia;juan,serbia;yugoslav sfr,9.2e+04,9.799e+05,10.6511,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1941,iia;juan,czech republic;czechoslovakia,3000,3.18e+04,10.6000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1940,iia;juan,czech republic;czechoslovakia,2900,3.06e+04,10.5517,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1944,iia;juan,czech republic;czechoslovakia,3000,3.16e+04,10.5333,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1939,iia;juan,czech republic;czechoslovakia,3900,4.1e+04,10.5128,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1943,iia;juan,czech republic;czechoslovakia,3500,3.67e+04,10.4857,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1942,iia;juan,czech republic;czechoslovakia,3600,3.76e+04,10.4444,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,grapes,tonnes,1945,iia;juan,czech republic;czechoslovakia,3800,3.95e+04,10.3947,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1940,iia;juan,czech republic;czechoslovakia,4000,4.1e+04,10.2500,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1941,iia;juan,czech republic;czechoslovakia,7.8e+04,7.84e+05,10.0513,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1939,iia;juan,czech republic;czechoslovakia,9.8e+04,9.84e+05,10.0408,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1934,iia;juan,serbia;yugoslav sfr,2400,2.4e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1935,iia;juan,serbia;yugoslav sfr,2600,2.6e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1936,iia;juan,serbia;yugoslav sfr,2700,2.7e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1937,iia;juan,serbia;yugoslav sfr,2900,2.9e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1938,iia;juan,serbia;yugoslav sfr,2800,2.8e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1931,iia;juan,serbia;yugoslav sfr,2.442e+04,2.442e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1932,iia;juan,serbia;yugoslav sfr,2.43e+04,2.43e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1934,iia;juan,czech republic;czechoslovakia,1.09e+04,1.09e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1935,iia;juan,czech republic;czechoslovakia,1.12e+04,1.12e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1936,iia;juan,czech republic;czechoslovakia,1.14e+04,1.14e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1941,iia;juan,czech republic;czechoslovakia,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1942,iia;juan,czech republic;czechoslovakia,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1938,iia;juan,czech republic;czechoslovakia,1.16e+04,1.16e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1937,iia;juan,czech republic;czechoslovakia,1.15e+04,1.13e+05,9.8261,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1939,iia;juan,czech republic;czechoslovakia,4000,3.9e+04,9.7500,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1938,iia;juan,serbia;yugoslav sfr,1400,1.29e+04,9.2143,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1940,iia;juan,czech republic;czechoslovakia,7.8e+04,7.08e+05,9.0769,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1937,iia;juan,czech republic;czechoslovakia,1.11e+04,1.006e+05,9.0631,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1933,iia;juan,czech republic;czechoslovakia,6800,6.05e+04,8.8971,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1937,iia;juan,serbia;yugoslav sfr,1300,1.11e+04,8.5385,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1939,iia;juan,czech republic;czechoslovakia,2000,1.7e+04,8.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1934,iia;juan,czech republic;czechoslovakia,7000,5.8e+04,8.2857,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1936,iia;juan,serbia;yugoslav sfr,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1939,iia;juan,serbia;yugoslav sfr,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1943,iia;juan,czech republic;czechoslovakia,5000,3.5e+04,7.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1944,iia;juan,czech republic;czechoslovakia,5000,3e+04,6.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1935,iia;juan,serbia;yugoslav sfr,2.25e+04,1.147e+05,5.0978,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1940,iia;juan,czech republic;czechoslovakia,4700,2.29e+04,4.8723,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"beans, dry",ha,1945,iia;juan,czech republic;czechoslovakia,6000,2.8e+04,4.6667,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1937,iia;juan,czech republic;czechoslovakia,6900,3.04e+04,4.4058,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1936,iia;juan,serbia;yugoslav sfr,3.06e+04,1.335e+05,4.3627,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1937,iia;juan,serbia;yugoslav sfr,3.56e+04,1.55e+05,4.3539,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1941,iia;juan,czech republic;czechoslovakia,4500,1.95e+04,4.3333,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1939,iia;juan,czech republic;czechoslovakia,5700,2.43e+04,4.2632,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1938,iia;juan,serbia;yugoslav sfr,2.69e+04,1.141e+05,4.2416,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1942,iia;juan,czech republic;czechoslovakia,6100,2.46e+04,4.0328,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1939,iia;juan,serbia;yugoslav sfr,2.48e+04,9.82e+04,3.9597,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1934,iia;juan,serbia;yugoslav sfr,4.04e+04,1.582e+05,3.9158,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1936,iia;juan,czech republic;czechoslovakia,7600,2.91e+04,3.8289,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1933,iia;juan,serbia;yugoslav sfr,3.06e+04,1.166e+05,3.8105,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1938,iia;juan,czech republic;czechoslovakia,5900,2.19e+04,3.7119,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1935,iia;juan,czech republic;czechoslovakia,4900,1.67e+04,3.4082,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1934,iia;juan,czech republic;czechoslovakia,7100,2.31e+04,3.2535,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1943,iia;juan,czech republic;czechoslovakia,5000,1.54e+04,3.0800,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1920,iia;mitchell,korea;south korea,5508,1.6e+04,2.9047,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1944,iia;juan,czech republic;czechoslovakia,5100,1.46e+04,2.8627,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1932,iia;mitchell,israel;palestine,3019,8118,2.6887,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"beans, dry",tonnes,1945,iia;juan,czech republic;czechoslovakia,6500,1.32e+04,2.0308,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1920,iia;juan,serbia;yugoslav sfr,1929,3900,2.0217,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1939,iia;juan,serbia;yugoslav sfr,1000,2000,2.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1933,iia;juan,serbia;yugoslav sfr,50.9,100,1.9646,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1933,iia;mitchell,israel;palestine,1584,2890,1.8245,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1930,iia;mitchell,israel;palestine,1980,3569,1.8024,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1933,iia;juan,serbia;yugoslav sfr,200,350,1.7500,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1932,iia;juan,serbia;yugoslav sfr,110,180,1.6364,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1933,iia;juan,serbia;yugoslav sfr,68.4,100,1.4620,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1930,iia;juan,serbia;yugoslav sfr,121.6,170,1.3980,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1931,iia;mitchell,israel;palestine,2772,3854,1.3904,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1925,iia;mitchell,korea;south korea,1.017e+04,1.4e+04,1.3765,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,3406,4567,1.3406,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1941,iia;juan,czech republic;czechoslovakia,1.61e+04,2.15e+04,1.3354,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1931,iia;juan,serbia;yugoslav sfr,300,395,1.3167,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1934,iia;juan,czech republic;czechoslovakia,4300,5600,1.3023,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1936,iia;juan,czech republic;czechoslovakia,7300,9500,1.3014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1942,iia;juan,czech republic;czechoslovakia,1.72e+04,2.21e+04,1.2849,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1925,iia;juan,czech republic;czechoslovakia,1.176e+06,1.476e+06,1.2552,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1923,iia;juan,serbia;yugoslav sfr,2300,2885,1.2543,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1940,iia;juan,czech republic;czechoslovakia,1.88e+04,2.35e+04,1.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,flax fibre and tow,tonnes,1945,iia;juan,czech republic;czechoslovakia,5800,7100,1.2241,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1937,iia;juan,czech republic;czechoslovakia,9000,1.1e+04,1.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1944,iia;juan,czech republic;czechoslovakia,1.32e+04,1.61e+04,1.2197,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1939,iia;juan,czech republic;czechoslovakia,8300,1e+04,1.2048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1935,iia;juan,czech republic;czechoslovakia,5700,6800,1.1930,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1919,iia;juan,czech republic;czechoslovakia,400,477,1.1925,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1933,iia;juan,czech republic;czechoslovakia,1.73e+04,2e+04,1.1562,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1922,iia;juan,serbia;yugoslav sfr,6020,6925,1.1503,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1932,iia;juan,serbia;yugoslav sfr,400,459,1.1475,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1930,iia;juan,serbia;yugoslav sfr,400,454,1.1350,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1933,iia;juan,serbia;yugoslav sfr,3000,3383,1.1277,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,5185,5832,1.1248,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1922,iia;juan,serbia;yugoslav sfr,50,56.1,1.1220,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1921,iia;juan,czech republic;czechoslovakia,2260,2509,1.1100,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1923,iia;juan,serbia;yugoslav sfr,40,44.1,1.1025,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1923,iia;juan,czech republic;czechoslovakia,1.107e+04,1.19e+04,1.0746,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1932,iia;juan,serbia;yugoslav sfr,110,117.6,1.0691,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1941,iia;juan,czech republic;czechoslovakia,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1942,iia;juan,czech republic;czechoslovakia,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1922,iia;mitchell,israel;palestine,2696,2871,1.0648,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1935,iia;mitchell,israel;palestine,2425,2574,1.0614,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1921,iia;juan,czech republic;czechoslovakia,1.134e+04,1.202e+04,1.0608,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1931,iia;juan,serbia;yugoslav sfr,70,74.1,1.0586,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1925,iia;juan,czech republic;czechoslovakia,1.101e+04,1.16e+04,1.0539,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1922,iia;juan,serbia;yugoslav sfr,9391,9890,1.0531,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1933,iia;juan,czech republic;czechoslovakia,7627,8000,1.0489,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1925,iia;juan,serbia;yugoslav sfr,120,125.8,1.0483,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1924,iia;mitchell,israel;palestine,1420,1485,1.0456,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1920,iia;juan,czech republic;czechoslovakia,1200,1254,1.0450,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1932,iia;juan,serbia;yugoslav sfr,1400,1462,1.0443,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1921,iia;juan,czech republic;czechoslovakia,1300,1357,1.0438,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1922,iia;mitchell,korea;south korea,1.054e+04,1.1e+04,1.0433,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1924,iia;juan,serbia;yugoslav sfr,80,83.4,1.0425,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1922,iia;juan,czech republic;czechoslovakia,1600,1668,1.0425,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1909,iia;mitchell,korea;south korea,1.151e+04,1.2e+04,1.0424,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1911,iia;mitchell,korea;south korea,1.056e+04,1.1e+04,1.0416,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1925,iia;juan,serbia;yugoslav sfr,1.43e+04,1.489e+04,1.0414,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,210,218.4,1.0400,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1930,iia;juan,czech republic;czechoslovakia,1100,1144,1.0400,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1924,iia;juan,serbia;yugoslav sfr,2200,2287,1.0395,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1930,iia;juan,serbia;yugoslav sfr,130,134.9,1.0377,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1923,iia;juan,czech republic;czechoslovakia,2.12e+04,2.2e+04,1.0377,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1931,iia;juan,serbia;yugoslav sfr,2200,2275,1.0341,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,1000,1034,1.0335,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1930,iia;juan,serbia;yugoslav sfr,2800,2889,1.0318,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1933,iia;juan,czech republic;czechoslovakia,970,1000,1.0309,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1922,iia;juan,serbia;yugoslav sfr,3000,3089,1.0297,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1918,iia;mitchell,korea;south korea,1.457e+04,1.5e+04,1.0297,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,7411,7627,1.0292,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1923,iia;juan,serbia;yugoslav sfr,1.734e+04,1.784e+04,1.0287,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1912,iia;mitchell,korea;south korea,1.264e+04,1.3e+04,1.0285,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1924,iia;mitchell,korea;south korea,1.459e+04,1.5e+04,1.0278,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1924,iia;juan,serbia;yugoslav sfr,3.523e+04,3.62e+04,1.0275,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1931,iia;mitchell,korea;south korea,1.6e+04,1.644e+04,1.0275,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1933,iia;mitchell,korea;south korea,1.655e+04,1.7e+04,1.0270,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1932,iia;juan,czech republic;czechoslovakia,1500,1539,1.0260,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1919,iia;mitchell,korea;south korea,1.4e+04,1.434e+04,1.0241,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1931,iia;juan,serbia;yugoslav sfr,60,61.4,1.0233,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1933,iia;juan,czech republic;czechoslovakia,1.027e+04,1.05e+04,1.0227,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1923,iia;juan,czech republic;czechoslovakia,2600,2654,1.0208,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1934,iia;mitchell,israel;palestine,2328,2376,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1936,iia;mitchell,israel;palestine,2231,2277,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1937,iia;mitchell,israel;palestine,2425,2475,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1938,iia;mitchell,israel;palestine,2910,2970,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1939,iia;mitchell,israel;palestine,3298,3366,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1940,iia;mitchell,israel;palestine,3589,3663,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1941,iia;mitchell,israel;palestine,3589,3663,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1942,iia;mitchell,israel;palestine,3977,4059,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1943,iia;mitchell,israel;palestine,4171,4257,1.0206,layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1944,iia;mitchell,israel;palestine,5335,5445,1.0206,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1924,iia;juan,czech republic;czechoslovakia,3400,3464,1.0188,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1943,iia;juan,czech republic;czechoslovakia,1.22e+04,1.24e+04,1.0164,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1925,iia;juan,serbia;yugoslav sfr,2000,2032,1.0160,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1913,iia;mitchell,korea;south korea,1.4e+04,1.422e+04,1.0160,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1915,iia;mitchell,korea;south korea,1.378e+04,1.4e+04,1.0158,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1931,iia;juan,czech republic;czechoslovakia,2000,2031,1.0155,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1933,iia;juan,czech republic;czechoslovakia,7000,7098,1.0140,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1933,iia;juan,czech republic;czechoslovakia,7000,7098,1.0140,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-PAL-1920-1948,wine,tonnes,1923,iia;mitchell,israel;palestine,2441,2475,1.0139,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1930,iia;juan,czech republic;czechoslovakia,7400,7499,1.0134,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1925,iia;juan,serbia;yugoslav sfr,2700,2736,1.0133,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1933,iia;juan,serbia;yugoslav sfr,1.1e+04,1.114e+04,1.0131,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1922,iia;juan,serbia;yugoslav sfr,1800,1823,1.0128,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1914,iia;mitchell,korea;south korea,9874,1e+04,1.0128,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1924,iia;juan,serbia;yugoslav sfr,2200,2228,1.0127,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1921,iia;juan,czech republic;czechoslovakia,4800,4860,1.0125,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1933,iia;juan,serbia;yugoslav sfr,1.1e+04,1.113e+04,1.0117,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1924,iia;juan,czech republic;czechoslovakia,8100,8192,1.0114,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1924,iia;juan,czech republic;czechoslovakia,4100,4146,1.0112,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1931,iia;juan,czech republic;czechoslovakia,8200,8290,1.0110,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1923,iia;mitchell,korea;south korea,1.187e+04,1.2e+04,1.0109,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1923,iia;juan,serbia;yugoslav sfr,1600,1616,1.0100,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1919,iia;juan,czech republic;czechoslovakia,8500,8585,1.0100,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1932,iia;juan,czech republic;czechoslovakia,9900,9997,1.0098,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1931,iia;juan,czech republic;czechoslovakia,8900,8984,1.0094,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,3469,3500,1.0089,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1910,iia;mitchell,korea;south korea,8921,9000,1.0089,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,2677,2700,1.0087,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rye,ha,1945,iia;juan,czech republic;czechoslovakia,8.02e+05,8.09e+05,1.0087,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,2777,2800,1.0084,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1931,iia;juan,czech republic;czechoslovakia,8900,8970,1.0079,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1923,iia;juan,czech republic;czechoslovakia,7700,7761,1.0079,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1922,iia;juan,czech republic;czechoslovakia,3900,3931,1.0079,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1921,iia;juan,czech republic;czechoslovakia,8300,8362,1.0075,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1930,iia;juan,czech republic;czechoslovakia,1.25e+04,1.259e+04,1.0075,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1920,iia;juan,czech republic;czechoslovakia,8300,8361,1.0073,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1931,iia;juan,serbia;yugoslav sfr,1.23e+04,1.239e+04,1.0071,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,1000,1007,1.0071,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1920,iia;juan,czech republic;czechoslovakia,6600,6647,1.0071,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1917,iia;mitchell,korea;south korea,1.4e+04,1.41e+04,1.0071,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1920,iia;juan,serbia;yugoslav sfr,1.24e+04,1.249e+04,1.0070,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1922,iia;juan,czech republic;czechoslovakia,7800,7854,1.0069,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1922,iia;juan,czech republic;czechoslovakia,1.19e+04,1.198e+04,1.0068,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1924,iia;juan,czech republic;czechoslovakia,1.16e+04,1.168e+04,1.0068,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1930,iia;mitchell,korea;south korea,1.5e+04,1.51e+04,1.0067,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1924,iia;juan,serbia;yugoslav sfr,1.3e+04,1.309e+04,1.0066,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1932,iia;juan,czech republic;czechoslovakia,9500,9563,1.0066,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1916,iia;mitchell,korea;south korea,1.3e+04,1.308e+04,1.0065,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1932,iia;juan,serbia;yugoslav sfr,1.06e+04,1.067e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1930,iia;juan,czech republic;czechoslovakia,1.25e+04,1.258e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1932,iia;juan,czech republic;czechoslovakia,7700,7749,1.0064,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1922,iia;juan,serbia;yugoslav sfr,1.31e+04,1.318e+04,1.0061,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1921,iia;juan,serbia;yugoslav sfr,1.43e+04,1.439e+04,1.0061,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-SER-1878-1913,flax fibre and tow,ha,1911,iia;juan,serbia;yugoslav sfr,1800,1811,1.0061,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1932,iia;juan,serbia;yugoslav sfr,820,824.9,1.0060,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1931,iia;juan,czech republic;czechoslovakia,9000,9053,1.0059,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1925,iia;juan,serbia;yugoslav sfr,1100,1106,1.0055,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1920,iia;juan,czech republic;czechoslovakia,1.86e+04,1.87e+04,1.0052,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,1740,1749,1.0051,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1923,iia;juan,serbia;yugoslav sfr,1820,1829,1.0050,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1919,iia;juan,czech republic;czechoslovakia,9000,9044,1.0049,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1930,iia;juan,serbia;yugoslav sfr,1.31e+04,1.316e+04,1.0048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1925,iia;juan,czech republic;czechoslovakia,9000,9042,1.0047,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,9039,9080,1.0046,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1931,iia;juan,serbia;yugoslav sfr,1580,1587,1.0045,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1930,iia;juan,serbia;yugoslav sfr,1.53e+04,1.537e+04,1.0045,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1930,iia;juan,czech republic;czechoslovakia,6200,6228,1.0045,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1923,iia;juan,serbia;yugoslav sfr,2.16e+04,2.169e+04,1.0044,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1932,iia;mitchell,korea;south korea,1.991e+04,2e+04,1.0044,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1921,iia;juan,serbia;yugoslav sfr,1.47e+04,1.476e+04,1.0041,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1930,iia;juan,serbia;yugoslav sfr,1750,1757,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1924,iia;juan,czech republic;czechoslovakia,2.18e+04,2.189e+04,1.0039,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1930,iia;juan,czech republic;czechoslovakia,1.55e+04,1.556e+04,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1924,iia;juan,czech republic;czechoslovakia,2.18e+04,2.189e+04,1.0039,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-CHN-1921-1932,soybeans,tonnes,1930,iia;mitchell,"china, mainland;china, manchuria province of",5.298e+06,5.317e+06,1.0037,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1933,iia;juan,serbia;yugoslav sfr,1694,1700,1.0035,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1924,iia;juan,serbia;yugoslav sfr,1470,1475,1.0035,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-SER-1878-1913,hemp tow waste,ha,1910,iia;juan,serbia;yugoslav sfr,1.54e+04,1.545e+04,1.0035,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1920,iia;juan,czech republic;czechoslovakia,9900,9934,1.0034,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1925,iia;juan,czech republic;czechoslovakia,2.47e+04,2.478e+04,1.0033,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-CHN-1921-1932,soybeans,tonnes,1931,iia;mitchell,"china, mainland;china, manchuria province of",5.227e+06,5.244e+06,1.0032,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1923,iia;juan,serbia;yugoslav sfr,1510,1515,1.0032,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,1680,1685,1.0030,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1933,iia;juan,czech republic;czechoslovakia,1e+04,1.003e+04,1.0030,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1933,iia;juan,serbia;yugoslav sfr,9900,9928,1.0028,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1924,iia;juan,serbia;yugoslav sfr,2180,2186,1.0026,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1923,iia;juan,czech republic;czechoslovakia,3800,3810,1.0026,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,1500,1504,1.0025,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,997.5,1000,1.0025,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1931,iia;juan,serbia;yugoslav sfr,3960,3969,1.0024,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1931,iia;juan,czech republic;czechoslovakia,3380,3388,1.0024,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1925,iia;juan,czech republic;czechoslovakia,3000,3007,1.0023,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1920,iia;juan,serbia;yugoslav sfr,2.87e+04,2.876e+04,1.0022,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1930,iia;juan,serbia;yugoslav sfr,1.16e+04,1.162e+04,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1931,iia;juan,serbia;yugoslav sfr,7700,7717,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,2760,2766,1.0021,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,3860,3868,1.0021,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,1360,1363,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,2870,2876,1.0020,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,2540,2545,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-SER-1878-1913,hemp tow waste,ha,1911,iia;juan,serbia;yugoslav sfr,1.57e+04,1.573e+04,1.0020,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1925,iia;juan,serbia;yugoslav sfr,1.32e+04,1.322e+04,1.0017,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,1480,1482,1.0017,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,5280,5289,1.0017,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1924,iia;juan,czech republic;czechoslovakia,5760,5770,1.0017,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1923,iia;juan,serbia;yugoslav sfr,1.34e+04,1.342e+04,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1930,iia;juan,serbia;yugoslav sfr,1.422e+04,1.424e+04,1.0016,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1932,iia;juan,czech republic;czechoslovakia,3280,3285,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1931,iia;juan,czech republic;czechoslovakia,1.22e+04,1.222e+04,1.0016,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1931,iia;juan,serbia;yugoslav sfr,1.93e+04,1.933e+04,1.0015,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,4210,4216,1.0015,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1923,iia;juan,czech republic;czechoslovakia,2790,2794,1.0015,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1932,iia;juan,czech republic;czechoslovakia,6600,6609,1.0014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,6440,6449,1.0014,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1932,iia;juan,czech republic;czechoslovakia,6600,6609,1.0014,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1922,iia;juan,czech republic;czechoslovakia,2060,2063,1.0014,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1920,iia;juan,serbia;yugoslav sfr,1.41e+04,1.412e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1925,iia;juan,czech republic;czechoslovakia,2.47e+04,2.473e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,6270,6278,1.0013,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,5620,5627,1.0013,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1922,iia;juan,serbia;yugoslav sfr,1.27e+04,1.272e+04,1.0012,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,4310,4315,1.0012,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,7950,7959,1.0012,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,7070,7078,1.0011,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1922,iia;juan,czech republic;czechoslovakia,2.27e+04,2.272e+04,1.0011,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1920,iia;juan,czech republic;czechoslovakia,5260,5266,1.0011,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1922,iia;juan,czech republic;czechoslovakia,2.27e+04,2.272e+04,1.0011,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1923,iia;juan,serbia;yugoslav sfr,8690,8698,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1931,iia;juan,serbia;yugoslav sfr,9800,9810,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,840,840.8,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1923,iia;juan,czech republic;czechoslovakia,2.12e+04,2.122e+04,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,4280,4284,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,2410,2412,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,4780,4785,1.0010,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,920,920.8,1.0009,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1919,iia;juan,czech republic;czechoslovakia,7650,7657,1.0009,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1923,iia;juan,czech republic;czechoslovakia,3090,3093,1.0009,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1925,iia;juan,czech republic;czechoslovakia,6870,6876,1.0009,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,2070,2072,1.0008,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1933,iia;juan,serbia;yugoslav sfr,4250,4253,1.0008,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1933,iia;juan,serbia;yugoslav sfr,2.56e+05,2.562e+05,1.0008,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1920,iia;juan,czech republic;czechoslovakia,2.2e+04,2.202e+04,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1933,iia;juan,czech republic;czechoslovakia,3597,3600,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,3980,3983,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1932,iia;juan,serbia;yugoslav sfr,2900,2902,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1922,iia;juan,czech republic;czechoslovakia,1.257e+04,1.258e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1924,iia;juan,czech republic;czechoslovakia,1.226e+04,1.227e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1925,iia;juan,czech republic;czechoslovakia,1.366e+04,1.367e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1930,iia;juan,serbia;yugoslav sfr,1.033e+04,1.034e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1921,iia;juan,serbia;yugoslav sfr,3.2e+04,3.202e+04,1.0006,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1932,iia;juan,serbia;yugoslav sfr,2.14e+04,2.141e+04,1.0006,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1920,iia;juan,czech republic;czechoslovakia,1.307e+04,1.308e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1925,iia;juan,czech republic;czechoslovakia,7030,7034,1.0006,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1931,iia;juan,czech republic;czechoslovakia,1.232e+04,1.233e+04,1.0006,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1924,iia;juan,serbia;yugoslav sfr,8470,8475,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1925,iia;juan,serbia;yugoslav sfr,1.993e+05,1.994e+05,1.0005,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1932,iia;juan,serbia;yugoslav sfr,1.691e+04,1.692e+04,1.0005,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1930,iia;juan,czech republic;czechoslovakia,5810,5813,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,1.154e+04,1.155e+04,1.0005,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1920,iia;juan,serbia;yugoslav sfr,8810,8814,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1925,iia;juan,serbia;yugoslav sfr,1.021e+04,1.021e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1932,iia;juan,serbia;yugoslav sfr,1.063e+04,1.063e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,710,710.3,1.0004,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1932,iia;juan,serbia;yugoslav sfr,3750,3752,1.0004,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1921,iia;juan,serbia;yugoslav sfr,1.904e+05,1.905e+05,1.0004,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1931,iia;juan,serbia;yugoslav sfr,1.332e+04,1.333e+04,1.0004,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,5150,5152,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1919,iia;juan,czech republic;czechoslovakia,4350,4352,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1924,iia;juan,czech republic;czechoslovakia,9960,9964,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1930,iia;juan,czech republic;czechoslovakia,1.472e+04,1.473e+04,1.0004,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1930,iia;juan,serbia;yugoslav sfr,1350,1350,1.0003,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1920,iia;juan,serbia;yugoslav sfr,1.98e+05,1.981e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1921,iia;juan,czech republic;czechoslovakia,2.39e+04,2.391e+04,1.0003,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1932,iia;juan,czech republic;czechoslovakia,7520,7522,1.0003,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,7920,7922,1.0003,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1933,iia;juan,czech republic;czechoslovakia,1.046e+06,1.046e+06,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1932,iia;juan,czech republic;czechoslovakia,1.706e+04,1.707e+04,1.0003,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1941,iia;juan,czech republic;czechoslovakia,9.81e+05,9.813e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1920,iia;juan,serbia;yugoslav sfr,1.638e+05,1.638e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1921,iia;juan,serbia;yugoslav sfr,1.708e+05,1.708e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1933,iia;juan,serbia;yugoslav sfr,1464,1464,1.0002,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1925,iia;juan,serbia;yugoslav sfr,2250,2250,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1933,iia;juan,serbia;yugoslav sfr,2.453e+05,2.453e+05,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,9190,9191,1.0002,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,1310,1310,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1930,iia;juan,czech republic;czechoslovakia,1.002e+04,1.002e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1931,iia;juan,czech republic;czechoslovakia,1.383e+04,1.383e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1939,iia;juan,czech republic;czechoslovakia,1.729e+06,1.729e+06,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1922,iia;juan,serbia;yugoslav sfr,1.972e+05,1.972e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1922,iia;juan,serbia;yugoslav sfr,1.149e+05,1.149e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1924,iia;juan,serbia;yugoslav sfr,3.568e+04,3.569e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1925,iia;juan,serbia;yugoslav sfr,1.206e+04,1.206e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1919,iia;juan,czech republic;czechoslovakia,1.4e+04,1.4e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1923,iia;juan,czech republic;czechoslovakia,1.287e+04,1.287e+04,1.0001,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,3790,3790,1.0001,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,1.057e+04,1.057e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1919,iia;juan,czech republic;czechoslovakia,7.329e+05,7.33e+05,1.0001,layerb-nested-reporting-levels-one-polity
-ETH-1907-1936,"coffee, green",tonnes,1933,iia;mitchell,ethiopia;ethiopia pdr,1.62e+04,1.62e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-ETH-1907-1936,"coffee, green",tonnes,1934,iia;mitchell,ethiopia;ethiopia pdr,2.24e+04,2.24e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-ETH-1907-1936,"coffee, green",tonnes,1935,iia;mitchell,ethiopia;ethiopia pdr,1.98e+04,1.98e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-ETH-1941-1952,"coffee, green",tonnes,1942,iia;mitchell,ethiopia;ethiopia pdr,8400,8400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-ETH-1941-1952,"coffee, green",tonnes,1943,iia;mitchell,ethiopia;ethiopia pdr,1.1e+04,1.1e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-ETH-1941-1952,"coffee, green",tonnes,1944,iia;mitchell,ethiopia;ethiopia pdr,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1933,iia;juan,serbia;yugoslav sfr,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1934,iia;juan,serbia;yugoslav sfr,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1935,iia;juan,serbia;yugoslav sfr,3.2e+04,3.2e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1936,iia;juan,serbia;yugoslav sfr,3.1e+04,3.1e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1937,iia;juan,serbia;yugoslav sfr,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1938,iia;juan,serbia;yugoslav sfr,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1939,iia;juan,serbia;yugoslav sfr,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,castor beans seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,300,300,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1934,iia;juan,serbia;yugoslav sfr,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1935,iia;juan,serbia;yugoslav sfr,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1936,iia;juan,serbia;yugoslav sfr,400,400,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1937,iia;juan,serbia;yugoslav sfr,700,700,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1938,iia;juan,serbia;yugoslav sfr,1200,1200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1939,iia;juan,serbia;yugoslav sfr,1100,1100,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1921,iia;juan,serbia;yugoslav sfr,8260,8260,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1934,iia;juan,serbia;yugoslav sfr,1.1e+04,1.1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1935,iia;juan,serbia;yugoslav sfr,1.2e+04,1.2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1936,iia;juan,serbia;yugoslav sfr,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1937,iia;juan,serbia;yugoslav sfr,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1938,iia;juan,serbia;yugoslav sfr,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1939,iia;juan,serbia;yugoslav sfr,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1933,iia;juan,serbia;yugoslav sfr,1.95e+05,1.95e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1934,iia;juan,serbia;yugoslav sfr,1.99e+05,1.99e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1935,iia;juan,serbia;yugoslav sfr,2.07e+05,2.07e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1935,iia;juan,serbia;yugoslav sfr,9.156e+05,9.156e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1936,iia;juan,serbia;yugoslav sfr,2.14e+05,2.14e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1936,iia;juan,serbia;yugoslav sfr,6.571e+05,6.571e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1937,iia;juan,serbia;yugoslav sfr,2.15e+05,2.15e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1937,iia;juan,serbia;yugoslav sfr,4.826e+05,4.826e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1938,iia;juan,serbia;yugoslav sfr,2.19e+05,2.19e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1938,iia;juan,serbia;yugoslav sfr,7.94e+05,7.94e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1939,iia;juan,serbia;yugoslav sfr,2.23e+05,2.23e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1939,iia;juan,serbia;yugoslav sfr,7.778e+05,7.778e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1939,iia;juan,serbia;yugoslav sfr,5.7e+04,5.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,tonnes,1939,iia;juan,serbia;yugoslav sfr,5.35e+04,5.35e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1940,iia;juan,serbia;yugoslav sfr,6e+04,6e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,tonnes,1940,iia;juan,serbia;yugoslav sfr,4.5e+04,4.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,2100,2100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,4500,4500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,3100,3100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1939,iia;juan,serbia;yugoslav sfr,2800,2800,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1934,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1935,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1937,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1938,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1939,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,ha,1939,iia;juan,serbia;yugoslav sfr,3.57e+05,3.57e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,tonnes,1939,iia;juan,serbia;yugoslav sfr,3.483e+05,3.483e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,ha,1940,iia;juan,serbia;yugoslav sfr,3.52e+05,3.52e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,tonnes,1940,iia;juan,serbia;yugoslav sfr,2.879e+05,2.879e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1922,iia;juan,serbia;yugoslav sfr,5780,5780,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1923,iia;juan,serbia;yugoslav sfr,3180,3180,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1924,iia;juan,serbia;yugoslav sfr,5140,5140,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1925,iia;juan,serbia;yugoslav sfr,1370,1370,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1934,iia;juan,serbia;yugoslav sfr,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1935,iia;juan,serbia;yugoslav sfr,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1936,iia;juan,serbia;yugoslav sfr,2000,2000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1937,iia;juan,serbia;yugoslav sfr,7200,7200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1938,iia;juan,serbia;yugoslav sfr,6100,6100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1939,iia;juan,serbia;yugoslav sfr,5900,5900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1940,iia;juan,serbia;yugoslav sfr,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1941,iia;juan,serbia;yugoslav sfr,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1942,iia;juan,serbia;yugoslav sfr,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1943,iia;juan,serbia;yugoslav sfr,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1944,iia;juan,serbia;yugoslav sfr,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1945,iia;juan,serbia;yugoslav sfr,1800,1800,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1935,iia;juan,serbia;yugoslav sfr,1.67e+04,1.67e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1936,iia;juan,serbia;yugoslav sfr,1.3e+04,1.3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1937,iia;juan,serbia;yugoslav sfr,4.83e+04,4.83e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1938,iia;juan,serbia;yugoslav sfr,3.07e+04,3.07e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1939,iia;juan,serbia;yugoslav sfr,3.84e+04,3.84e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1934,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1935,iia;juan,serbia;yugoslav sfr,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1936,iia;juan,serbia;yugoslav sfr,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1937,iia;juan,serbia;yugoslav sfr,700,700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1938,iia;juan,serbia;yugoslav sfr,400,400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1939,iia;juan,serbia;yugoslav sfr,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1934,iia;juan,serbia;yugoslav sfr,7000,7000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,5400,5400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1935,iia;juan,serbia;yugoslav sfr,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,1.01e+04,1.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1936,iia;juan,serbia;yugoslav sfr,2.4e+04,2.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,2.1e+04,2.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1937,iia;juan,serbia;yugoslav sfr,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,8200,8200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1938,iia;juan,serbia;yugoslav sfr,1.8e+04,1.8e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1939,iia;juan,serbia;yugoslav sfr,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,7800,7800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1940,iia;juan,serbia;yugoslav sfr,2900,2900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1941,iia;juan,serbia;yugoslav sfr,3600,3600,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1920,iia;juan,serbia;yugoslav sfr,1.547e+05,1.547e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1921,iia;juan,serbia;yugoslav sfr,1.466e+05,1.466e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1923,iia;juan,serbia;yugoslav sfr,1.871e+05,1.871e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1923,iia;juan,serbia;yugoslav sfr,1.5e+05,1.5e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1924,iia;juan,serbia;yugoslav sfr,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1924,iia;juan,serbia;yugoslav sfr,1.408e+05,1.408e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1925,iia;juan,serbia;yugoslav sfr,1.998e+05,1.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1930,iia;juan,serbia;yugoslav sfr,2.469e+05,2.469e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1930,iia;juan,serbia;yugoslav sfr,1.988e+05,1.988e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1931,iia;juan,serbia;yugoslav sfr,1.934e+05,1.934e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1932,iia;juan,serbia;yugoslav sfr,2.115e+05,2.115e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1934,iia;juan,serbia;yugoslav sfr,2.48e+05,2.48e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1934,iia;juan,serbia;yugoslav sfr,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1935,iia;juan,serbia;yugoslav sfr,2.52e+05,2.52e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1935,iia;juan,serbia;yugoslav sfr,1.961e+05,1.961e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1936,iia;juan,serbia;yugoslav sfr,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1936,iia;juan,serbia;yugoslav sfr,2.033e+05,2.033e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1937,iia;juan,serbia;yugoslav sfr,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1937,iia;juan,serbia;yugoslav sfr,2.094e+05,2.094e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1938,iia;juan,serbia;yugoslav sfr,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1938,iia;juan,serbia;yugoslav sfr,2.271e+05,2.271e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1939,iia;juan,serbia;yugoslav sfr,2.58e+05,2.58e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1939,iia;juan,serbia;yugoslav sfr,2.435e+05,2.435e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1940,iia;juan,serbia;yugoslav sfr,2.55e+05,2.55e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1940,iia;juan,serbia;yugoslav sfr,2.111e+05,2.111e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1934,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1934,iia;juan,serbia;yugoslav sfr,200,200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1935,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1935,iia;juan,serbia;yugoslav sfr,200,200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1936,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1936,iia;juan,serbia;yugoslav sfr,300,300,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1937,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1937,iia;juan,serbia;yugoslav sfr,400,400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1938,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1938,iia;juan,serbia;yugoslav sfr,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1934,iia;juan,serbia;yugoslav sfr,700,700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1935,iia;juan,serbia;yugoslav sfr,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1936,iia;juan,serbia;yugoslav sfr,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1937,iia;juan,serbia;yugoslav sfr,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1939,iia;juan,serbia;yugoslav sfr,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1939,iia;juan,serbia;yugoslav sfr,2800,2800,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1940,iia;juan,serbia;yugoslav sfr,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1940,iia;juan,serbia;yugoslav sfr,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1941,iia;juan,serbia;yugoslav sfr,1.7e+04,1.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sunflower seed,ha,1939,iia;juan,serbia;yugoslav sfr,1.9e+04,1.9e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1920,iia;juan,serbia;yugoslav sfr,7800,7800,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1921,iia;juan,serbia;yugoslav sfr,9327,9327,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1933,iia;juan,serbia;yugoslav sfr,8751,8751,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1934,iia;juan,serbia;yugoslav sfr,7000,7000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1935,iia;juan,serbia;yugoslav sfr,1.2e+04,1.2e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1936,iia;juan,serbia;yugoslav sfr,1.8e+04,1.8e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1937,iia;juan,serbia;yugoslav sfr,2.1e+04,2.1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1938,iia;juan,serbia;yugoslav sfr,1.6e+04,1.6e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1939,iia;juan,serbia;yugoslav sfr,1.8e+04,1.8e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1945,iia;juan,serbia;yugoslav sfr,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1933,iia;juan,czech republic;czechoslovakia,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1933,iia;juan,czech republic;czechoslovakia,6600,6600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1921,iia;juan,czech republic;czechoslovakia,1.028e+04,1.028e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1934,iia;juan,czech republic;czechoslovakia,1e+04,1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1935,iia;juan,czech republic;czechoslovakia,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1936,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1937,iia;juan,czech republic;czechoslovakia,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1930,iia;juan,czech republic;czechoslovakia,7.324e+04,7.324e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1931,iia;juan,czech republic;czechoslovakia,7.08e+04,7.08e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1934,iia;juan,czech republic;czechoslovakia,2.1e+04,2.1e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1935,iia;juan,czech republic;czechoslovakia,2.4e+04,2.4e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1936,iia;juan,czech republic;czechoslovakia,2.5e+04,2.5e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1937,iia;juan,czech republic;czechoslovakia,2.6e+04,2.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1934,iia;juan,czech republic;czechoslovakia,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1935,iia;juan,czech republic;czechoslovakia,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,3400,3400,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1933,iia;juan,czech republic;czechoslovakia,6268,6268,1.0000,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,7204,7204,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1934,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,1500,1500,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1935,iia;juan,czech republic;czechoslovakia,4000,4000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,4800,4800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1936,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,7400,7400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1937,iia;juan,czech republic;czechoslovakia,6000,6000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,8900,8900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1919,iia;juan,czech republic;czechoslovakia,8.315e+05,8.315e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1920,iia;juan,czech republic;czechoslovakia,8.998e+05,8.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1920,iia;juan,czech republic;czechoslovakia,8.368e+05,8.368e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1921,iia;juan,czech republic;czechoslovakia,8.835e+05,8.835e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1921,iia;juan,czech republic;czechoslovakia,1.381e+06,1.381e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1922,iia;juan,czech republic;czechoslovakia,8.797e+05,8.797e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1922,iia;juan,czech republic;czechoslovakia,1.298e+06,1.298e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1923,iia;juan,czech republic;czechoslovakia,8.593e+05,8.593e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1923,iia;juan,czech republic;czechoslovakia,1.355e+06,1.355e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1924,iia;juan,czech republic;czechoslovakia,8.375e+05,8.375e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1924,iia;juan,czech republic;czechoslovakia,1.136e+06,1.136e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1925,iia;juan,czech republic;czechoslovakia,8.46e+05,8.46e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1930,iia;juan,czech republic;czechoslovakia,1.046e+06,1.046e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1930,iia;juan,czech republic;czechoslovakia,1.788e+06,1.788e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1931,iia;juan,czech republic;czechoslovakia,9.996e+05,9.996e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1931,iia;juan,czech republic;czechoslovakia,1.388e+06,1.388e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1932,iia;juan,czech republic;czechoslovakia,1.04e+06,1.04e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1932,iia;juan,czech republic;czechoslovakia,2.176e+06,2.176e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1933,iia;juan,czech republic;czechoslovakia,2.086e+06,2.086e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1934,iia;juan,czech republic;czechoslovakia,9.88e+05,9.88e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1934,iia;juan,czech republic;czechoslovakia,1.523e+06,1.523e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1935,iia;juan,czech republic;czechoslovakia,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1935,iia;juan,czech republic;czechoslovakia,1.638e+06,1.638e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1936,iia;juan,czech republic;czechoslovakia,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1936,iia;juan,czech republic;czechoslovakia,1.436e+06,1.436e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1937,iia;juan,czech republic;czechoslovakia,9.67e+05,9.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1937,iia;juan,czech republic;czechoslovakia,1.485e+06,1.485e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1934,iia;juan,czech republic;czechoslovakia,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1935,iia;juan,czech republic;czechoslovakia,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1936,iia;juan,czech republic;czechoslovakia,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1937,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1920,iia;juan,czech republic;czechoslovakia,1766,1766,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1921,iia;juan,czech republic;czechoslovakia,1289,1289,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1925,iia;juan,czech republic;czechoslovakia,5400,5400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1933,iia;juan,czech republic;czechoslovakia,1.178e+04,1.178e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1934,iia;juan,czech republic;czechoslovakia,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1935,iia;juan,czech republic;czechoslovakia,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1936,iia;juan,czech republic;czechoslovakia,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1937,iia;juan,czech republic;czechoslovakia,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1938,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1939,iia;juan,czech republic;czechoslovakia,2e+04,2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1940,iia;juan,czech republic;czechoslovakia,4.6e+04,4.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1941,iia;juan,czech republic;czechoslovakia,4.7e+04,4.7e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1943,iia;juan,czech republic;czechoslovakia,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1944,iia;juan,czech republic;czechoslovakia,3.4e+04,3.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1938,iia;juan,czech republic;czechoslovakia,2.7e+04,2.7e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1940,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1943,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1944,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1939,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1939,iia;juan,czech republic;czechoslovakia,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1940,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1940,iia;juan,czech republic;czechoslovakia,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1941,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1941,iia;juan,czech republic;czechoslovakia,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1942,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1942,iia;juan,czech republic;czechoslovakia,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1943,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1943,iia;juan,czech republic;czechoslovakia,4900,4900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1944,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1944,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1939,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,2600,2600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1940,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1941,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1942,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1943,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1944,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1939,iia;juan,czech republic;czechoslovakia,1.05e+04,1.05e+04,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1940,iia;juan,czech republic;czechoslovakia,8900,8900,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1941,iia;juan,czech republic;czechoslovakia,7500,7500,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1942,iia;juan,czech republic;czechoslovakia,7300,7300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1943,iia;juan,czech republic;czechoslovakia,6300,6300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1944,iia;juan,czech republic;czechoslovakia,7000,7000,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1939,iia;juan,czech republic;czechoslovakia,7.06e+05,7.06e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1939,iia;juan,czech republic;czechoslovakia,1.265e+06,1.265e+06,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1940,iia;juan,czech republic;czechoslovakia,7.99e+05,7.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1940,iia;juan,czech republic;czechoslovakia,1.277e+06,1.277e+06,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1941,iia;juan,czech republic;czechoslovakia,6.55e+05,6.55e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1941,iia;juan,czech republic;czechoslovakia,8.443e+05,8.443e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1942,iia;juan,czech republic;czechoslovakia,6.36e+05,6.36e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1942,iia;juan,czech republic;czechoslovakia,9.863e+05,9.863e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1943,iia;juan,czech republic;czechoslovakia,6.02e+05,6.02e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1943,iia;juan,czech republic;czechoslovakia,9.65e+05,9.65e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1944,iia;juan,czech republic;czechoslovakia,5.72e+05,5.72e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1944,iia;juan,czech republic;czechoslovakia,7.44e+05,7.44e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1938,iia;juan,czech republic;czechoslovakia,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1938,iia;juan,czech republic;czechoslovakia,1.32e+04,1.32e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1939,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,7200,7200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1940,iia;juan,czech republic;czechoslovakia,3000,3000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,3700,3700,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1941,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,2.01e+04,2.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1942,iia;juan,czech republic;czechoslovakia,1.5e+04,1.5e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,1.85e+04,1.85e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1943,iia;juan,czech republic;czechoslovakia,3.6e+04,3.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,3.72e+04,3.72e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1944,iia;juan,czech republic;czechoslovakia,6.1e+04,6.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,7.28e+04,7.28e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1938,iia;juan,czech republic;czechoslovakia,1.016e+06,1.016e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1938,iia;juan,czech republic;czechoslovakia,1.906e+06,1.906e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1940,iia;juan,czech republic;czechoslovakia,8.67e+05,8.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1942,iia;juan,czech republic;czechoslovakia,8.61e+05,8.61e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1944,iia;juan,czech republic;czechoslovakia,9.15e+05,9.15e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1939,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1939,iia;juan,czech republic;czechoslovakia,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1940,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1940,iia;juan,czech republic;czechoslovakia,1100,1100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1941,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1941,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1942,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1942,iia;juan,czech republic;czechoslovakia,1200,1200,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1943,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1943,iia;juan,czech republic;czechoslovakia,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1944,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1944,iia;juan,czech republic;czechoslovakia,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1938,iia;juan,czech republic;czechoslovakia,9000,9000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1939,iia;juan,czech republic;czechoslovakia,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1940,iia;juan,czech republic;czechoslovakia,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1941,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1942,iia;juan,czech republic;czechoslovakia,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1943,iia;juan,czech republic;czechoslovakia,2000,2000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1944,iia;juan,czech republic;czechoslovakia,3000,3000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,flax fibre and tow,ha,1945,iia;juan,czech republic;czechoslovakia,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,grapes,ha,1945,iia;juan,czech republic;czechoslovakia,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hemp tow waste,ha,1945,iia;juan,czech republic;czechoslovakia,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hemp tow waste,tonnes,1945,iia;juan,czech republic;czechoslovakia,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hempseed,ha,1945,iia;juan,czech republic;czechoslovakia,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hempseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hops,ha,1945,iia;juan,czech republic;czechoslovakia,8300,8300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,oats,ha,1945,iia;juan,czech republic;czechoslovakia,5.99e+05,5.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,oats,tonnes,1945,iia;juan,czech republic;czechoslovakia,7.242e+05,7.242e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rapeseed,ha,1945,iia;juan,czech republic;czechoslovakia,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rapeseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,2.48e+04,2.48e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,soybeans,ha,1945,iia;juan,czech republic;czechoslovakia,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,soybeans,tonnes,1945,iia;juan,czech republic;czechoslovakia,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-SER-1878-1913,hemp tow waste,ha,1909,iia;juan,serbia;yugoslav sfr,1.5e+04,1.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
+polity_code,item,unit,year,sources,labels,indicators,value_min,value_max,ratio,known_defect
+F51-1918-1938,wheat,tonnes,1930,iia;juan,czech republic;czechoslovakia,,311.9,1.377e+06,4415.7743,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1930,iia;juan,czech republic;czechoslovakia,,239,7.95e+05,3326.3598,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1933,iia;juan,czech republic;czechoslovakia,,700.2,1.984e+06,2833.3333,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1930,iia;juan,czech republic;czechoslovakia,,8,1.75e+04,2187.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1933,iia;juan,czech republic;czechoslovakia,,440,9.19e+05,2088.6364,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1931,iia;juan,czech republic;czechoslovakia,,553.6,1.122e+06,2027.0051,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1012,1.462e+06,1444.7101,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1931,iia;juan,czech republic;czechoslovakia,,607,8.284e+05,1364.7446,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1932,iia;juan,czech republic;czechoslovakia,,829,8.354e+05,1007.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1932,iia;juan,czech republic;czechoslovakia,,20,1.91e+04,955.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,1.773e+06,886.7000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1931,iia;juan,czech republic;czechoslovakia,,23,1.88e+04,817.3913,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1925,iia;juan,czech republic;czechoslovakia,,1615,6.174e+05,382.2910,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9580,2.689e+06,280.6493,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.17e+04,2.876e+06,245.7778,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1938,iia;juan,czech republic;czechoslovakia,,9800,1.814e+06,185.1020,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1.442e+04,2.629e+06,182.3492,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1938,iia;juan,czech republic;czechoslovakia,,5000,8.98e+05,179.6000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.248e+04,2.186e+06,175.1919,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1935,iia;juan,czech republic;czechoslovakia,,9900,1.69e+06,170.7071,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1936,iia;juan,czech republic;czechoslovakia,,9100,1.513e+06,166.2308,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1935,iia;juan,czech republic;czechoslovakia,,6000,9.63e+05,160.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8700,1.395e+06,160.3793,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1936,iia;juan,czech republic;czechoslovakia,,6000,9.27e+05,154.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1939,iia;juan,serbia;yugoslav sfr,,1.5e+04,2.203e+06,146.8667,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.482e+04,2.14e+06,144.4226,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.561e+06,143.2110,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.49e+05,141.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1934,iia;juan,czech republic;czechoslovakia,,9800,1.361e+06,138.8980,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,9.31e+05,133.0000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1931,iia;juan,serbia;yugoslav sfr,,1.652e+04,2.14e+06,129.5467,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.138e+04,1.455e+06,127.8359,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1922,iia;juan,serbia;yugoslav sfr,,9489,1.21e+06,127.5508,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1933,iia;juan,serbia;yugoslav sfr,,1.672e+04,2.079e+06,124.3719,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1932,iia;juan,serbia;yugoslav sfr,,1.639e+04,1.95e+06,119.0345,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1930,iia;juan,serbia;yugoslav sfr,,1.843e+04,2.123e+06,115.1730,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1934,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.54e+06,102.6933,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1943,iia;juan,czech republic;czechoslovakia,,9000,9.1e+05,101.1111,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1941,iia;mitchell,korea;south korea,;page_13_table_1,3.5e+04,3.512e+06,100.3429,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1939,iia;mitchell,korea;south korea,;page_12_table_1,3.1e+04,3.102e+06,100.0613,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1891,1.891e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1962,1.962e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2132,2.132e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1600,1.6e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1815,1.815e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1934,iia;juan,serbia;yugoslav sfr,,6049,6.049e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1935,iia;juan,serbia;yugoslav sfr,,9249,9.249e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.662e+04,1.662e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.078e+04,2.078e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1938,iia;juan,serbia;yugoslav sfr,,1.471e+04,1.471e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.543e+04,1.543e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.27e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1934,iia;juan,czech republic;czechoslovakia,,7074,7.074e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1935,iia;juan,czech republic;czechoslovakia,,7619,7.619e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.208e+04,1.208e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.216e+04,1.216e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.368e+04,1.368e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.363e+04,1.363e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.507e+04,1.507e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.404e+04,1.404e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1940,iia;juan,czech republic;czechoslovakia,,4576,4.576e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3527,3.527e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3107,3.107e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3152,3.152e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1939,iia;juan,czech republic;czechoslovakia,,9330,9.33e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1941,iia;juan,czech republic;czechoslovakia,,6914,6.914e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1942,iia;juan,czech republic;czechoslovakia,,7468,7.468e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5429,5.429e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1944,iia;juan,czech republic;czechoslovakia,,3928,3.928e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hops,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3721,3.721e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,czech republic;czechoslovakia,,2500,2.5e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7635,7.634e+05,99.9869,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1940,iia;juan,czech republic;czechoslovakia,,7803,7.8e+05,99.9616,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1938,iia;mitchell,korea;south korea,;page_12_table_1,2.8e+04,2.798e+06,99.9429,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1935,iia;mitchell,korea;south korea,;page_12_table_1,2.2e+04,2.192e+06,99.6409,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1455,1.433e+05,98.4880,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1936,iia;mitchell,korea;south korea,;page_12_table_1,2.1e+04,2.063e+06,98.2190,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1937,iia;mitchell,korea;south korea,;page_12_table_1,2.7e+04,2.649e+06,98.1037,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.604e+04,1.572e+06,97.9986,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.26e+04,1.21e+06,96.0317,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.828e+04,1.662e+06,90.9181,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,wheat,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1.29e+04,1.122e+06,86.9380,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,wheat,ha,1945,iia;juan,czech republic;czechoslovakia,,1e+04,8.43e+05,84.3000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1944,iia;juan,czech republic;czechoslovakia,,1.1e+04,9.12e+05,82.9091,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1924,iia;juan,serbia;yugoslav sfr,,2.209e+04,1.717e+06,77.7270,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.96e+04,1.451e+06,74.0102,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2.18e+04,1.572e+06,72.1147,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1922,iia;juan,serbia;yugoslav sfr,,2.108e+04,1.48e+06,70.2296,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1923,iia;juan,serbia;yugoslav sfr,,2.295e+04,1.555e+06,67.7648,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1939,iia;juan,czech republic;czechoslovakia,,1.4e+04,8.5e+05,60.7143,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1942,iia;juan,czech republic;czechoslovakia,,1.6e+04,8.71e+05,54.4375,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1936,iia;juan,serbia;yugoslav sfr,,5.48e+04,2.924e+06,53.3504,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2.17e+04,1.111e+06,51.1797,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1938,iia;juan,serbia;yugoslav sfr,,6.05e+04,3.03e+06,50.0810,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.777e+04,8.774e+05,49.3851,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1925,iia;juan,czech republic;czechoslovakia,,2.246e+04,1.07e+06,47.6231,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1940,iia;juan,czech republic;czechoslovakia,,1.7e+04,7.46e+05,43.8824,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,1.536e+06,42.6667,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1935,iia;juan,serbia;yugoslav sfr,,4.67e+04,1.99e+06,42.6017,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2.95e+04,1.231e+06,41.7288,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1923,iia;juan,czech republic;czechoslovakia,,2.376e+04,9.859e+05,41.4924,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1937,iia;juan,serbia;yugoslav sfr,,5.77e+04,2.347e+06,40.6759,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.96e+04,1.16e+06,39.1993,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1924,iia;juan,czech republic;czechoslovakia,,1.578e+04,6.057e+05,38.3938,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1922,iia;juan,czech republic;czechoslovakia,,2.398e+04,9.15e+05,38.1618,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.93e+04,1.86e+06,37.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3.25e+04,1.214e+06,37.3538,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1923,iia;juan,czech republic;czechoslovakia,,1.687e+04,6.097e+05,36.1497,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1936,iia;juan,serbia;yugoslav sfr,,6.2e+04,2.211e+06,35.6613,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1943,iia;juan,czech republic;czechoslovakia,,2.6e+04,9.26e+05,35.6154,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1935,iia;juan,serbia;yugoslav sfr,,6.1e+04,2.15e+06,35.2459,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,rye,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.8e+04,9.81e+05,35.0357,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1934,iia;juan,serbia;yugoslav sfr,,5.8e+04,2.024e+06,34.8966,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,ha,1922,iia;juan,czech republic;czechoslovakia,,1.8e+04,6.179e+05,34.3278,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1937,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,wheat,ha,1938,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,wheat,ha,1941,iia;juan,czech republic;czechoslovakia,,2.8e+04,8e+05,28.5714,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1938,iia;juan,czech republic;czechoslovakia,,5000,7.2e+04,14.4000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sunflower seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1900,2.73e+04,14.3684,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.3e+04,13.8333,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3461,4.61e+04,13.3198,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1934,iia;juan,serbia;yugoslav sfr,,800,1.06e+04,13.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4500,5.59e+04,12.4222,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1935,iia;juan,czech republic;czechoslovakia,,8600,1.022e+05,11.8837,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",ha,1935,iia;juan,czech republic;czechoslovakia,,6000,7e+04,11.6667,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1935,iia;juan,serbia;yugoslav sfr,,900,1.01e+04,11.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1936,iia;juan,czech republic;czechoslovakia,,8400,9.39e+04,11.1786,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1932,iia;juan,czech republic;czechoslovakia,,6671,7.418e+04,11.1193,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4.3e+04,10.7500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",ha,1936,iia;juan,czech republic;czechoslovakia,,7000,7.5e+04,10.7143,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1945,iia;juan,serbia;yugoslav sfr,,9.2e+04,9.799e+05,10.6511,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3000,3.18e+04,10.6000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2900,3.06e+04,10.5517,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3000,3.16e+04,10.5333,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3900,4.1e+04,10.5128,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3500,3.67e+04,10.4857,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3600,3.76e+04,10.4444,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,grapes,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3800,3.95e+04,10.3947,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1940,iia;juan,czech republic;czechoslovakia,,4000,4.1e+04,10.2500,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1941,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.84e+05,10.0513,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1939,iia;juan,czech republic;czechoslovakia,,9.8e+04,9.84e+05,10.0408,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1934,iia;juan,serbia;yugoslav sfr,,2400,2.4e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1935,iia;juan,serbia;yugoslav sfr,,2600,2.6e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1936,iia;juan,serbia;yugoslav sfr,,2700,2.7e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1937,iia;juan,serbia;yugoslav sfr,,2900,2.9e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1938,iia;juan,serbia;yugoslav sfr,,2800,2.8e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1931,iia;juan,serbia;yugoslav sfr,,2.442e+04,2.442e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1932,iia;juan,serbia;yugoslav sfr,,2.43e+04,2.43e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1934,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.09e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1935,iia;juan,czech republic;czechoslovakia,,1.12e+04,1.12e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1936,iia;juan,czech republic;czechoslovakia,,1.14e+04,1.14e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1941,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1938,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.16e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1937,iia;juan,czech republic;czechoslovakia,,1.15e+04,1.13e+05,9.8261,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1939,iia;juan,czech republic;czechoslovakia,,4000,3.9e+04,9.7500,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1400,1.29e+04,9.2143,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1940,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.08e+05,9.0769,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.11e+04,1.006e+05,9.0631,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6800,6.05e+04,8.8971,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1300,1.11e+04,8.5385,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1939,iia;juan,czech republic;czechoslovakia,,2000,1.7e+04,8.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",ha,1934,iia;juan,czech republic;czechoslovakia,,7000,5.8e+04,8.2857,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1943,iia;juan,czech republic;czechoslovakia,,5000,3.5e+04,7.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",ha,1944,iia;juan,czech republic;czechoslovakia,,5000,3e+04,6.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1935,iia;juan,serbia;yugoslav sfr,,2.25e+04,1.147e+05,5.0978,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1940,iia;juan,czech republic;czechoslovakia,,4700,2.29e+04,4.8723,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,"beans, dry",ha,1945,iia;juan,czech republic;czechoslovakia,,6000,2.8e+04,4.6667,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",tonnes,1937,iia;juan,czech republic;czechoslovakia,,6900,3.04e+04,4.4058,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1936,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.335e+05,4.3627,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1937,iia;juan,serbia;yugoslav sfr,,3.56e+04,1.55e+05,4.3539,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1941,iia;juan,czech republic;czechoslovakia,,4500,1.95e+04,4.3333,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1939,iia;juan,czech republic;czechoslovakia,,5700,2.43e+04,4.2632,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.69e+04,1.141e+05,4.2416,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1942,iia;juan,czech republic;czechoslovakia,,6100,2.46e+04,4.0328,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.48e+04,9.82e+04,3.9597,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.04e+04,1.582e+05,3.9158,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",tonnes,1936,iia;juan,czech republic;czechoslovakia,,7600,2.91e+04,3.8289,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",tonnes,1933,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.166e+05,3.8105,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1938,iia;juan,czech republic;czechoslovakia,,5900,2.19e+04,3.7119,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",tonnes,1935,iia;juan,czech republic;czechoslovakia,,4900,1.67e+04,3.4082,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",tonnes,1934,iia;juan,czech republic;czechoslovakia,,7100,2.31e+04,3.2535,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5000,1.54e+04,3.0800,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1920,iia;mitchell,korea;south korea,;page_12_table_1,5508,1.6e+04,2.9047,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"beans, dry",tonnes,1944,iia;juan,czech republic;czechoslovakia,,5100,1.46e+04,2.8627,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1932,iia;mitchell,israel;palestine,;page_38_table_1,3019,8118,2.6887,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,"beans, dry",tonnes,1945,iia;juan,czech republic;czechoslovakia,,6500,1.32e+04,2.0308,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1929,3900,2.0217,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1000,2000,2.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,50.9,100,1.9646,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1933,iia;mitchell,israel;palestine,;page_38_table_1,1584,2890,1.8245,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1930,iia;mitchell,israel;palestine,;page_38_table_1,1980,3569,1.8024,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1933,iia;juan,serbia;yugoslav sfr,,200,350,1.7500,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,180,1.6364,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1933,iia;juan,serbia;yugoslav sfr,,68.4,100,1.4620,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,121.6,170,1.3980,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1931,iia;mitchell,israel;palestine,;page_38_table_1,2772,3854,1.3904,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1925,iia;mitchell,korea;south korea,;page_12_table_1,1.017e+04,1.4e+04,1.3765,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,3406,4567,1.3406,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1.61e+04,2.15e+04,1.3354,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1931,iia;juan,serbia;yugoslav sfr,,300,395,1.3167,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4300,5600,1.3023,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7300,9500,1.3014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.72e+04,2.21e+04,1.2849,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.176e+06,1.476e+06,1.2552,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1923,iia;juan,serbia;yugoslav sfr,,2300,2885,1.2543,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.88e+04,2.35e+04,1.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,flax fibre and tow,tonnes,1945,iia;juan,czech republic;czechoslovakia,,5800,7100,1.2241,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1937,iia;juan,czech republic;czechoslovakia,,9000,1.1e+04,1.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.61e+04,1.2197,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1939,iia;juan,czech republic;czechoslovakia,,8300,1e+04,1.2048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1935,iia;juan,czech republic;czechoslovakia,,5700,6800,1.1930,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hemp tow waste,ha,1919,iia;juan,czech republic;czechoslovakia,,400,477,1.1925,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1933,iia;juan,czech republic;czechoslovakia,,1.73e+04,2e+04,1.1562,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1922,iia;juan,serbia;yugoslav sfr,,6020,6925,1.1503,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1932,iia;juan,serbia;yugoslav sfr,,400,459,1.1475,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1930,iia;juan,serbia;yugoslav sfr,,400,454,1.1350,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1933,iia;juan,serbia;yugoslav sfr,,3000,3383,1.1277,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,5185,5832,1.1248,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1922,iia;juan,serbia;yugoslav sfr,,50,56.1,1.1220,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1921,iia;juan,czech republic;czechoslovakia,,2260,2509,1.1100,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1923,iia;juan,serbia;yugoslav sfr,,40,44.1,1.1025,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1923,iia;juan,czech republic;czechoslovakia,,1.107e+04,1.19e+04,1.0746,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,117.6,1.0691,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1941,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1922,iia;mitchell,israel;palestine,;page_38_table_1,2696,2871,1.0648,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1935,iia;mitchell,israel;palestine,;page_38_table_1,2425,2574,1.0614,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hemp tow waste,ha,1921,iia;juan,czech republic;czechoslovakia,,1.134e+04,1.202e+04,1.0608,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1931,iia;juan,serbia;yugoslav sfr,,70,74.1,1.0586,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1925,iia;juan,czech republic;czechoslovakia,,1.101e+04,1.16e+04,1.0539,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1922,iia;juan,serbia;yugoslav sfr,,9391,9890,1.0531,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7627,8000,1.0489,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1925,iia;juan,serbia;yugoslav sfr,,120,125.8,1.0483,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1924,iia;mitchell,israel;palestine,;page_38_table_1,1420,1485,1.0456,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1920,iia;juan,czech republic;czechoslovakia,,1200,1254,1.0450,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1932,iia;juan,serbia;yugoslav sfr,,1400,1462,1.0443,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1921,iia;juan,czech republic;czechoslovakia,,1300,1357,1.0438,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1922,iia;mitchell,korea;south korea,;page_12_table_1,1.054e+04,1.1e+04,1.0433,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1924,iia;juan,serbia;yugoslav sfr,,80,83.4,1.0425,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1922,iia;juan,czech republic;czechoslovakia,,1600,1668,1.0425,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1909,iia;mitchell,korea;south korea,;page_12_table_1,1.151e+04,1.2e+04,1.0424,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1911,iia;mitchell,korea;south korea,;page_12_table_1,1.056e+04,1.1e+04,1.0416,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1925,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.489e+04,1.0414,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,210,218.4,1.0400,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1100,1144,1.0400,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2287,1.0395,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1930,iia;juan,serbia;yugoslav sfr,,130,134.9,1.0377,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.2e+04,1.0377,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1931,iia;juan,serbia;yugoslav sfr,,2200,2275,1.0341,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,1000,1034,1.0335,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1930,iia;juan,serbia;yugoslav sfr,,2800,2889,1.0318,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1933,iia;juan,czech republic;czechoslovakia,,970,1000,1.0309,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1922,iia;juan,serbia;yugoslav sfr,,3000,3089,1.0297,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1918,iia;mitchell,korea;south korea,;page_12_table_1,1.457e+04,1.5e+04,1.0297,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,7411,7627,1.0292,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.734e+04,1.784e+04,1.0287,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1912,iia;mitchell,korea;south korea,;page_12_table_1,1.264e+04,1.3e+04,1.0285,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1924,iia;mitchell,korea;south korea,;page_12_table_1,1.459e+04,1.5e+04,1.0278,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1924,iia;juan,serbia;yugoslav sfr,,3.523e+04,3.62e+04,1.0275,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1931,iia;mitchell,korea;south korea,;page_12_table_1,1.6e+04,1.644e+04,1.0275,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1933,iia;mitchell,korea;south korea,;page_12_table_1,1.655e+04,1.7e+04,1.0270,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1932,iia;juan,czech republic;czechoslovakia,,1500,1539,1.0260,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1919,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.434e+04,1.0241,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,60,61.4,1.0233,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1933,iia;juan,czech republic;czechoslovakia,,1.027e+04,1.05e+04,1.0227,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1923,iia;juan,czech republic;czechoslovakia,,2600,2654,1.0208,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1934,iia;mitchell,israel;palestine,;page_38_table_1,2328,2376,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1936,iia;mitchell,israel;palestine,;page_38_table_1,2231,2277,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1937,iia;mitchell,israel;palestine,;page_38_table_1,2425,2475,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1938,iia;mitchell,israel;palestine,;page_38_table_1,2910,2970,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1939,iia;mitchell,israel;palestine,;page_38_table_1,3298,3366,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1940,iia;mitchell,israel;palestine,;page_38_table_1,3589,3663,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1941,iia;mitchell,israel;palestine,;page_38_table_1,3589,3663,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1942,iia;mitchell,israel;palestine,;page_38_table_1,3977,4059,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1943,iia;mitchell,israel;palestine,;page_38_table_1,4171,4257,1.0206,layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1944,iia;mitchell,israel;palestine,;page_38_table_1,5335,5445,1.0206,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1924,iia;juan,czech republic;czechoslovakia,,3400,3464,1.0188,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.24e+04,1.0164,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,2032,1.0160,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1913,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.422e+04,1.0160,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1915,iia;mitchell,korea;south korea,;page_12_table_1,1.378e+04,1.4e+04,1.0158,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1931,iia;juan,czech republic;czechoslovakia,,2000,2031,1.0155,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+PAL-1920-1948,wine,tonnes,1923,iia;mitchell,israel;palestine,;page_38_table_1,2441,2475,1.0139,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1930,iia;juan,czech republic;czechoslovakia,,7400,7499,1.0134,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1925,iia;juan,serbia;yugoslav sfr,,2700,2736,1.0133,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.114e+04,1.0131,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1922,iia;juan,serbia;yugoslav sfr,,1800,1823,1.0128,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1914,iia;mitchell,korea;south korea,;page_12_table_1,9874,1e+04,1.0128,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2228,1.0127,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1921,iia;juan,czech republic;czechoslovakia,,4800,4860,1.0125,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.113e+04,1.0117,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1924,iia;juan,czech republic;czechoslovakia,,8100,8192,1.0114,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1924,iia;juan,czech republic;czechoslovakia,,4100,4146,1.0112,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8200,8290,1.0110,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1923,iia;mitchell,korea;south korea,;page_12_table_1,1.187e+04,1.2e+04,1.0109,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1923,iia;juan,serbia;yugoslav sfr,,1600,1616,1.0100,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1919,iia;juan,czech republic;czechoslovakia,,8500,8585,1.0100,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1932,iia;juan,czech republic;czechoslovakia,,9900,9997,1.0098,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8984,1.0094,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3469,3500,1.0089,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1910,iia;mitchell,korea;south korea,;page_12_table_1,8921,9000,1.0089,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2677,2700,1.0087,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,rye,ha,1945,iia;juan,czech republic;czechoslovakia,,8.02e+05,8.09e+05,1.0087,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2777,2800,1.0084,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8970,1.0079,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1923,iia;juan,czech republic;czechoslovakia,,7700,7761,1.0079,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1922,iia;juan,czech republic;czechoslovakia,,3900,3931,1.0079,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1921,iia;juan,czech republic;czechoslovakia,,8300,8362,1.0075,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.259e+04,1.0075,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1920,iia;juan,czech republic;czechoslovakia,,8300,8361,1.0073,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1931,iia;juan,serbia;yugoslav sfr,,1.23e+04,1.239e+04,1.0071,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1000,1007,1.0071,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1920,iia;juan,czech republic;czechoslovakia,,6600,6647,1.0071,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1917,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.41e+04,1.0071,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1920,iia;juan,serbia;yugoslav sfr,,1.24e+04,1.249e+04,1.0070,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1922,iia;juan,czech republic;czechoslovakia,,7800,7854,1.0069,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1922,iia;juan,czech republic;czechoslovakia,,1.19e+04,1.198e+04,1.0068,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1924,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.168e+04,1.0068,layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1930,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.51e+04,1.0067,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1924,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.309e+04,1.0066,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1932,iia;juan,czech republic;czechoslovakia,,9500,9563,1.0066,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1916,iia;mitchell,korea;south korea,;page_12_table_1,1.3e+04,1.308e+04,1.0065,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1932,iia;juan,serbia;yugoslav sfr,,1.06e+04,1.067e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.258e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1932,iia;juan,czech republic;czechoslovakia,,7700,7749,1.0064,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1922,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.318e+04,1.0061,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1921,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.439e+04,1.0061,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+SER-1878-1913,flax fibre and tow,ha,1911,iia;juan,serbia;yugoslav sfr,,1800,1811,1.0061,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1932,iia;juan,serbia;yugoslav sfr,,820,824.9,1.0060,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1931,iia;juan,czech republic;czechoslovakia,,9000,9053,1.0059,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1100,1106,1.0055,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1920,iia;juan,czech republic;czechoslovakia,,1.86e+04,1.87e+04,1.0052,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1740,1749,1.0051,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1820,1829,1.0050,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1919,iia;juan,czech republic;czechoslovakia,,9000,9044,1.0049,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1930,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.316e+04,1.0048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1925,iia;juan,czech republic;czechoslovakia,,9000,9042,1.0047,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9039,9080,1.0046,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1580,1587,1.0045,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1930,iia;juan,serbia;yugoslav sfr,,1.53e+04,1.537e+04,1.0045,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1930,iia;juan,czech republic;czechoslovakia,,6200,6228,1.0045,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1923,iia;juan,serbia;yugoslav sfr,,2.16e+04,2.169e+04,1.0044,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1932,iia;mitchell,korea;south korea,;page_12_table_1,1.991e+04,2e+04,1.0044,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1921,iia;juan,serbia;yugoslav sfr,,1.47e+04,1.476e+04,1.0041,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1750,1757,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1930,iia;juan,czech republic;czechoslovakia,,1.55e+04,1.556e+04,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+CHN-1921-1932,soybeans,tonnes,1930,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.298e+06,5.317e+06,1.0037,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1933,iia;juan,serbia;yugoslav sfr,,1694,1700,1.0035,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1470,1475,1.0035,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+SER-1878-1913,hemp tow waste,ha,1910,iia;juan,serbia;yugoslav sfr,,1.54e+04,1.545e+04,1.0035,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hemp tow waste,ha,1920,iia;juan,czech republic;czechoslovakia,,9900,9934,1.0034,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.478e+04,1.0033,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+CHN-1921-1932,soybeans,tonnes,1931,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.227e+06,5.244e+06,1.0032,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1510,1515,1.0032,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1680,1685,1.0030,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1933,iia;juan,czech republic;czechoslovakia,,1e+04,1.003e+04,1.0030,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1933,iia;juan,serbia;yugoslav sfr,,9900,9928,1.0028,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1924,iia;juan,serbia;yugoslav sfr,,2180,2186,1.0026,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1923,iia;juan,czech republic;czechoslovakia,,3800,3810,1.0026,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1500,1504,1.0025,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,linseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,997.5,1000,1.0025,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1931,iia;juan,serbia;yugoslav sfr,,3960,3969,1.0024,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1931,iia;juan,czech republic;czechoslovakia,,3380,3388,1.0024,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1925,iia;juan,czech republic;czechoslovakia,,3000,3007,1.0023,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,ha,1920,iia;juan,serbia;yugoslav sfr,,2.87e+04,2.876e+04,1.0022,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1930,iia;juan,serbia;yugoslav sfr,,1.16e+04,1.162e+04,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1931,iia;juan,serbia;yugoslav sfr,,7700,7717,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2760,2766,1.0021,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,3860,3868,1.0021,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,linseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1360,1363,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,2870,2876,1.0020,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2540,2545,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+SER-1878-1913,hemp tow waste,ha,1911,iia;juan,serbia;yugoslav sfr,,1.57e+04,1.573e+04,1.0020,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1925,iia;juan,serbia;yugoslav sfr,,1.32e+04,1.322e+04,1.0017,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1480,1482,1.0017,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,5280,5289,1.0017,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1924,iia;juan,czech republic;czechoslovakia,,5760,5770,1.0017,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1923,iia;juan,serbia;yugoslav sfr,,1.34e+04,1.342e+04,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.422e+04,1.424e+04,1.0016,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3280,3285,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,ha,1931,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.222e+04,1.0016,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1931,iia;juan,serbia;yugoslav sfr,,1.93e+04,1.933e+04,1.0015,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,4210,4216,1.0015,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1923,iia;juan,czech republic;czechoslovakia,,2790,2794,1.0015,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,6440,6449,1.0014,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1922,iia;juan,czech republic;czechoslovakia,,2060,2063,1.0014,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1920,iia;juan,serbia;yugoslav sfr,,1.41e+04,1.412e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.473e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,6270,6278,1.0013,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,5620,5627,1.0013,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1922,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.272e+04,1.0012,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,4310,4315,1.0012,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7950,7959,1.0012,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,7070,7078,1.0011,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1920,iia;juan,czech republic;czechoslovakia,,5260,5266,1.0011,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1923,iia;juan,serbia;yugoslav sfr,,8690,8698,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9800,9810,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,linseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,840,840.8,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.122e+04,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,4280,4284,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2410,2412,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,4780,4785,1.0010,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,920,920.8,1.0009,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1919,iia;juan,czech republic;czechoslovakia,,7650,7657,1.0009,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1923,iia;juan,czech republic;czechoslovakia,,3090,3093,1.0009,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1925,iia;juan,czech republic;czechoslovakia,,6870,6876,1.0009,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,2070,2072,1.0008,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1933,iia;juan,serbia;yugoslav sfr,,4250,4253,1.0008,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1933,iia;juan,serbia;yugoslav sfr,,2.56e+05,2.562e+05,1.0008,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1920,iia;juan,czech republic;czechoslovakia,,2.2e+04,2.202e+04,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3597,3600,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,3980,3983,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1932,iia;juan,serbia;yugoslav sfr,,2900,2902,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.257e+04,1.258e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.226e+04,1.227e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.366e+04,1.367e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.033e+04,1.034e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,ha,1921,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.202e+04,1.0006,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1932,iia;juan,serbia;yugoslav sfr,,2.14e+04,2.141e+04,1.0006,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1920,iia;juan,czech republic;czechoslovakia,,1.307e+04,1.308e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1925,iia;juan,czech republic;czechoslovakia,,7030,7034,1.0006,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.232e+04,1.233e+04,1.0006,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1924,iia;juan,serbia;yugoslav sfr,,8470,8475,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1925,iia;juan,serbia;yugoslav sfr,,1.993e+05,1.994e+05,1.0005,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.691e+04,1.692e+04,1.0005,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1930,iia;juan,czech republic;czechoslovakia,,5810,5813,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,1.154e+04,1.155e+04,1.0005,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1920,iia;juan,serbia;yugoslav sfr,,8810,8814,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.021e+04,1.021e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.063e+04,1.063e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,linseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,710,710.3,1.0004,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1932,iia;juan,serbia;yugoslav sfr,,3750,3752,1.0004,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1921,iia;juan,serbia;yugoslav sfr,,1.904e+05,1.905e+05,1.0004,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.332e+04,1.333e+04,1.0004,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,5150,5152,1.0004,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1919,iia;juan,czech republic;czechoslovakia,,4350,4352,1.0004,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9960,9964,1.0004,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.472e+04,1.473e+04,1.0004,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1350,1350,1.0003,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1920,iia;juan,serbia;yugoslav sfr,,1.98e+05,1.981e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1921,iia;juan,czech republic;czechoslovakia,,2.39e+04,2.391e+04,1.0003,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1932,iia;juan,czech republic;czechoslovakia,,7520,7522,1.0003,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,7920,7922,1.0003,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1933,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1932,iia;juan,czech republic;czechoslovakia,,1.706e+04,1.707e+04,1.0003,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1941,iia;juan,czech republic;czechoslovakia,,9.81e+05,9.813e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1920,iia;juan,serbia;yugoslav sfr,,1.638e+05,1.638e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1921,iia;juan,serbia;yugoslav sfr,,1.708e+05,1.708e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1464,1464,1.0002,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1925,iia;juan,serbia;yugoslav sfr,,2250,2250,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2.453e+05,2.453e+05,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,9190,9191,1.0002,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1310,1310,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.002e+04,1.002e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.383e+04,1.383e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.729e+06,1.729e+06,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1922,iia;juan,serbia;yugoslav sfr,,1.972e+05,1.972e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1922,iia;juan,serbia;yugoslav sfr,,1.149e+05,1.149e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1924,iia;juan,serbia;yugoslav sfr,,3.568e+04,3.569e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.206e+04,1.206e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1919,iia;juan,czech republic;czechoslovakia,,1.4e+04,1.4e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.287e+04,1.287e+04,1.0001,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3790,3790,1.0001,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,linseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.057e+04,1.057e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1919,iia;juan,czech republic;czechoslovakia,,7.329e+05,7.33e+05,1.0001,layerb-nested-reporting-levels-one-polity
+ETH-1907-1936,"coffee, green",tonnes,1933,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.62e+04,1.62e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+ETH-1907-1936,"coffee, green",tonnes,1934,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,2.24e+04,2.24e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+ETH-1907-1936,"coffee, green",tonnes,1935,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.98e+04,1.98e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+ETH-1941-1952,"coffee, green",tonnes,1942,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,8400,8400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+ETH-1941-1952,"coffee, green",tonnes,1943,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.1e+04,1.1e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+ETH-1941-1952,"coffee, green",tonnes,1944,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1933,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1934,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1935,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.2e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1936,iia;juan,serbia;yugoslav sfr,,3.1e+04,3.1e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1937,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1938,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1939,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,castor beans seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1936,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1200,1200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,cotton lint,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1100,1100,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,tonnes,1921,iia;juan,serbia;yugoslav sfr,,8260,8260,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1934,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1936,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1937,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1938,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1933,iia;juan,serbia;yugoslav sfr,,1.95e+05,1.95e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1934,iia;juan,serbia;yugoslav sfr,,1.99e+05,1.99e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1935,iia;juan,serbia;yugoslav sfr,,2.07e+05,2.07e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,9.156e+05,9.156e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1936,iia;juan,serbia;yugoslav sfr,,2.14e+05,2.14e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,tonnes,1936,iia;juan,serbia;yugoslav sfr,,6.571e+05,6.571e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1937,iia;juan,serbia;yugoslav sfr,,2.15e+05,2.15e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.826e+05,4.826e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1938,iia;juan,serbia;yugoslav sfr,,2.19e+05,2.19e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,7.94e+05,7.94e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,ha,1939,iia;juan,serbia;yugoslav sfr,,2.23e+05,2.23e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,grapes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7.778e+05,7.778e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,ha,1939,iia;juan,serbia;yugoslav sfr,,5.7e+04,5.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,tonnes,1939,iia;juan,serbia;yugoslav sfr,,5.35e+04,5.35e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,ha,1940,iia;juan,serbia;yugoslav sfr,,6e+04,6e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hemp tow waste,tonnes,1940,iia;juan,serbia;yugoslav sfr,,4.5e+04,4.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,2100,2100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4500,4500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hempseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3100,3100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,ha,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,lemons and limes,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,lemons and limes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,lemons and limes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,lemons and limes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,lemons and limes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oats,ha,1939,iia;juan,serbia;yugoslav sfr,,3.57e+05,3.57e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oats,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.483e+05,3.483e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oats,ha,1940,iia;juan,serbia;yugoslav sfr,,3.52e+05,3.52e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oats,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.879e+05,2.879e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1922,iia;juan,serbia;yugoslav sfr,,5780,5780,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1923,iia;juan,serbia;yugoslav sfr,,3180,3180,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1924,iia;juan,serbia;yugoslav sfr,,5140,5140,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1370,1370,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1934,iia;juan,serbia;yugoslav sfr,,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1935,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1936,iia;juan,serbia;yugoslav sfr,,2000,2000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1937,iia;juan,serbia;yugoslav sfr,,7200,7200,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1938,iia;juan,serbia;yugoslav sfr,,6100,6100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1939,iia;juan,serbia;yugoslav sfr,,5900,5900,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1940,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1941,iia;juan,serbia;yugoslav sfr,,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1942,iia;juan,serbia;yugoslav sfr,,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1943,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1944,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"oil, olive, virgin",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1800,1800,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,olives,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.67e+04,1.67e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,olives,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,olives,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.83e+04,4.83e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,olives,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3.07e+04,3.07e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,olives,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.84e+04,3.84e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1935,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1936,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1938,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,oranges,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,5400,5400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1935,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.01e+04,1.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1936,iia;juan,serbia;yugoslav sfr,,2.4e+04,2.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1937,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,8200,8200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1938,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2900,2900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rapeseed,tonnes,1941,iia;juan,serbia;yugoslav sfr,,3600,3600,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1.547e+05,1.547e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1921,iia;juan,serbia;yugoslav sfr,,1.466e+05,1.466e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1923,iia;juan,serbia;yugoslav sfr,,1.871e+05,1.871e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.5e+05,1.5e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1924,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.408e+05,1.408e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.998e+05,1.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1930,iia;juan,serbia;yugoslav sfr,,2.469e+05,2.469e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.988e+05,1.988e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.934e+05,1.934e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1932,iia;juan,serbia;yugoslav sfr,,2.115e+05,2.115e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1934,iia;juan,serbia;yugoslav sfr,,2.48e+05,2.48e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1935,iia;juan,serbia;yugoslav sfr,,2.52e+05,2.52e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.961e+05,1.961e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1936,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.033e+05,2.033e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1937,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.094e+05,2.094e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1938,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.271e+05,2.271e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1939,iia;juan,serbia;yugoslav sfr,,2.58e+05,2.58e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.435e+05,2.435e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,ha,1940,iia;juan,serbia;yugoslav sfr,,2.55e+05,2.55e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,rye,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.111e+05,2.111e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1934,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1936,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1937,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1938,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1934,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1936,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,ha,1939,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,ha,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,tonnes,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,soybeans,ha,1941,iia;juan,serbia;yugoslav sfr,,1.7e+04,1.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sunflower seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.9e+04,1.9e+04,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1920,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1921,iia;juan,serbia;yugoslav sfr,,9327,9327,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1933,iia;juan,serbia;yugoslav sfr,,8751,8751,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1936,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1937,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1938,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1939,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"tobacco, unmanufactured",ha,1945,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"beans, dry",tonnes,1933,iia;juan,czech republic;czechoslovakia,,6600,6600,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.028e+04,1.028e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1935,iia;juan,czech republic;czechoslovakia,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1936,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,flax fibre and tow,ha,1937,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1930,iia;juan,czech republic;czechoslovakia,,7.324e+04,7.324e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,tonnes,1931,iia;juan,czech republic;czechoslovakia,,7.08e+04,7.08e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1934,iia;juan,czech republic;czechoslovakia,,2.1e+04,2.1e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1935,iia;juan,czech republic;czechoslovakia,,2.4e+04,2.4e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1936,iia;juan,czech republic;czechoslovakia,,2.5e+04,2.5e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,grapes,ha,1937,iia;juan,czech republic;czechoslovakia,,2.6e+04,2.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,ha,1935,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hempseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,3400,3400,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hops,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6268,6268,1.0000,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7204,7204,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1934,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1500,1500,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1935,iia;juan,czech republic;czechoslovakia,,4000,4000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,4800,4800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1936,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7400,7400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1919,iia;juan,czech republic;czechoslovakia,,8.315e+05,8.315e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1920,iia;juan,czech republic;czechoslovakia,,8.998e+05,8.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1920,iia;juan,czech republic;czechoslovakia,,8.368e+05,8.368e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1921,iia;juan,czech republic;czechoslovakia,,8.835e+05,8.835e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.381e+06,1.381e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1922,iia;juan,czech republic;czechoslovakia,,8.797e+05,8.797e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.298e+06,1.298e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1923,iia;juan,czech republic;czechoslovakia,,8.593e+05,8.593e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.355e+06,1.355e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1924,iia;juan,czech republic;czechoslovakia,,8.375e+05,8.375e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.136e+06,1.136e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1925,iia;juan,czech republic;czechoslovakia,,8.46e+05,8.46e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1930,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.788e+06,1.788e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1931,iia;juan,czech republic;czechoslovakia,,9.996e+05,9.996e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.388e+06,1.388e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1932,iia;juan,czech republic;czechoslovakia,,1.04e+06,1.04e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2.176e+06,2.176e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2.086e+06,2.086e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1934,iia;juan,czech republic;czechoslovakia,,9.88e+05,9.88e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.523e+06,1.523e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1935,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.638e+06,1.638e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1936,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.436e+06,1.436e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,ha,1937,iia;juan,czech republic;czechoslovakia,,9.67e+05,9.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rye,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.485e+06,1.485e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,soybeans,tonnes,1934,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,soybeans,tonnes,1935,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,soybeans,tonnes,1936,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,soybeans,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1920,iia;juan,czech republic;czechoslovakia,,1766,1766,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1921,iia;juan,czech republic;czechoslovakia,,1289,1289,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1925,iia;juan,czech republic;czechoslovakia,,5400,5400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1933,iia;juan,czech republic;czechoslovakia,,1.178e+04,1.178e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1935,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1936,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1937,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1938,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1939,iia;juan,czech republic;czechoslovakia,,2e+04,2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1940,iia;juan,czech republic;czechoslovakia,,4.6e+04,4.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1941,iia;juan,czech republic;czechoslovakia,,4.7e+04,4.7e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1943,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,flax fibre and tow,ha,1944,iia;juan,czech republic;czechoslovakia,,3.4e+04,3.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1938,iia;juan,czech republic;czechoslovakia,,2.7e+04,2.7e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1940,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1943,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,grapes,ha,1944,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1941,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1943,iia;juan,czech republic;czechoslovakia,,4900,4900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hemp tow waste,tonnes,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2600,2600,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hempseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1939,iia;juan,czech republic;czechoslovakia,,1.05e+04,1.05e+04,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1940,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1941,iia;juan,czech republic;czechoslovakia,,7500,7500,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1942,iia;juan,czech republic;czechoslovakia,,7300,7300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1943,iia;juan,czech republic;czechoslovakia,,6300,6300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,hops,ha,1944,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1939,iia;juan,czech republic;czechoslovakia,,7.06e+05,7.06e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.265e+06,1.265e+06,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1940,iia;juan,czech republic;czechoslovakia,,7.99e+05,7.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.277e+06,1.277e+06,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1941,iia;juan,czech republic;czechoslovakia,,6.55e+05,6.55e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1941,iia;juan,czech republic;czechoslovakia,,8.443e+05,8.443e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1942,iia;juan,czech republic;czechoslovakia,,6.36e+05,6.36e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1942,iia;juan,czech republic;czechoslovakia,,9.863e+05,9.863e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1943,iia;juan,czech republic;czechoslovakia,,6.02e+05,6.02e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1943,iia;juan,czech republic;czechoslovakia,,9.65e+05,9.65e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,ha,1944,iia;juan,czech republic;czechoslovakia,,5.72e+05,5.72e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,oats,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.44e+05,7.44e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.32e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7200,7200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1940,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3700,3700,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1941,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.01e+04,2.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.5e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.85e+04,1.85e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,3.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.72e+04,3.72e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,ha,1944,iia;juan,czech republic;czechoslovakia,,6.1e+04,6.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rapeseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.28e+04,7.28e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1938,iia;juan,czech republic;czechoslovakia,,1.016e+06,1.016e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.906e+06,1.906e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,tonnes,1940,iia;juan,czech republic;czechoslovakia,,8.67e+05,8.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1942,iia;juan,czech republic;czechoslovakia,,8.61e+05,8.61e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,rye,ha,1944,iia;juan,czech republic;czechoslovakia,,9.15e+05,9.15e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1939,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1939,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1940,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1100,1100,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1942,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1200,1200,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1943,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1943,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,ha,1944,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,soybeans,tonnes,1944,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1939,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1940,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1943,iia;juan,czech republic;czechoslovakia,,2000,2000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1938-1945,"tobacco, unmanufactured",ha,1944,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,flax fibre and tow,ha,1945,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,grapes,ha,1945,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hemp tow waste,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hemp tow waste,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hempseed,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hempseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,hops,ha,1945,iia;juan,czech republic;czechoslovakia,,8300,8300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,oats,ha,1945,iia;juan,czech republic;czechoslovakia,,5.99e+05,5.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,oats,tonnes,1945,iia;juan,czech republic;czechoslovakia,,7.242e+05,7.242e+05,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,rapeseed,ha,1945,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,rapeseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.48e+04,2.48e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F51-1945-1947,soybeans,ha,1945,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,soybeans,tonnes,1945,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+SER-1878-1913,hemp tow waste,ha,1909,iia;juan,serbia;yugoslav sfr,,1.5e+04,1.5e+04,1.0000,layerb-nested-reporting-levels-one-polity

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -751,6 +751,35 @@ def mutate_observed_area_backdated_before_the_reporting_era(root, gpd, make_vali
     )
 
 
+def mutate_cross_source_indicators_disagree(root, gpd, make_valid, affinity):
+    """Make one cell's two sources annotate different measurements.
+
+    The cross-source key excludes `indicator` deliberately: fao1952 and iia use it for a measurement
+    type (`crops:production`) while mitchell uses it for a PAGE REFERENCE (`page_12_table_1`), so
+    keying on it would split iia from mitchell on a field that does not mean the same thing in each
+    and destroy the comparison the table exists for. `unit` already separates production from area.
+
+    What WOULD invalidate a cell is both sides being annotated and disagreeing -- then the ratio is
+    between two different measurements and means nothing. Zero such cells today. This mutation
+    creates one while leaving the ratio, the values, the sources, the count and the recorded defect
+    exactly as they were, so no other arm moves.
+    """
+    import csv as _csv
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/cross_source_agreement.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+        fields = list(rows[0].keys())
+    assert "indicators" in fields, "the table no longer publishes indicators -- case obsolete"
+    rows[0]["indicators"] = "crops:area;crops:production"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=fields, lineterminator="\n")
+        w.writeheader()
+        w.writerows(rows)
+    return (f"gave {rows[0]['polity_code']}/{rows[0]['item']}/{rows[0]['year']} two sources "
+            f"annotating `crops:area` and `crops:production`, so its ratio compares an area with a "
+            f"tonnage")
+
+
 def mutate_cross_source_defect_citation_vanishes(root, gpd, make_valid, affinity):
     """Strip the recorded explanation from a large cross-source disagreement.
 
@@ -5251,6 +5280,12 @@ CASES = (
         "not reach and where the enclave declares no area for check A to notice",
     ),
     (
+        "validate_cross_source_agreement.py",
+        mutate_cross_source_indicators_disagree,
+        "annotate DIFFERENT indicators",
+        "two sources compared across different measurements — the ratio, values, sources and "
+        "recorded defect all stay exactly as they were, so nothing but the indicator arm moves",
+    ),    (
         "validate_cross_source_agreement.py",
         mutate_cross_source_defect_citation_vanishes,
         "with no entry in data_errors.csv explaining them",

--- a/scripts/validate_cross_source_agreement.py
+++ b/scripts/validate_cross_source_agreement.py
@@ -35,6 +35,16 @@ BIG_RATIO = 10.0
 BASELINE_UNEXPLAINED = 0        # reachable today; a new one is a finding
 BASELINE_MIN_CELLS = 700        # 804 today. A floor, so the surface cannot quietly disappear.
 
+# Arm E. The key excludes `indicator` on purpose -- the column holds a measurement type for fao1952
+# and iia (`crops:production`) and a PAGE REFERENCE for mitchell (`page_12_table_1`), so keying on it
+# would split iia from mitchell on a field that does not mean the same thing in each and destroy the
+# comparison. `unit` already separates production from area.
+#
+# What would genuinely invalidate a cell is both sides being annotated and DISAGREEING, which is a
+# different test from "is the column in the key". Zero today: every mismatch is a null against a
+# mitchell page string.
+BASELINE_INDICATOR_CONFLICTS = 0
+
 
 def main() -> int:
     if not os.path.exists(TABLE):
@@ -47,7 +57,7 @@ def main() -> int:
         known_ids = {e["issue_id"] for e in csv.DictReader(fh)}
 
     problems = []
-    big, unexplained, dangling = [], [], []
+    big, unexplained, dangling, conflicts = [], [], [], []
     for r in rows:
         try:
             lo, hi, ratio = float(r["value_min"]), float(r["value_max"]), float(r["ratio"])
@@ -69,6 +79,11 @@ def main() -> int:
         for issue_id in filter(None, r["known_defect"].split(";")):
             if issue_id not in known_ids:
                 dangling.append(f"{r['polity_code']}/{r['item']}/{r['year']} -> {issue_id}")
+        # nulls are written as an empty segment, so a cell reads e.g. ";page_14_table_1"
+        annotated = {x for x in r.get("indicators", "").split(";") if x}
+        if len(annotated) > 1:
+            conflicts.append(f"{r['polity_code']}/{r['item']}/{r['year']}: "
+                             f"{sorted(annotated)} across {r['sources']}")
         if ratio >= BIG_RATIO:
             big.append(r)
             if not r["known_defect"]:
@@ -98,6 +113,14 @@ def main() -> int:
     elif len(unexplained) < BASELINE_UNEXPLAINED:
         problems.append(f"only {len(unexplained)} unexplained cell(s), below the ceiling of "
                         f"{BASELINE_UNEXPLAINED} -- lower it so the improvement is held")
+    print(f"  cells whose sources give DIFFERENT non-null indicators: {len(conflicts)} "
+          f"(ceiling {BASELINE_INDICATOR_CONFLICTS})")
+    if len(conflicts) > BASELINE_INDICATOR_CONFLICTS:
+        problems.append(
+            f"{len(conflicts)} cell(s) compare two sources that annotate DIFFERENT indicators, so "
+            f"the two numbers are not measuring the same thing and their ratio means nothing: "
+            + "; ".join(conflicts[:4]))
+
     if dangling:
         problems.append(
             f"{len(dangling)} cell(s) cite a data_errors entry that no longer exists, so the "


### PR DESCRIPTION
*PR by Claude.* A self-check on #591, prompted by #411.

## Why I went looking

#411's whole-and-parts case made me re-run my own disjointness test from #590 — which keyed on `(item, unit, year)` **without `indicator`**. This repo has published an error before by confusing `population total` with `population agricultural`, so a key that omits the column is exactly the shape worth distrusting. The gate I had just merged in #591 uses the same key.

## The key is right, for a reason I had not established

`indicator` holds a different **kind** of value per source:

```
fao1952, iia    crops:production, livestock:production   a measurement type
mitchell        page_12_table_1, page_38_table_1         a PAGE REFERENCE
```

Adding it to the key splits iia from mitchell on a field that does not mean the same thing in each, destroying exactly the comparisons the surface exists for — **53 of the 804 cells** pair a null indicator against a mitchell page string. And `unit` already separates production from area, which is what the column would otherwise be protecting against.

## Two probes lied to me on the way, both the same documented trap

```
groupby(key + ["indicator"])          ->    0 multi-source cells
groupby(..., dropna=False)            ->  751
```

**126,631 of 189,578 rows have a null `indicator`**, and `dropna=True` is the pandas default — so two thirds of the panel vanished and the answer read as *"the key needs no change"* for entirely the wrong reason. My follow-up check (*"do any cells mix indicators?"*) used `nunique()`, which **also** excludes nulls, and answered `0 of 804` when the true answer is 53.

Two independent checks agreeing on the wrong answer, for the same cause. Both are now recorded in the pipeline docstring, because the next person to look at this will reach for the same two functions.

## Arm E

Tests what would genuinely invalidate a cell — **both sides annotated and disagreeing** — rather than the presence of the column. Zero today: every mismatch is a null against a mitchell page string.

The table now publishes an `indicators` column so the gate can see it. Case 76 sets one cell to `crops:area;crops:production` while leaving the ratio, values, sources, count and recorded defect untouched, so nothing but the new arm moves. Verified firing by control before the case was written.

## Also re-verified

#590's Ruanda-Urundi conclusion under the stricter key: **still zero overlap at both granularities**, so that published claim stands. (For `DEU-1920-1938` the two counts are 22 and 28 — not comparable as magnitudes, since adding a key column splits tuples; both are non-zero, which is what matters.)

## Verification

- 85 `validate_*` gates pass; all 11 `--check` invocations pass
- `selftest_gates.py` **138/138** (was 137)