### PR TITLE
docs: state the faithful-territory principle — data attaches to a polity whose territory it describes (issue 400)

### DIFF
--- a/site/wiki/README.md
+++ b/site/wiki/README.md
@@ -78,6 +78,50 @@ Ingest implication: CShapes, Euratlas, Cliopatria, and historical atlases
 polity. COW, GW, Polity V, V-Dem (state-system-membership sources) can
 inform regime/status notes but **must not** drive start or end years.
 
+## Data attaches to a polity whose territory the data describes
+
+The other basis of this project, and the companion to the rule above: **data
+attaches to a faithful polity.** A polity row exists for the territory the
+numbers were actually collected on. Where the reporting territory is clearly
+different from every existing row's territory, **we need a polity for that
+territory** — not the nearest larger row carrying the data with a note. The
+full rule is in `wiki/log.md` 2026-08-31
+`decision-faithful-territory-for-reporting-units`
+([issue 400](https://github.com/eduaguilera/whep-polities/issues/400)). In
+short:
+
+- **A reporting unit does not have to have been a sovereign state to get a
+  row.** A customs union, a colony's civil zone as distinct from its military
+  territory, an occupation administration, a constituent republic of a
+  federation, a sub-federal territory inside a trust territory — each is a
+  WHEP polity if production or trade statistics were collected on it. This
+  follows from *territorial-economic unit, not Westphalian legal state*
+  above; it is written down separately because it was being re-decided case
+  by case instead of applied.
+- **Small approximations make sense; clear mismatches do not.** A polygon a
+  few percent off its territory, or a vintage that lags a minor border
+  adjustment, is an approximation — record it as one (`polygon_status: proxy`,
+  `polygon_vintage_drift`) and move on. A territory that differs by a *factor*
+  is a different territory. The three Algerian civil departments the yearbooks
+  measured are 575,511 km²; `DZA-1902-1919` including the Sahara is
+  2,442,844 km². That is a 4.2× per-km² error, and it is not an
+  approximation.
+- **"Best available" is not a resting place.** Routing data onto a territory
+  already known to be the wrong one, and recording that as best-available, is
+  the option that misleads: every per-km² figure derived from it — a yield, a
+  density, a constant-territory denominator — is wrong, and nothing in the
+  published data warns the consumer. Either create the faithful row, or mark
+  the rows as attributable to no polity. Do not route them to the nearest
+  larger row and leave them there.
+- **The test is the data's territory, not its sovereign.** Ask what ground the
+  numbers were collected on, then ask whether some row describes that ground.
+  If the answer is no, that is a polity-creation task, not a routing puzzle.
+
+Creating such a row is still a **structural change** — follow the
+structural-change checklist under *Workflows* below, and give the new page a
+`Data routing` section saying which source labels and years it takes over and
+from which row.
+
 ## Sister Wiki — WHEP Project Wiki
 
 This polities wiki is one of two LLM wikis in the WHEP project:
@@ -608,6 +652,14 @@ and the layer-B dataset; the human steps (writing the page, the `log.md`
    entry of `kind: decision`, a commit message with rationale). If no
    evidence exists, say so explicitly on the polity page and flag it as
    a candidate oddity.
+8. **Do not park data on a territory it does not describe.** When a source's
+   reporting unit is clearly a different territory from the row you would
+   route it to, the answer is a polity for that territory — see *Data attaches
+   to a polity whose territory the data describes* above. Small approximations
+   are fine and should be recorded as such; a factor-scale mismatch is a
+   polity-creation task, and the unit does not need to have been a sovereign
+   state to get a row. Never write it up as "best available" onto a territory
+   you have already established is the wrong one.
 
 ## Critical stance: audit, don't deferentially cite
 

--- a/site/wiki/log.md
+++ b/site/wiki/log.md
@@ -26,6 +26,56 @@ Kinds:
 
 ---
 
+## decision-faithful-territory-for-reporting-units
+**Date:** 2026-08-31
+**Touched:** DEU-1800-1866, DEU-1866-1871, DZA-1902-1919, F51-1938-1945,
+RWB-1922-1962, AZE-1991-2025, IND-1914-1937, SER-1918-1945 (none edited — this
+entry records the rule, not its application)
+**Source:** none
+**Kind:** decision
+
+**Data attaches to a faithful polity.** [Issue
+400](https://github.com/eduaguilera/whep-polities/issues/400) consolidated nine
+separately-investigated cases that all ended in the same sentence — the data is
+correctly identified and there is no polity to route it to — and asked whether
+this database admits polity rows for reporting units that were not sovereign
+states. It does. The owner's answer, verbatim:
+
+> the idea is the data is attached to a faithful polity. if the territory is
+> clearly different, we need a polity for that territory, thats another basis of
+> this project, so write that down. if its not clear, of course small
+> approximations make sense, but for the one you mentioned its clear we need a
+> separate territory defined.
+
+So the rule, now stated in `wiki/README.md` under *Data attaches to a polity
+whose territory the data describes* and as agent rule 8: a polity row exists for
+the territory the numbers were collected on. **A reporting unit does not have to
+have been a sovereign state to get a row** — a customs union, a colony's civil
+zone as distinct from its military territory, an occupation administration, a
+constituent republic of a federation, a sub-federal territory inside a trust
+territory all qualify if production or trade statistics were collected on them.
+Small approximations are acceptable and should be recorded as such
+(`polygon_status: proxy`, `polygon_vintage_drift`). A **clear** mismatch is not:
+the yearbooks' three Algerian civil departments are 575,511 km² against
+`DZA-1902-1919`'s 2,442,844 km² including the Sahara, a 4.2× per-km² error, and
+that is the case the answer names as clear. This is the companion to
+`decision-whep-polity-definition` (2026-04-11): that rule says a polity is a
+territory rather than a legal state, and this one says the *data's* territory is
+what a row has to match.
+
+The consequence for the ~840 rows issue 400 counted is that they are no longer
+blocked on a definition question. Each of the nine becomes an ordinary
+polity-creation task — and therefore a **structural change**, subject to the
+eleven-step checklist in `pipelines/polity-autoimprove/README.md`, because
+creating these rows silently re-routes the data that currently matches the
+larger polity. What is explicitly *not* licensed by this entry is bulk creation:
+each row still needs a page with sourced territorial extent, and several of the
+nine have a documented area from the source itself (IIA states 575,511 km² for
+northern Algeria) that the page should declare and cite rather than read off a
+polygon (issue 195). Nothing was created here; this entry is the rule only.
+
+Signed off by: Catalin Covaci. Written up by Claude (Claude Code), issue 400.
+
 ## decision-chl-pre-1884-clip-at-24s
 **Date:** 2026-08-17
 **Touched:** CHL-1810-1884

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -78,6 +78,50 @@ Ingest implication: CShapes, Euratlas, Cliopatria, and historical atlases
 polity. COW, GW, Polity V, V-Dem (state-system-membership sources) can
 inform regime/status notes but **must not** drive start or end years.
 
+## Data attaches to a polity whose territory the data describes
+
+The other basis of this project, and the companion to the rule above: **data
+attaches to a faithful polity.** A polity row exists for the territory the
+numbers were actually collected on. Where the reporting territory is clearly
+different from every existing row's territory, **we need a polity for that
+territory** — not the nearest larger row carrying the data with a note. The
+full rule is in `wiki/log.md` 2026-08-31
+`decision-faithful-territory-for-reporting-units`
+([issue 400](https://github.com/eduaguilera/whep-polities/issues/400)). In
+short:
+
+- **A reporting unit does not have to have been a sovereign state to get a
+  row.** A customs union, a colony's civil zone as distinct from its military
+  territory, an occupation administration, a constituent republic of a
+  federation, a sub-federal territory inside a trust territory — each is a
+  WHEP polity if production or trade statistics were collected on it. This
+  follows from *territorial-economic unit, not Westphalian legal state*
+  above; it is written down separately because it was being re-decided case
+  by case instead of applied.
+- **Small approximations make sense; clear mismatches do not.** A polygon a
+  few percent off its territory, or a vintage that lags a minor border
+  adjustment, is an approximation — record it as one (`polygon_status: proxy`,
+  `polygon_vintage_drift`) and move on. A territory that differs by a *factor*
+  is a different territory. The three Algerian civil departments the yearbooks
+  measured are 575,511 km²; `DZA-1902-1919` including the Sahara is
+  2,442,844 km². That is a 4.2× per-km² error, and it is not an
+  approximation.
+- **"Best available" is not a resting place.** Routing data onto a territory
+  already known to be the wrong one, and recording that as best-available, is
+  the option that misleads: every per-km² figure derived from it — a yield, a
+  density, a constant-territory denominator — is wrong, and nothing in the
+  published data warns the consumer. Either create the faithful row, or mark
+  the rows as attributable to no polity. Do not route them to the nearest
+  larger row and leave them there.
+- **The test is the data's territory, not its sovereign.** Ask what ground the
+  numbers were collected on, then ask whether some row describes that ground.
+  If the answer is no, that is a polity-creation task, not a routing puzzle.
+
+Creating such a row is still a **structural change** — follow the
+structural-change checklist under *Workflows* below, and give the new page a
+`Data routing` section saying which source labels and years it takes over and
+from which row.
+
 ## Sister Wiki — WHEP Project Wiki
 
 This polities wiki is one of two LLM wikis in the WHEP project:
@@ -608,6 +652,14 @@ and the layer-B dataset; the human steps (writing the page, the `log.md`
    entry of `kind: decision`, a commit message with rationale). If no
    evidence exists, say so explicitly on the polity page and flag it as
    a candidate oddity.
+8. **Do not park data on a territory it does not describe.** When a source's
+   reporting unit is clearly a different territory from the row you would
+   route it to, the answer is a polity for that territory — see *Data attaches
+   to a polity whose territory the data describes* above. Small approximations
+   are fine and should be recorded as such; a factor-scale mismatch is a
+   polity-creation task, and the unit does not need to have been a sovereign
+   state to get a row. Never write it up as "best available" onto a territory
+   you have already established is the wrong one.
 
 ## Critical stance: audit, don't deferentially cite
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -26,6 +26,56 @@ Kinds:
 
 ---
 
+## decision-faithful-territory-for-reporting-units
+**Date:** 2026-08-31
+**Touched:** DEU-1800-1866, DEU-1866-1871, DZA-1902-1919, F51-1938-1945,
+RWB-1922-1962, AZE-1991-2025, IND-1914-1937, SER-1918-1945 (none edited — this
+entry records the rule, not its application)
+**Source:** none
+**Kind:** decision
+
+**Data attaches to a faithful polity.** [Issue
+400](https://github.com/eduaguilera/whep-polities/issues/400) consolidated nine
+separately-investigated cases that all ended in the same sentence — the data is
+correctly identified and there is no polity to route it to — and asked whether
+this database admits polity rows for reporting units that were not sovereign
+states. It does. The owner's answer, verbatim:
+
+> the idea is the data is attached to a faithful polity. if the territory is
+> clearly different, we need a polity for that territory, thats another basis of
+> this project, so write that down. if its not clear, of course small
+> approximations make sense, but for the one you mentioned its clear we need a
+> separate territory defined.
+
+So the rule, now stated in `wiki/README.md` under *Data attaches to a polity
+whose territory the data describes* and as agent rule 8: a polity row exists for
+the territory the numbers were collected on. **A reporting unit does not have to
+have been a sovereign state to get a row** — a customs union, a colony's civil
+zone as distinct from its military territory, an occupation administration, a
+constituent republic of a federation, a sub-federal territory inside a trust
+territory all qualify if production or trade statistics were collected on them.
+Small approximations are acceptable and should be recorded as such
+(`polygon_status: proxy`, `polygon_vintage_drift`). A **clear** mismatch is not:
+the yearbooks' three Algerian civil departments are 575,511 km² against
+`DZA-1902-1919`'s 2,442,844 km² including the Sahara, a 4.2× per-km² error, and
+that is the case the answer names as clear. This is the companion to
+`decision-whep-polity-definition` (2026-04-11): that rule says a polity is a
+territory rather than a legal state, and this one says the *data's* territory is
+what a row has to match.
+
+The consequence for the ~840 rows issue 400 counted is that they are no longer
+blocked on a definition question. Each of the nine becomes an ordinary
+polity-creation task — and therefore a **structural change**, subject to the
+eleven-step checklist in `pipelines/polity-autoimprove/README.md`, because
+creating these rows silently re-routes the data that currently matches the
+larger polity. What is explicitly *not* licensed by this entry is bulk creation:
+each row still needs a page with sourced territorial extent, and several of the
+nine have a documented area from the source itself (IIA states 575,511 km² for
+northern Algeria) that the page should declare and cite rather than read off a
+polygon (issue 195). Nothing was created here; this entry is the rule only.
+
+Signed off by: Catalin Covaci. Written up by Claude (Claude Code), issue 400.
+
 ## decision-chl-pre-1884-clip-at-24s
 **Date:** 2026-08-17
 **Touched:** CHL-1810-1884


### PR DESCRIPTION
*PR created by Claude (Claude Code). Docs only — no polity created, no pipeline, gate, CSV or polygon touched.*

Closes the decision half of #400.

## What #400 asked

#400 consolidated nine cases that had each been investigated separately, by different routes, and each ended in the same sentence: **the data is correctly identified and there is no polity to route it to.** Roughly 840 rows sit on a polity whose territory is demonstrably not what the data measures. The worst is `DZA-1902-1919`: 397 rows whose yearbooks measured the three Algerian civil departments (575,511 km²) sit on a 2,442,844 km² polity including the Sahara — a **4.2× per-km² error** with nothing in the published data to warn the consumer.

Nothing in the repo forbade a row for a non-sovereign reporting unit (`F248`, `F51`, `MASG`, `IDN-JVM-1949-1951` already do something close), but nothing stated it either, so each case was decided ad hoc and mostly deferred.

## The answer, and where it now lives

The owner has answered: **data attaches to a faithful polity; where the territory is clearly different we need a polity for that territory; small approximations make sense, but a clear mismatch needs a separate territory defined.** The verbatim answer is quoted in the log entry.

Written down in the two places it will actually be read:

| where | what |
| --- | --- |
| `wiki/README.md` — new section *Data attaches to a polity whose territory the data describes*, immediately after *What a WHEP polity is* | the principle itself, as the companion to the definition rule it follows from |
| `wiki/README.md` — *Rules for the agent*, new rule 8 | the operative form, so the ingest/query/lint/autonomous workflows honour it |
| `wiki/log.md` — `decision-faithful-territory-for-reporting-units`, 2026-08-31 | the full rule and the verbatim answer, beside `decision-whep-polity-definition` (2026-04-11) which `wiki/README.md` already points to for the load-bearing definition |

The four points stated:

1. **A reporting unit does not have to have been a sovereign state to get a row** — a customs union, a colony's civil zone as distinct from its military territory, an occupation administration, a constituent republic of a federation, a sub-federal territory inside a trust territory.
2. **Small approximations make sense; clear mismatches do not.** A polygon a few percent off, or a vintage lagging a minor border adjustment, is an approximation — record it (`polygon_status: proxy`, `polygon_vintage_drift`). A factor-scale difference is a different territory.
3. **"Best available" is not a resting place.** Routing onto a territory already established as wrong is the option that misleads, because every per-km² figure derived from it is wrong and silent about it. Either create the faithful row or mark the rows attributable to no polity.
4. **The test is the data's territory, not its sovereign.**

The new section also records that creating such a row is a **structural change**, subject to the eleven-step checklist in `pipelines/polity-autoimprove/README.md`, since it silently re-routes the rows currently matching the larger polity.

## Checks

Run against this branch:

* `scripts/validate_citations.py` — PASS (2,614 citations, 0 unresolvable source files, 0 unresolvable anchors)
* `scripts/validate_constants.py` — PASS, including its own read of `wiki/README.md` (`polygon_status` values documented: 5 of 5)
* `scripts/validate_code_year_agreement.py` — PASS (1 pre-existing baselined disagreement, `TAN-1922-1964`, untouched)

* `scripts/validate_site_outputs.py` — PASS **after a fix**. The first push failed here: `site/wiki/README.md` and `site/wiki/log.md` are *committed copies* of the two files this PR edits, produced by `site/build_wiki.sh` step 4, and the gate correctly reported both STALE. Commit `190a1a4` regenerates them by the same plain `cp` the script performs. `site/polities.csv` and `site/polities.geojson` are deliberately untouched and stay byte-identical to `main`, so the PR is still docs-only.
* `scripts/validate_declared_sources.py`, `scripts/validate_year_semantics.py`, `scripts/validate_coexisting_overlaps.py` — PASS (the other gates that read `wiki/README.md` or `wiki/log.md`)
* `scripts/build_database.py --check` — PASS (781 rows from 781 pages; the committed CSV and GeoPackage still match the wiki)

Every polity code named in the new log entry was checked against `data/final/polities_database.csv`. The first draft cited `AZE-1918-1922`, which does not exist — #400's Transcaucasian-SFSR case currently lands on `AZE-1991-2025`, and the entry says so.

## Deliberately not in this PR

* **No polity created.** Nine polity-creation tasks are now unblocked and each needs its own page with sourced territorial extent; one of them is already being worked separately.
* **No decision on whether to declare source-stated areas.** Several of the nine have an area stated by the source itself (IIA gives 575,511 km² for northern Algeria), which is the `polygon_area_source` question in #195, not this one.
* **No claim about which of the nine is easiest or should go first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ

