### PR TITLE
Issue 366's five-way classification lived only in a comment; make it reproducible and gate it

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -457,6 +457,18 @@ jobs:
         if: '!cancelled()'
         run: python3 scripts/validate_constant_runs.py
 
+      # And is each of those runs innocent? A source whose grid in that unit and era is coarser than
+      # the run's constant prints the same figure every year without anybody filling a gap -- the
+      # ground on which issue 366's headline was withdrawn. 17_constant_runs.py joins
+      # source_value_precision.csv (#446) and writes a verdict per run: 68 EXPLAINED, 153 UNDETERMINED
+      # (all juan, whose ha and tonnes are both `mixed`), 11 REFUTED, 4 OFF-GRID, 10 NOT ATTRIBUTABLE.
+      # The 15 refuted and off-grid runs are the residue the issue exists to isolate, and the split
+      # lived only in a comment until this gate; the counts and those 15 identities are pinned, and
+      # every verdict is re-derived from the other table so the two cannot drift apart.
+      - name: Sources — a constant run's verdict must re-derive from its source's measured precision
+        if: '!cancelled()'
+        run: python3 scripts/validate_constant_run_verdicts.py
+
       # 05_magnitude_screen.py screens series MEDIANS against polity area, so a single bad year is
       # invisible to it: iia cameroon groundnuts runs 61,000 / 620,004,098 / 62,000 ha and its median
       # is 71,000, while Cameroon's whole land area is ~47.5M ha. No source seam either -- spike and

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ python3 scripts/validate_source_conventions.py     # the conventions registry: w
 python3 scripts/validate_iia_label_provenance.py   # 335 raw IIA labels -> 173 countries: no equality claim on a label that mixes territories
 python3 scripts/validate_source_splices.py         # a series spliced across sources must not change scale at the seam
 python3 scripts/validate_constant_runs.py           # a value repeated for years must not outlive the resolution that refutes it, and a same-volume witness must not be cross-era
+python3 scripts/validate_constant_run_verdicts.py   # and each such run's verdict must re-derive from its source's measured reporting grid: 68 explained, 153 undetermined, 11 refuted, 4 off-grid, 10 not attributable
 python3 scripts/validate_isolated_spikes.py         # no single year may read many times its own neighbours
 python3 scripts/validate_same_polity_overlaps.py   # two labels of one source may not collide on one polity's cells
 python3 scripts/validate_era_shift_verdicts.py     # post-1933 tobacco/hops verdicts must match their own numbers

--- a/pipelines/polity-autoimprove/17_constant_runs.py
+++ b/pipelines/polity-autoimprove/17_constant_runs.py
@@ -41,6 +41,50 @@ bare run: a real constant would not sit in a series that resolves finer than it.
 A run is counted over consecutive OBSERVATIONS, not consecutive years, since the panel is not
 gap-free; `year_first`/`year_last` give the real span and `n_values` the number of rows.
 
+IS THE RUN A RESOLUTION LIMIT AFTER ALL? THE `verdict` COLUMN (issue 366). Everything above tests a
+run against its OWN series, which cannot see the one explanation that would exonerate it: a source
+whose reporting grid in that unit and era is coarser than the run's constant prints the same figure
+every year without anybody filling a gap. Issue 366's headline argument was withdrawn on exactly that
+ground, and `state/source_value_precision.csv` (issue 446, written by 37_value_precision.py) is the
+table that answers it -- it measures, per (source, unit, era), what share of non-zero values sit on a
+1000- and a 100-grid and reduces that to `coarse_1000` / `coarse_100` / `mixed` / `fine`.
+
+Joining the two settles each run five ways, which is what `verdict` records:
+
+    EXPLAINED         the era's grid is coarse and the constant sits ON it, so rounding produces it
+    UNDETERMINED      the era is `mixed`: the grid COULD account for the run, but the source also
+                      reports finer there, so nothing is settled either way
+    REFUTED           the era is `fine`: that source demonstrably reports finer in this unit, so the
+                      grid is not available as an explanation
+    OFF-GRID          the era's grid is coarse but the constant is NOT a multiple of it, so rounding
+                      to that grid cannot produce the constant however coarse the era is
+    NOT ATTRIBUTABLE  the run straddles the source's own era boundary, so it has no single grid
+
+`precision_era` and `precision_grid` record WHICH row of the precision table the verdict was read
+from and what grid that row implies, so the judgement is legible without re-deriving the join.
+
+THE ERA PARTITION IS READ OFF THE PRECISION TABLE, NOT RESTATED HERE. 37_value_precision.py splits
+only `iia`, and only because its 1934 volume handover is independently registered (#445); the cut is
+recovered from the `<year>+` era labels the table carries, so removing or moving the split there
+cannot leave a stale boundary here. A run whose years fall on both sides of the cut is
+NOT ATTRIBUTABLE rather than being assigned to the era it spends more years in: the panel carries no
+volume provenance, so which volume printed the run's flat years is not knowable from the row.
+
+WHAT THE VERDICT IS NOT. `coarse_1000` is a statement about a SOURCE, not about a cell -- 96.3% of
+`iia` `ha` values from 1934 sit on the 1000-grid, not 100% -- so EXPLAINED means "consistent with the
+grid", never "measured". Nor is REFUTED a repair: a run that is not a rounding artifact may still be a
+real plateau, a carried-forward figure or a filled gap, and separating those needs the source page.
+
+WHAT THE RUN THAT ADDED THE VERDICT MEASURED (2026-08-31), reproducing by code the classification
+that had lived only in a comment on issue 366:
+
+     68  EXPLAINED          iia 54, mitchell 11, juan 3 (its `heads`)
+    153  UNDETERMINED       all `juan` -- its `ha` and `tonnes` are both `mixed`
+     11  REFUTED            all `iia`, all pre-1934, where `ha` is 9.8% on a 1000-grid
+      4  OFF-GRID           iia australia/new zealand hops 500/200 ha on a 1000 grid, france eggs
+                            5.390 t and madagascar wine 291 t on a 100 grid
+     10  NOT ATTRIBUTABLE   iia runs crossing 1934
+
 Usage:
   python3 pipelines/polity-autoimprove/17_constant_runs.py            # report only
   python3 pipelines/polity-autoimprove/17_constant_runs.py --write    # refresh the tracked table
@@ -118,6 +162,64 @@ IIA_AMBIGUOUS_YEARS = frozenset(
 
 def _iia_volumes_covering(year: int) -> set:
     return {i for i, (a, b) in enumerate(IIA_VOLUMES) if a <= year <= b}
+
+
+# THE PRECISION JOIN (issue 366). See the docstring for the five verdicts.
+PRECISION = os.path.join(HERE, "state/source_value_precision.csv")
+
+# The precision table's verdict word -> the grid, in the series' own unit, that it asserts. `mixed`
+# and `fine` name no single grid, which is why they are absent rather than mapped to 1.
+ERA_GRID = {"coarse_1000": 1000, "coarse_100": 100}
+
+
+def load_precision(path: str):
+    """-> {(source, unit, era): verdict}, {source: era cut year}.
+
+    The cut is RECOVERED from the era labels rather than restated, so this file cannot hold a
+    boundary 37_value_precision.py has moved. A source with two cuts would make `era_of` ambiguous
+    and is refused rather than guessed at.
+    """
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    prec = {(r["source"], r["unit"], r["era"]): r["verdict"] for r in rows}
+    cuts = defaultdict(set)
+    for r in rows:
+        m = re.fullmatch(r"(\d{4})\+", r["era"])
+        if m:
+            cuts[r["source"]].add(int(m.group(1)))
+    for src, cs in cuts.items():
+        if len(cs) != 1:
+            raise SystemExit(f"{os.path.basename(path)}: {src} carries {len(cs)} era cuts {sorted(cs)};"
+                             f" a run spanning two of them has no single grid to be judged against")
+    return prec, {src: cs.pop() for src, cs in cuts.items()}
+
+
+def judge(row: dict, prec: dict, cuts: dict) -> dict:
+    """The five-way verdict for one run, plus the precision row it was read from."""
+    src, unit = row["source"], row["unit"]
+    cut = cuts.get(src)
+    if cut is None:
+        era = "all"
+    elif int(row["year_first"]) < cut <= int(row["year_last"]):
+        # No volume provenance in the panel, so a run crossing the cut cannot be assigned to either
+        # side, and the two sides have different grids. Assigning it by majority of years would
+        # invent the provenance the row does not carry.
+        return {"verdict": "NOT ATTRIBUTABLE", "precision_era": f"straddles-{cut}",
+                "precision_grid": ""}
+    else:
+        era = f"{cut}+" if int(row["year_first"]) >= cut else f"pre-{cut}"
+    word = prec.get((src, unit, era))
+    if word is None:
+        # Below 37_value_precision.py's MIN_ROWS the source's grid in this unit and era is not
+        # measured, so the innocent explanation is neither available nor excluded.
+        return {"verdict": "UNDETERMINED", "precision_era": era, "precision_grid": "unmeasured"}
+    grid = ERA_GRID.get(word)
+    if grid is None:
+        return {"verdict": "UNDETERMINED" if word == "mixed" else "REFUTED",
+                "precision_era": era, "precision_grid": word}
+    on_grid = int(round(float(row["constant"]) * SCALE)) % (grid * SCALE) == 0
+    return {"verdict": "EXPLAINED" if on_grid else "OFF-GRID",
+            "precision_era": era, "precision_grid": str(grid)}
 
 
 def find_runs(panel_path):
@@ -205,7 +307,15 @@ def main() -> int:
         print(f"SKIP: layer-B panel not present at {args.layer_b}")
         return 0
 
+    if not os.path.exists(PRECISION):
+        print(f"MISSING {os.path.relpath(PRECISION, REPO)}; run 37_value_precision.py --write first",
+              file=sys.stderr)
+        return 1
+    prec, cuts = load_precision(PRECISION)
+
     rows, n_series, n_runs_all, n_rows_all = find_runs(args.layer_b)
+    for r in rows:
+        r.update(judge(r, prec, cuts))
     print(f"series (country, item, unit, source) with >={MIN_SERIES} values: {n_series:,}")
     print(f"constant runs of >={MIN_RUN} identical values: {n_runs_all:,} ({n_rows_all:,} rows)")
     print(f"  refuted as rounding by their own series: {len(rows):,} "
@@ -214,6 +324,10 @@ def main() -> int:
     print("  by source:",
           dict(Counter({s: sum(r["n_values"] for r in rows if r["source"] == s)
                         for s in {r["source"] for r in rows}}).most_common()))
+    print("  against each source's own reporting grid (issue 366):")
+    for v, n in sorted(Counter(r["verdict"] for r in rows).items(), key=lambda kv: -kv[1]):
+        print(f"    {n:>4}  {v:17} "
+              f"{dict(Counter(r['source'] for r in rows if r['verdict'] == v).most_common())}")
     print("\nlongest refuted runs (the series resolves finer than the value it repeats):")
     for r in rows[:14]:
         print(f"   {r['source']:9} {r['country'][:17]:18} {r['item'][:21]:22} {r['unit']:7} "
@@ -224,7 +338,8 @@ def main() -> int:
     if args.write or args.check:
         cols = ["source", "country", "item", "unit", "constant", "n_values", "year_first",
                 "year_last", "series_n", "grid", "finest_elsewhere", "n_finer_elsewhere",
-                "finer_in_volume_year", "finer_in_volume_value"]
+                "finer_in_volume_year", "finer_in_volume_value", "verdict", "precision_era",
+                "precision_grid"]
         if args.check:
             if not os.path.exists(OUT):
                 print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)

--- a/pipelines/polity-autoimprove/README.md
+++ b/pipelines/polity-autoimprove/README.md
@@ -324,6 +324,16 @@ verify_assertions      one economic-historian agent per pending assertion ->
                        54,100. 246 runs, 1,619 rows, 210 series (juan 1,035, iia 522, mitchell 62;
                        fao1952 nil, as its values are non-integer and have no coarse grid to sit
                        on). --write refreshes state/constant_runs.csv for validate_constant_runs.py
+                       and validate_constant_run_verdicts.py. Each run also carries a `verdict`
+                       joined from state/source_value_precision.csv (37_value_precision.py), which
+                       answers the one explanation a series cannot test against itself — a source
+                       whose grid in that unit and era is coarser than the constant prints the same
+                       figure every year with nothing filled in. 68 EXPLAINED, 153 UNDETERMINED (all
+                       juan: its ha and tonnes are both `mixed`), 11 REFUTED, 4 OFF-GRID, 10 NOT
+                       ATTRIBUTABLE for runs straddling iia's 1934 boundary. `precision_era` and
+                       `precision_grid` record which row of the precision table each verdict was
+                       read from; the era cut is recovered from that table's own labels rather than
+                       restated here
 18_isolated_spikes.py  does one year read many times its own neighbours? 05_magnitude_screen.py
                        screens series MEDIANS, so a single bad year is invisible to it: iia
                        cameroon groundnuts runs 61,000 / 620,004,098 / 62,000 ha, median 71,000,

--- a/pipelines/polity-autoimprove/state/constant_runs.csv
+++ b/pipelines/polity-autoimprove/state/constant_runs.csv
@@ -1,247 +1,247 @@
-source,country,item,unit,constant,n_values,year_first,year_last,series_n,grid,finest_elsewhere,n_finer_elsewhere,finer_in_volume_year,finer_in_volume_value
-juan,iceland,potatoes,ha,1000.000,20,1933,1957,21,1000,400.000,1,,
-juan,malta,grapes,ha,1000.000,20,1933,1956,33,1000,600.000,11,,
-juan,luxembourg,grapes,ha,1000.000,17,1933,1959,45,1000,1200.000,28,,
-juan,norway,wheat,ha,5000.000,15,1900,1914,64,1000,4300.000,20,,
-juan,colombia,cocoa beans,tonnes,3000.000,14,1901,1914,60,1000,3670.900,21,,
-juan,luxembourg,grain mixed,ha,1000.000,14,1939,1953,38,1000,2400.000,11,,
-juan,costa rica,tobacco unmanufactured,ha,1000.000,13,1939,1955,32,1000,417.000,15,,
-juan,switzerland,tobacco unmanufactured,ha,1000.000,13,1933,1945,59,1000,100.000,34,,
-juan,malta,barley,ha,2000.000,12,1943,1956,47,1000,1700.000,22,,
-juan,malta,wheat,ha,2000.000,12,1944,1959,45,1000,3500.000,22,,
-juan,switzerland,tobacco unmanufactured,ha,1000.000,12,1948,1959,59,1000,100.000,34,,
-iia,australia,lemons and limes,ha,2000.000,11,1933,1944,14,1000,896.000,3,1930,896.000
-iia,grenada,cotton lint,tonnes,100.000,11,1935,1945,31,100,16.200,18,,
-iia,new zealand,tobacco unmanufactured,ha,1000.000,11,1934,1945,20,1000,11.000,9,,
-juan,italy,sesame seed,ha,1000.000,11,1945,1955,26,1000,337.000,10,,
-juan,switzerland,maize,ha,1000.000,11,1930,1940,53,1000,1100.000,23,,
-iia,india,sesame seed,ha,1000.000,10,1934,1945,18,1000,2016349.000,8,,
-iia,south africa,tea,ha,1000.000,10,1933,1943,27,1000,785.000,17,1930,799.000
-iia,viet nam,cotton lint,tonnes,100.000,10,1934,1944,14,100,20.000,4,,
-juan,argentina,soybeans,ha,1000.000,10,1950,1960,19,1000,2.000,9,,
-juan,denmark,potatoes,ha,54000.000,10,1902,1911,85,1000,54100.000,21,,
-iia,australia,wine,ha,20000.000,9,1935,1944,16,10000,18787.000,7,1934,19000.000
-iia,niger,tobacco unmanufactured,ha,1000.000,9,1934,1944,13,1000,200.000,4,,
-iia,saint lucia,lemons and limes,ha,1000.000,9,1934,1945,12,1000,1070.000,3,,
-iia,saint vincent and the grenadines,cacao beans,ha,400.000,9,1909,1917,18,100,305.000,2,,
-iia,trinidad and tobago,coffee green,ha,1700.000,9,1909,1917,20,100,320.000,7,1919,3593.000
-juan,denmark,potatoes,ha,52000.000,9,1888,1896,85,1000,54100.000,21,,
-juan,france,hemp tow waste,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,
-juan,france,hempseed,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,
-juan,mexico,cocoa beans,tonnes,1000.000,9,1901,1909,60,1000,547.200,33,,
-juan,switzerland,grapes,ha,11000.000,9,1940,1948,66,1000,12300.000,29,,
-iia,cyprus,flax fibre and tow,ha,1000.000,8,1934,1942,12,1000,349.000,4,,
-iia,dominica,lemons and limes,ha,1000.000,8,1936,1944,12,1000,400.000,4,,
-iia,fiji,tea,ha,80.000,8,1911,1918,15,10,81.000,6,1909,82.000
-iia,guadeloupe,cacao beans,ha,3000.000,8,1930,1937,22,1000,4750.000,1,,
-iia,india,sesame seed,tonnes,300.000,8,1934,1943,18,100,425723.700,8,,
-iia,sri lanka,cacao beans,ha,14000.000,8,1930,1937,20,1000,9461.000,12,,
-iia,viet nam,cotton lint,ha,1000.000,8,1934,1942,14,1000,997.000,4,,
-iia,viet nam,cotton seed,ha,1000.000,8,1934,1942,14,1000,997.000,4,,
-iia,viet nam,other berries and fruits of the genus vaccinium n e c,ha,2000.000,8,1934,1942,14,1000,2611.000,4,,
-juan,austria,beans dry,tonnes,2000.000,8,1950,1958,25,1000,1600.000,10,,
-juan,ireland,rye,ha,1000.000,8,1933,1941,56,1000,900.000,32,,
-juan,italy,groundnuts with shell,ha,5000.000,8,1953,1960,26,1000,200.000,1,,
-juan,italy,oranges,ha,33000.000,8,1935,1942,27,1000,32679.000,15,,
-juan,malta,barley,ha,2000.000,8,1933,1940,47,1000,1700.000,22,,
-juan,malta,wheat,tonnes,3000.000,8,1949,1959,45,1000,270.000,34,,
-juan,malta,wheat,ha,4000.000,8,1933,1940,45,1000,3500.000,22,,
-juan,mexico,cocoa beans,tonnes,2000.000,8,1910,1917,60,1000,547.200,33,,
-juan,nicaragua,tobacco unmanufactured,ha,1000.000,8,1933,1959,12,1000,1048.000,3,,
-juan,spain,apricots,ha,3700.000,8,1939,1946,98,100,925.650,76,,
-iia,algeria,rye,ha,2000.000,7,1938,1944,33,1000,91.000,21,,
-iia,algeria,tangerines mandarins clementines satsumas,ha,5000.000,7,1937,1944,14,1000,3453.000,3,,
-iia,cameroon,cacao beans,ha,50000.000,7,1939,1945,15,10000,12140.000,5,,
-iia,guadeloupe,cotton seed,tonnes,100.000,7,1935,1941,15,100,12.000,7,,
-iia,guyana,coffee green,ha,1000.000,7,1939,1945,31,1000,514.000,20,,
-iia,ivory coast,tobacco unmanufactured,ha,2000.000,7,1934,1943,11,1000,85.000,2,,
-iia,malta,wine,ha,1000.000,7,1934,1945,15,1000,651.000,8,,
-iia,montserrat,lemons and limes,tonnes,600.000,7,1939,1945,15,100,241.900,3,,
-iia,new caledonia,coffee green,ha,4000.000,7,1939,1945,16,1000,700.000,2,,
-iia,portugal,oranges,tonnes,100.000,7,1939,1945,11,100,30.000,3,,
-iia,saint lucia,cacao beans,ha,2400.000,7,1910,1916,28,100,2145.000,1,,
-iia,viet nam,groundnuts with shell,ha,2000.000,7,1934,1941,14,1000,1270.000,4,,
-juan,albania,potatoes,ha,1000.000,7,1937,1951,12,1000,400.000,3,,
-juan,argentina,soybeans,tonnes,1000.000,7,1951,1960,15,1000,270.000,8,,
-juan,austria,grapes,ha,207000.000,7,1878,1884,92,1000,29600.000,28,,
-juan,austria,hemp tow waste,ha,1000.000,7,1940,1953,38,1000,100.000,30,,
-juan,austria,hempseed,ha,1000.000,7,1940,1953,38,1000,100.000,30,,
-juan,bolivia,tobacco unmanufactured,tonnes,1000.000,7,1954,1960,10,1000,4100.000,1,,
-juan,bulgaria,berries nes,ha,4000.000,7,1933,1939,24,1000,2306.000,10,,
-juan,canada,hops,ha,400.000,7,1953,1959,42,100,135.000,20,,
-juan,chile,rye,ha,8000.000,7,1954,1960,50,1000,1064.000,26,,
-juan,costa rica,potatoes,ha,1000.000,7,1939,1945,19,1000,692.000,8,,
-juan,ecuador,cotton lint,tonnes,3000.000,7,1954,1960,17,1000,1400.000,7,,
-juan,france,hops,ha,3000.000,7,1886,1892,86,1000,300.000,57,,
-juan,honduras,potatoes,ha,1000.000,7,1953,1959,13,1000,1661.000,1,,
-juan,hungary,hops,ha,100.000,7,1932,1938,33,100,2226.248,4,,
-juan,norway,barley,ha,35900.000,7,1907,1913,64,100,50433.000,4,,
-juan,norway,rye,ha,13000.000,7,1900,1906,64,1000,500.000,26,,
-juan,norway,rye,ha,15000.000,7,1907,1913,64,1000,500.000,26,,
-juan,sweden,wheat,ha,71000.000,7,1890,1896,96,1000,78900.000,31,,
-juan,switzerland,maize,ha,1000.000,7,1953,1959,53,1000,1100.000,23,,
-juan,switzerland,sugar beet,ha,6000.000,7,1953,1959,52,1000,400.000,29,,
-mitchell,dr congo,goats,heads,500000.000,7,1919,1925,26,100000,1109000.000,19,,
-mitchell,mozambique,sugar cane,ha,30000.000,7,1949,1955,14,10000,16000.000,7,,
-iia,australia,hops,ha,500.000,6,1939,1944,28,100,47.000,17,,
-iia,australia,oranges,ha,14000.000,6,1939,1944,14,1000,15366.000,3,,
-iia,bulgaria,other berries and fruits of the genus vaccinium n e c,ha,4000.000,6,1934,1939,19,1000,2306.000,8,,
-iia,congo,cacao beans,tonnes,1700.000,6,1940,1945,17,100,73.700,6,,
-iia,czech republic,hemp tow waste,ha,5000.000,6,1939,1944,10,1000,477.000,3,,
-iia,czech republic,hempseed,ha,5000.000,6,1939,1944,17,1000,6228.000,8,,
-iia,egypt,grapes,ha,3000.000,6,1934,1939,25,1000,1716.000,15,,
-iia,france,eggs hen in shell,tonnes,5.390,6,1939,1944,10,0.01,7.762,2,,
-iia,grenada,cotton lint,ha,2000.000,6,1933,1938,18,1000,1291.000,12,1930,1600.000
-iia,grenada,cotton seed,ha,2000.000,6,1933,1938,12,1000,1310.000,6,1930,1600.000
-iia,guadeloupe,coffee green,ha,7000.000,6,1918,1930,23,1000,6508.000,4,1911,6508.000
-iia,madagascar,cacao beans,ha,1000.000,6,1940,1945,9,1000,1067.000,3,,
-iia,montserrat,sugar raw centrifugal,tonnes,400.000,6,1939,1944,13,100,56.000,2,,
-iia,morocco,tobacco unmanufactured,ha,1000.000,6,1939,1944,10,1000,92.000,4,,
-iia,new zealand,hops,ha,200.000,6,1939,1944,27,100,144.000,17,,
-iia,saint lucia,cacao beans,ha,2000.000,6,1933,1939,28,1000,2145.000,17,1930,2400.000
-iia,saint lucia,cacao beans,tonnes,300.000,6,1933,1939,31,100,307.700,20,1930,529.300
-iia,saint lucia,lemons and limes,tonnes,100.000,6,1939,1944,14,100,6988.300,3,,
-iia,saint vincent and the grenadines,cotton lint,ha,2000.000,6,1936,1941,33,1000,271.000,21,,
-iia,saint vincent and the grenadines,cotton seed,ha,2000.000,6,1936,1941,20,1000,271.000,8,,
-iia,suriname,oranges,ha,1000.000,6,1939,1944,9,1000,86.000,3,,
-iia,thailand,sesame seed,ha,1000.000,6,1933,1939,16,1000,771.000,5,1930,883.000
-iia,zimbabwe,groundnuts with shell,ha,2000.000,6,1935,1941,18,1000,1992.000,6,,
-juan,albania,tobacco unmanufactured,ha,2000.000,6,1934,1939,18,1000,800.000,3,,
-juan,austria,hemp tow waste,tonnes,100.000,6,1933,1939,46,100,140.000,21,,
-juan,belgium,rapeseed,tonnes,100.000,6,1933,1941,47,100,80.000,22,,
-juan,brazil,tea,tonnes,700.000,6,1953,1958,21,100,236.000,11,,
-juan,canada,grapes,ha,9000.000,6,1951,1957,16,1000,3969.000,7,,
-juan,chile,hemp tow waste,ha,4000.000,6,1952,1958,32,1000,61.000,13,,
-juan,chile,hempseed,ha,4000.000,6,1952,1958,33,1000,61.000,14,,
-juan,costa rica,oranges,tonnes,1000.000,6,1946,1951,16,1000,100.000,10,,
-juan,czechoslovakia,hemp tow waste,ha,5000.000,6,1939,1944,37,1000,10.117,17,,
-juan,czechoslovakia,hempseed,ha,5000.000,6,1939,1944,37,1000,10.117,17,,
-juan,dominican republic,geese and guinea fowls,heads,1000.000,6,1947,1952,7,1000,3400.000,1,,
-juan,france,hemp tow waste,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,
-juan,france,hempseed,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,
-juan,france,hops,ha,1400.000,6,1953,1958,86,100,3090.000,8,,
-juan,france,oranges,tonnes,1000.000,6,1954,1959,32,1000,100.000,17,,
-juan,france,tangerines mandarins clementines satsumas,tonnes,300.000,6,1934,1940,18,100,70.000,7,,
-juan,haiti,cotton lint,tonnes,1000.000,6,1954,1959,40,1000,1302.000,26,,
-juan,ireland,rye,ha,1000.000,6,1954,1959,56,1000,900.000,32,,
-juan,italy,lemons and limes,ha,27750.000,6,1935,1940,27,10,30628.000,8,,
-juan,malta,maize,tonnes,100.000,6,1937,1943,15,100,110.000,2,,
-juan,mexico,broad beans horse beans dry,tonnes,19000.000,6,1946,1951,34,1000,7372.240,21,,
-juan,mexico,lentils,tonnes,3000.000,6,1953,1959,27,1000,399.983,16,,
-juan,mexico,lentils,ha,4000.000,6,1953,1959,27,1000,1262.000,16,,
-juan,netherlands,grapes,ha,1000.000,6,1946,1951,12,1000,400.000,6,,
-juan,norway,barley,ha,39500.000,6,1901,1906,64,100,50433.000,4,,
-juan,paraguay,potatoes,ha,1000.000,6,1940,1960,10,1000,70.000,4,,
-juan,spain,olives,ha,1123000.000,6,1891,1896,98,1000,869150.000,73,,
-juan,sweden,flax fibre and tow,tonnes,100.000,6,1933,1940,50,100,80.000,23,,
-juan,switzerland,barley,ha,4000.000,6,1933,1938,57,1000,5100.000,21,,
-juan,switzerland,cereals nes,ha,12000.000,6,1933,1938,52,1000,4500.000,32,,
-juan,switzerland,grain mixed,ha,7000.000,6,1933,1938,35,1000,2900.000,11,,
-juan,uruguay,rice paddy,ha,5000.000,6,1936,1942,28,1000,390.000,3,,
-juan,uruguay,sugar beet,ha,1000.000,6,1934,1941,25,1000,607.000,9,,
-juan,uruguay,tobacco unmanufactured,ha,1000.000,6,1934,1941,35,1000,253.000,26,,
-juan,yugoslav sfr,linseed,tonnes,1000.000,6,1951,1959,22,1000,300.000,12,,
-juan,yugoslav sfr,sesame seed,ha,1000.000,6,1934,1939,20,1000,200.000,4,,
-mitchell,cameroon,cattle,heads,1250000.000,6,1951,1956,35,10000,291000.000,17,,
-mitchell,jamaica,goats,heads,350000.000,6,1950,1955,10,10000,224000.000,4,,
-mitchell,sri lanka,rice paddy,ha,340000.000,6,1931,1936,99,10000,135000.000,83,,
-iia,angola,sesame seed,ha,2000.000,5,1937,1942,10,1000,2047.000,2,,
-iia,austria,n,tonnes,24000.000,5,1914,1918,12,1000,4500.000,6,1912,4500.000
-iia,chile,raisins,tonnes,2000.000,5,1939,1943,8,1000,800.000,3,1944,800.000
-iia,cyprus,sesame seed,ha,1000.000,5,1941,1945,20,1000,562.000,8,,
-iia,czech republic,yarn of true hemp,ha,7000.000,5,1934,1938,13,1000,6240.000,8,,
-iia,egypt,oranges,ha,10000.000,5,1938,1944,13,10000,5325.000,8,1934,9000.000
-iia,grenada,cotton seed,tonnes,300.000,5,1935,1939,18,100,276.000,6,,
-iia,guadeloupe,cacao beans,ha,5000.000,5,1918,1925,22,1000,4750.000,1,1912,4750.000
-iia,kenya,tea,ha,6000.000,5,1939,1943,15,1000,4068.000,4,,
-iia,madagascar,wine,tonnes,291.000,5,1934,1941,12,1,261.900,2,,
-iia,malawi,tea,ha,8000.000,5,1941,1945,32,1000,210.000,21,,
-iia,martinique,cacao beans,tonnes,100.000,5,1941,1945,29,100,171.900,18,,
-iia,mauritius,tea,ha,150.000,5,1911,1915,24,10,45.000,4,1916,125.000
-iia,mauritius,tea,tonnes,38.000,5,1911,1915,27,1,16.200,1,,
-iia,papua new guinea,cacao beans,ha,1000.000,5,1933,1937,15,1000,238.000,10,1930,402.000
-iia,saint kitts and nevis,cotton lint,ha,2000.000,5,1936,1940,33,1000,154.000,20,,
-iia,saint kitts and nevis,cotton seed,ha,2000.000,5,1936,1940,20,1000,154.000,7,,
-iia,saint lucia,cacao beans,ha,2400.000,5,1922,1930,28,100,2145.000,1,,
-iia,saint lucia,cacao beans,ha,1000.000,5,1940,1944,28,1000,2145.000,17,,
-iia,saint lucia,cacao beans,tonnes,200.000,5,1940,1944,31,100,307.700,20,,
-iia,serbia,sesame seed,ha,1000.000,5,1934,1938,10,1000,350.000,4,,
-iia,sri lanka,tobacco unmanufactured,ha,6000.000,5,1934,1938,22,1000,5109.000,17,,
-iia,united states of america,n,tonnes,58000.000,5,1914,1918,15,1000,62131.000,4,,
-iia,viet nam,coffee green,ha,2000.000,5,1939,1943,13,1000,3190.000,4,,
-juan,argentina,cotton lint,tonnes,400.000,5,1906,1910,61,100,540.000,15,,
-juan,austria,grapes,ha,40000.000,5,1941,1945,92,10000,27000.000,85,,
-juan,belgium,cherries,tonnes,30000.000,5,1952,1956,9,10000,12000.000,1,,
-juan,belgium,tobacco unmanufactured,ha,3000.000,5,1933,1937,52,1000,1400.000,24,,
-juan,belgium,tobacco unmanufactured,ha,1000.000,5,1955,1959,52,1000,1400.000,24,,
-juan,bulgaria,berries nes,ha,4000.000,5,1941,1945,24,1000,2306.000,10,,
-juan,bulgaria,grapes,ha,146000.000,5,1947,1954,56,1000,43400.000,25,,
-juan,chile,grapes,ha,108000.000,5,1955,1960,54,1000,29680.000,25,,
-juan,colombia,cocoa beans,tonnes,4000.000,5,1919,1923,60,1000,3670.900,21,,
-juan,costa rica,sugar cane,tonnes,3000.000,5,1910,1914,26,1000,28240.000,8,,
-juan,costa rica,sugar cane,tonnes,5000.000,5,1919,1923,26,1000,28240.000,8,,
-juan,cuba,grapefruit inc pomelos,tonnes,7000.000,5,1954,1958,21,1000,1178.300,9,,
-juan,czechoslovakia,hemp tow waste,ha,7000.000,5,1934,1938,37,1000,10.117,17,,
-juan,czechoslovakia,hempseed,ha,7000.000,5,1934,1938,37,1000,10.117,17,,
-juan,czechoslovakia,tobacco unmanufactured,ha,10000.000,5,1933,1937,35,10000,1200.000,28,,
-juan,denmark,barley,ha,233700.000,5,1907,1911,85,100,269804.000,4,,
-juan,denmark,rye,ha,276000.000,5,1907,1911,85,1000,120325.000,26,,
-juan,dominican republic,horses,heads,242000.000,5,1955,1959,20,1000,114733.000,6,,
-juan,ecuador,rye,tonnes,4000.000,5,1956,1960,15,1000,3700.000,3,,
-juan,el salvador,tobacco unmanufactured,ha,1000.000,5,1955,1959,15,1000,400.000,5,,
-juan,finland,sugar beet,ha,3000.000,5,1933,1937,42,1000,600.000,9,,
-juan,france,hops,ha,2000.000,5,1896,1900,86,1000,300.000,57,,
-juan,france,lentils,ha,6000.000,5,1926,1930,51,1000,6471.000,16,,
-juan,france,tobacco unmanufactured,ha,16000.000,5,1895,1899,88,1000,7900.000,42,,
-juan,germany,grapes,ha,120000.000,5,1883,1887,78,10000,53000.000,70,,
-juan,germany,hemp tow waste,ha,1000.000,5,1949,1954,41,1000,200.000,17,,
-juan,germany,hempseed,ha,1000.000,5,1949,1954,41,1000,200.000,17,,
-juan,guatemala,groundnuts with shell,ha,1000.000,5,1939,1944,8,1000,5.000,3,,
-juan,haiti,coffee green,ha,141600.000,5,1928,1932,19,100,141690.000,1,,
-juan,haiti,horses,heads,400000.000,5,1932,1939,10,100000,110000.000,5,,
-juan,honduras,potatoes,tonnes,2000.000,5,1955,1959,12,1000,10474.200,1,,
-juan,ireland,flax fibre and tow,ha,2000.000,5,1935,1939,58,1000,100.000,37,,
-juan,ireland,linseed,ha,2000.000,5,1935,1939,58,1000,100.000,37,,
-juan,ireland,rye,tonnes,3000.000,5,1950,1955,56,1000,1300.000,43,,
-juan,italy,groundnuts with shell,ha,1000.000,5,1936,1940,26,1000,200.000,1,,
-juan,italy,groundnuts with shell,ha,4000.000,5,1948,1952,26,1000,200.000,1,,
-juan,italy,lentils,ha,26000.000,5,1950,1954,26,1000,20557.000,11,,
-juan,italy,linseed,tonnes,12000.000,5,1947,1951,52,1000,2200.000,34,,
-juan,italy,sesame seed,tonnes,300.000,5,1940,1944,26,100,373.900,1,,
-juan,italy,sesame seed,ha,2000.000,5,1956,1960,26,1000,337.000,10,,
-juan,italy,soybeans,ha,1000.000,5,1949,1953,25,1000,6.000,15,,
-juan,italy,soybeans,ha,300.000,5,1955,1959,25,100,6.000,9,,
-juan,italy,tangerines mandarins clementines satsumas,ha,10250.000,5,1941,1945,27,10,7766.000,5,,
-juan,luxembourg,rye,ha,4000.000,5,1955,1959,48,1000,4100.000,24,,
-juan,malta,potatoes,ha,4000.000,5,1936,1940,49,1000,1300.000,23,,
-juan,mexico,cocoa beans,tonnes,2000.000,5,1919,1923,60,1000,547.200,33,,
-juan,mexico,lentils,tonnes,2000.000,5,1946,1951,27,1000,399.983,16,,
-juan,mexico,lentils,ha,3000.000,5,1946,1951,27,1000,1262.000,16,,
-juan,mexico,peas dry,ha,7000.000,5,1946,1955,24,1000,3480.000,16,,
-juan,mexico,sweet potatoes,ha,12000.000,5,1948,1953,33,1000,5405.000,21,,
-juan,norway,grain mixed,ha,4000.000,5,1947,1951,48,1000,5400.000,15,,
-juan,norway,grain mixed,ha,2000.000,5,1956,1960,48,1000,5400.000,15,,
-juan,norway,rye,ha,6000.000,5,1933,1937,64,1000,500.000,26,,
-juan,norway,rye,ha,1000.000,5,1947,1951,64,1000,500.000,26,,
-juan,norway,rye,ha,1000.000,5,1953,1957,64,1000,500.000,26,,
-juan,paraguay,coffee green,tonnes,100.000,5,1940,1944,20,100,72.500,14,,
-juan,paraguay,groundnuts with shell,tonnes,10000.000,5,1954,1958,29,10000,4000.000,24,,
-juan,puerto rico,grapefruit inc pomelos,tonnes,19000.000,5,1948,1953,25,1000,300.000,11,,
-juan,puerto rico,rice paddy,tonnes,2000.000,5,1955,1959,14,1000,800.000,3,,
-juan,spain,carobs,ha,152000.000,5,1950,1954,98,1000,96333.495,76,,
-juan,spain,cherries,ha,1000.000,5,1941,1945,98,1000,271.845,93,,
-juan,spain,millet,ha,1000.000,5,1955,1959,101,1000,34.792,96,,
-juan,spain,plums and sloes,ha,2400.000,5,1948,1952,98,100,353.571,75,,
-juan,spain,tangerines mandarins clementines satsumas,tonnes,71900.000,5,1939,1943,98,100,23280.161,92,,
-juan,sweden,flax fibre and tow,ha,500.000,5,1929,1933,52,100,2722.000,1,,
-juan,sweden,tobacco unmanufactured,tonnes,300.000,5,1950,1955,55,100,384.000,40,,
-juan,switzerland,maize,tonnes,4000.000,5,1953,1957,53,1000,2100.000,35,,
-juan,united states of america,oil olive virgin,tonnes,700.000,5,1932,1936,46,100,192.913,16,,
-juan,uruguay,grapes,ha,18000.000,5,1943,1949,52,1000,3610.000,29,,
-juan,yugoslav sfr,rice paddy,ha,3000.000,5,1934,1938,29,1000,1100.000,8,,
-mitchell,australia,rice paddy,ha,10000.000,5,1937,1941,35,10000,1000.000,27,,
-mitchell,dr congo,sheep,heads,300000.000,5,1919,1923,26,100000,244000.000,20,,
-mitchell,indonesia,tea,tonnes,1000.000,5,1858,1862,104,1000,700.000,39,,
-mitchell,lebanon,wheat,ha,70000.000,5,1953,1957,20,10000,53000.000,11,,
-mitchell,senegal,rice paddy,ha,50000.000,5,1922,1926,37,10000,31000.000,24,,
-mitchell,sierra leone,rice paddy,tonnes,190000.000,5,1940,1944,42,10000,102000.000,30,,
+source,country,item,unit,constant,n_values,year_first,year_last,series_n,grid,finest_elsewhere,n_finer_elsewhere,finer_in_volume_year,finer_in_volume_value,verdict,precision_era,precision_grid
+juan,iceland,potatoes,ha,1000.000,20,1933,1957,21,1000,400.000,1,,,UNDETERMINED,all,mixed
+juan,malta,grapes,ha,1000.000,20,1933,1956,33,1000,600.000,11,,,UNDETERMINED,all,mixed
+juan,luxembourg,grapes,ha,1000.000,17,1933,1959,45,1000,1200.000,28,,,UNDETERMINED,all,mixed
+juan,norway,wheat,ha,5000.000,15,1900,1914,64,1000,4300.000,20,,,UNDETERMINED,all,mixed
+juan,colombia,cocoa beans,tonnes,3000.000,14,1901,1914,60,1000,3670.900,21,,,UNDETERMINED,all,mixed
+juan,luxembourg,grain mixed,ha,1000.000,14,1939,1953,38,1000,2400.000,11,,,UNDETERMINED,all,mixed
+juan,costa rica,tobacco unmanufactured,ha,1000.000,13,1939,1955,32,1000,417.000,15,,,UNDETERMINED,all,mixed
+juan,switzerland,tobacco unmanufactured,ha,1000.000,13,1933,1945,59,1000,100.000,34,,,UNDETERMINED,all,mixed
+juan,malta,barley,ha,2000.000,12,1943,1956,47,1000,1700.000,22,,,UNDETERMINED,all,mixed
+juan,malta,wheat,ha,2000.000,12,1944,1959,45,1000,3500.000,22,,,UNDETERMINED,all,mixed
+juan,switzerland,tobacco unmanufactured,ha,1000.000,12,1948,1959,59,1000,100.000,34,,,UNDETERMINED,all,mixed
+iia,australia,lemons and limes,ha,2000.000,11,1933,1944,14,1000,896.000,3,1930,896.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,grenada,cotton lint,tonnes,100.000,11,1935,1945,31,100,16.200,18,,,EXPLAINED,1934+,100
+iia,new zealand,tobacco unmanufactured,ha,1000.000,11,1934,1945,20,1000,11.000,9,,,EXPLAINED,1934+,1000
+juan,italy,sesame seed,ha,1000.000,11,1945,1955,26,1000,337.000,10,,,UNDETERMINED,all,mixed
+juan,switzerland,maize,ha,1000.000,11,1930,1940,53,1000,1100.000,23,,,UNDETERMINED,all,mixed
+iia,india,sesame seed,ha,1000.000,10,1934,1945,18,1000,2016349.000,8,,,EXPLAINED,1934+,1000
+iia,south africa,tea,ha,1000.000,10,1933,1943,27,1000,785.000,17,1930,799.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,viet nam,cotton lint,tonnes,100.000,10,1934,1944,14,100,20.000,4,,,EXPLAINED,1934+,100
+juan,argentina,soybeans,ha,1000.000,10,1950,1960,19,1000,2.000,9,,,UNDETERMINED,all,mixed
+juan,denmark,potatoes,ha,54000.000,10,1902,1911,85,1000,54100.000,21,,,UNDETERMINED,all,mixed
+iia,australia,wine,ha,20000.000,9,1935,1944,16,10000,18787.000,7,1934,19000.000,EXPLAINED,1934+,1000
+iia,niger,tobacco unmanufactured,ha,1000.000,9,1934,1944,13,1000,200.000,4,,,EXPLAINED,1934+,1000
+iia,saint lucia,lemons and limes,ha,1000.000,9,1934,1945,12,1000,1070.000,3,,,EXPLAINED,1934+,1000
+iia,saint vincent and the grenadines,cacao beans,ha,400.000,9,1909,1917,18,100,305.000,2,,,REFUTED,pre-1934,fine
+iia,trinidad and tobago,coffee green,ha,1700.000,9,1909,1917,20,100,320.000,7,1919,3593.000,REFUTED,pre-1934,fine
+juan,denmark,potatoes,ha,52000.000,9,1888,1896,85,1000,54100.000,21,,,UNDETERMINED,all,mixed
+juan,france,hemp tow waste,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,,UNDETERMINED,all,mixed
+juan,france,hempseed,ha,4000.000,9,1936,1944,89,1000,2300.000,33,,,UNDETERMINED,all,mixed
+juan,mexico,cocoa beans,tonnes,1000.000,9,1901,1909,60,1000,547.200,33,,,UNDETERMINED,all,mixed
+juan,switzerland,grapes,ha,11000.000,9,1940,1948,66,1000,12300.000,29,,,UNDETERMINED,all,mixed
+iia,cyprus,flax fibre and tow,ha,1000.000,8,1934,1942,12,1000,349.000,4,,,EXPLAINED,1934+,1000
+iia,dominica,lemons and limes,ha,1000.000,8,1936,1944,12,1000,400.000,4,,,EXPLAINED,1934+,1000
+iia,fiji,tea,ha,80.000,8,1911,1918,15,10,81.000,6,1909,82.000,REFUTED,pre-1934,fine
+iia,guadeloupe,cacao beans,ha,3000.000,8,1930,1937,22,1000,4750.000,1,,,NOT ATTRIBUTABLE,straddles-1934,
+iia,india,sesame seed,tonnes,300.000,8,1934,1943,18,100,425723.700,8,,,EXPLAINED,1934+,100
+iia,sri lanka,cacao beans,ha,14000.000,8,1930,1937,20,1000,9461.000,12,,,NOT ATTRIBUTABLE,straddles-1934,
+iia,viet nam,cotton lint,ha,1000.000,8,1934,1942,14,1000,997.000,4,,,EXPLAINED,1934+,1000
+iia,viet nam,cotton seed,ha,1000.000,8,1934,1942,14,1000,997.000,4,,,EXPLAINED,1934+,1000
+iia,viet nam,other berries and fruits of the genus vaccinium n e c,ha,2000.000,8,1934,1942,14,1000,2611.000,4,,,EXPLAINED,1934+,1000
+juan,austria,beans dry,tonnes,2000.000,8,1950,1958,25,1000,1600.000,10,,,UNDETERMINED,all,mixed
+juan,ireland,rye,ha,1000.000,8,1933,1941,56,1000,900.000,32,,,UNDETERMINED,all,mixed
+juan,italy,groundnuts with shell,ha,5000.000,8,1953,1960,26,1000,200.000,1,,,UNDETERMINED,all,mixed
+juan,italy,oranges,ha,33000.000,8,1935,1942,27,1000,32679.000,15,,,UNDETERMINED,all,mixed
+juan,malta,barley,ha,2000.000,8,1933,1940,47,1000,1700.000,22,,,UNDETERMINED,all,mixed
+juan,malta,wheat,tonnes,3000.000,8,1949,1959,45,1000,270.000,34,,,UNDETERMINED,all,mixed
+juan,malta,wheat,ha,4000.000,8,1933,1940,45,1000,3500.000,22,,,UNDETERMINED,all,mixed
+juan,mexico,cocoa beans,tonnes,2000.000,8,1910,1917,60,1000,547.200,33,,,UNDETERMINED,all,mixed
+juan,nicaragua,tobacco unmanufactured,ha,1000.000,8,1933,1959,12,1000,1048.000,3,,,UNDETERMINED,all,mixed
+juan,spain,apricots,ha,3700.000,8,1939,1946,98,100,925.650,76,,,UNDETERMINED,all,mixed
+iia,algeria,rye,ha,2000.000,7,1938,1944,33,1000,91.000,21,,,EXPLAINED,1934+,1000
+iia,algeria,tangerines mandarins clementines satsumas,ha,5000.000,7,1937,1944,14,1000,3453.000,3,,,EXPLAINED,1934+,1000
+iia,cameroon,cacao beans,ha,50000.000,7,1939,1945,15,10000,12140.000,5,,,EXPLAINED,1934+,1000
+iia,guadeloupe,cotton seed,tonnes,100.000,7,1935,1941,15,100,12.000,7,,,EXPLAINED,1934+,100
+iia,guyana,coffee green,ha,1000.000,7,1939,1945,31,1000,514.000,20,,,EXPLAINED,1934+,1000
+iia,ivory coast,tobacco unmanufactured,ha,2000.000,7,1934,1943,11,1000,85.000,2,,,EXPLAINED,1934+,1000
+iia,malta,wine,ha,1000.000,7,1934,1945,15,1000,651.000,8,,,EXPLAINED,1934+,1000
+iia,montserrat,lemons and limes,tonnes,600.000,7,1939,1945,15,100,241.900,3,,,EXPLAINED,1934+,100
+iia,new caledonia,coffee green,ha,4000.000,7,1939,1945,16,1000,700.000,2,,,EXPLAINED,1934+,1000
+iia,portugal,oranges,tonnes,100.000,7,1939,1945,11,100,30.000,3,,,EXPLAINED,1934+,100
+iia,saint lucia,cacao beans,ha,2400.000,7,1910,1916,28,100,2145.000,1,,,REFUTED,pre-1934,fine
+iia,viet nam,groundnuts with shell,ha,2000.000,7,1934,1941,14,1000,1270.000,4,,,EXPLAINED,1934+,1000
+juan,albania,potatoes,ha,1000.000,7,1937,1951,12,1000,400.000,3,,,UNDETERMINED,all,mixed
+juan,argentina,soybeans,tonnes,1000.000,7,1951,1960,15,1000,270.000,8,,,UNDETERMINED,all,mixed
+juan,austria,grapes,ha,207000.000,7,1878,1884,92,1000,29600.000,28,,,UNDETERMINED,all,mixed
+juan,austria,hemp tow waste,ha,1000.000,7,1940,1953,38,1000,100.000,30,,,UNDETERMINED,all,mixed
+juan,austria,hempseed,ha,1000.000,7,1940,1953,38,1000,100.000,30,,,UNDETERMINED,all,mixed
+juan,bolivia,tobacco unmanufactured,tonnes,1000.000,7,1954,1960,10,1000,4100.000,1,,,UNDETERMINED,all,mixed
+juan,bulgaria,berries nes,ha,4000.000,7,1933,1939,24,1000,2306.000,10,,,UNDETERMINED,all,mixed
+juan,canada,hops,ha,400.000,7,1953,1959,42,100,135.000,20,,,UNDETERMINED,all,mixed
+juan,chile,rye,ha,8000.000,7,1954,1960,50,1000,1064.000,26,,,UNDETERMINED,all,mixed
+juan,costa rica,potatoes,ha,1000.000,7,1939,1945,19,1000,692.000,8,,,UNDETERMINED,all,mixed
+juan,ecuador,cotton lint,tonnes,3000.000,7,1954,1960,17,1000,1400.000,7,,,UNDETERMINED,all,mixed
+juan,france,hops,ha,3000.000,7,1886,1892,86,1000,300.000,57,,,UNDETERMINED,all,mixed
+juan,honduras,potatoes,ha,1000.000,7,1953,1959,13,1000,1661.000,1,,,UNDETERMINED,all,mixed
+juan,hungary,hops,ha,100.000,7,1932,1938,33,100,2226.248,4,,,UNDETERMINED,all,mixed
+juan,norway,barley,ha,35900.000,7,1907,1913,64,100,50433.000,4,,,UNDETERMINED,all,mixed
+juan,norway,rye,ha,13000.000,7,1900,1906,64,1000,500.000,26,,,UNDETERMINED,all,mixed
+juan,norway,rye,ha,15000.000,7,1907,1913,64,1000,500.000,26,,,UNDETERMINED,all,mixed
+juan,sweden,wheat,ha,71000.000,7,1890,1896,96,1000,78900.000,31,,,UNDETERMINED,all,mixed
+juan,switzerland,maize,ha,1000.000,7,1953,1959,53,1000,1100.000,23,,,UNDETERMINED,all,mixed
+juan,switzerland,sugar beet,ha,6000.000,7,1953,1959,52,1000,400.000,29,,,UNDETERMINED,all,mixed
+mitchell,dr congo,goats,heads,500000.000,7,1919,1925,26,100000,1109000.000,19,,,EXPLAINED,all,1000
+mitchell,mozambique,sugar cane,ha,30000.000,7,1949,1955,14,10000,16000.000,7,,,EXPLAINED,all,1000
+iia,australia,hops,ha,500.000,6,1939,1944,28,100,47.000,17,,,OFF-GRID,1934+,1000
+iia,australia,oranges,ha,14000.000,6,1939,1944,14,1000,15366.000,3,,,EXPLAINED,1934+,1000
+iia,bulgaria,other berries and fruits of the genus vaccinium n e c,ha,4000.000,6,1934,1939,19,1000,2306.000,8,,,EXPLAINED,1934+,1000
+iia,congo,cacao beans,tonnes,1700.000,6,1940,1945,17,100,73.700,6,,,EXPLAINED,1934+,100
+iia,czech republic,hemp tow waste,ha,5000.000,6,1939,1944,10,1000,477.000,3,,,EXPLAINED,1934+,1000
+iia,czech republic,hempseed,ha,5000.000,6,1939,1944,17,1000,6228.000,8,,,EXPLAINED,1934+,1000
+iia,egypt,grapes,ha,3000.000,6,1934,1939,25,1000,1716.000,15,,,EXPLAINED,1934+,1000
+iia,france,eggs hen in shell,tonnes,5.390,6,1939,1944,10,0.01,7.762,2,,,OFF-GRID,1934+,100
+iia,grenada,cotton lint,ha,2000.000,6,1933,1938,18,1000,1291.000,12,1930,1600.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,grenada,cotton seed,ha,2000.000,6,1933,1938,12,1000,1310.000,6,1930,1600.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,guadeloupe,coffee green,ha,7000.000,6,1918,1930,23,1000,6508.000,4,1911,6508.000,REFUTED,pre-1934,fine
+iia,madagascar,cacao beans,ha,1000.000,6,1940,1945,9,1000,1067.000,3,,,EXPLAINED,1934+,1000
+iia,montserrat,sugar raw centrifugal,tonnes,400.000,6,1939,1944,13,100,56.000,2,,,EXPLAINED,1934+,100
+iia,morocco,tobacco unmanufactured,ha,1000.000,6,1939,1944,10,1000,92.000,4,,,EXPLAINED,1934+,1000
+iia,new zealand,hops,ha,200.000,6,1939,1944,27,100,144.000,17,,,OFF-GRID,1934+,1000
+iia,saint lucia,cacao beans,ha,2000.000,6,1933,1939,28,1000,2145.000,17,1930,2400.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,saint lucia,cacao beans,tonnes,300.000,6,1933,1939,31,100,307.700,20,1930,529.300,NOT ATTRIBUTABLE,straddles-1934,
+iia,saint lucia,lemons and limes,tonnes,100.000,6,1939,1944,14,100,6988.300,3,,,EXPLAINED,1934+,100
+iia,saint vincent and the grenadines,cotton lint,ha,2000.000,6,1936,1941,33,1000,271.000,21,,,EXPLAINED,1934+,1000
+iia,saint vincent and the grenadines,cotton seed,ha,2000.000,6,1936,1941,20,1000,271.000,8,,,EXPLAINED,1934+,1000
+iia,suriname,oranges,ha,1000.000,6,1939,1944,9,1000,86.000,3,,,EXPLAINED,1934+,1000
+iia,thailand,sesame seed,ha,1000.000,6,1933,1939,16,1000,771.000,5,1930,883.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,zimbabwe,groundnuts with shell,ha,2000.000,6,1935,1941,18,1000,1992.000,6,,,EXPLAINED,1934+,1000
+juan,albania,tobacco unmanufactured,ha,2000.000,6,1934,1939,18,1000,800.000,3,,,UNDETERMINED,all,mixed
+juan,austria,hemp tow waste,tonnes,100.000,6,1933,1939,46,100,140.000,21,,,UNDETERMINED,all,mixed
+juan,belgium,rapeseed,tonnes,100.000,6,1933,1941,47,100,80.000,22,,,UNDETERMINED,all,mixed
+juan,brazil,tea,tonnes,700.000,6,1953,1958,21,100,236.000,11,,,UNDETERMINED,all,mixed
+juan,canada,grapes,ha,9000.000,6,1951,1957,16,1000,3969.000,7,,,UNDETERMINED,all,mixed
+juan,chile,hemp tow waste,ha,4000.000,6,1952,1958,32,1000,61.000,13,,,UNDETERMINED,all,mixed
+juan,chile,hempseed,ha,4000.000,6,1952,1958,33,1000,61.000,14,,,UNDETERMINED,all,mixed
+juan,costa rica,oranges,tonnes,1000.000,6,1946,1951,16,1000,100.000,10,,,UNDETERMINED,all,mixed
+juan,czechoslovakia,hemp tow waste,ha,5000.000,6,1939,1944,37,1000,10.117,17,,,UNDETERMINED,all,mixed
+juan,czechoslovakia,hempseed,ha,5000.000,6,1939,1944,37,1000,10.117,17,,,UNDETERMINED,all,mixed
+juan,dominican republic,geese and guinea fowls,heads,1000.000,6,1947,1952,7,1000,3400.000,1,,,EXPLAINED,all,1000
+juan,france,hemp tow waste,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,,UNDETERMINED,all,mixed
+juan,france,hempseed,ha,2000.000,6,1954,1959,89,1000,2300.000,33,,,UNDETERMINED,all,mixed
+juan,france,hops,ha,1400.000,6,1953,1958,86,100,3090.000,8,,,UNDETERMINED,all,mixed
+juan,france,oranges,tonnes,1000.000,6,1954,1959,32,1000,100.000,17,,,UNDETERMINED,all,mixed
+juan,france,tangerines mandarins clementines satsumas,tonnes,300.000,6,1934,1940,18,100,70.000,7,,,UNDETERMINED,all,mixed
+juan,haiti,cotton lint,tonnes,1000.000,6,1954,1959,40,1000,1302.000,26,,,UNDETERMINED,all,mixed
+juan,ireland,rye,ha,1000.000,6,1954,1959,56,1000,900.000,32,,,UNDETERMINED,all,mixed
+juan,italy,lemons and limes,ha,27750.000,6,1935,1940,27,10,30628.000,8,,,UNDETERMINED,all,mixed
+juan,malta,maize,tonnes,100.000,6,1937,1943,15,100,110.000,2,,,UNDETERMINED,all,mixed
+juan,mexico,broad beans horse beans dry,tonnes,19000.000,6,1946,1951,34,1000,7372.240,21,,,UNDETERMINED,all,mixed
+juan,mexico,lentils,tonnes,3000.000,6,1953,1959,27,1000,399.983,16,,,UNDETERMINED,all,mixed
+juan,mexico,lentils,ha,4000.000,6,1953,1959,27,1000,1262.000,16,,,UNDETERMINED,all,mixed
+juan,netherlands,grapes,ha,1000.000,6,1946,1951,12,1000,400.000,6,,,UNDETERMINED,all,mixed
+juan,norway,barley,ha,39500.000,6,1901,1906,64,100,50433.000,4,,,UNDETERMINED,all,mixed
+juan,paraguay,potatoes,ha,1000.000,6,1940,1960,10,1000,70.000,4,,,UNDETERMINED,all,mixed
+juan,spain,olives,ha,1123000.000,6,1891,1896,98,1000,869150.000,73,,,UNDETERMINED,all,mixed
+juan,sweden,flax fibre and tow,tonnes,100.000,6,1933,1940,50,100,80.000,23,,,UNDETERMINED,all,mixed
+juan,switzerland,barley,ha,4000.000,6,1933,1938,57,1000,5100.000,21,,,UNDETERMINED,all,mixed
+juan,switzerland,cereals nes,ha,12000.000,6,1933,1938,52,1000,4500.000,32,,,UNDETERMINED,all,mixed
+juan,switzerland,grain mixed,ha,7000.000,6,1933,1938,35,1000,2900.000,11,,,UNDETERMINED,all,mixed
+juan,uruguay,rice paddy,ha,5000.000,6,1936,1942,28,1000,390.000,3,,,UNDETERMINED,all,mixed
+juan,uruguay,sugar beet,ha,1000.000,6,1934,1941,25,1000,607.000,9,,,UNDETERMINED,all,mixed
+juan,uruguay,tobacco unmanufactured,ha,1000.000,6,1934,1941,35,1000,253.000,26,,,UNDETERMINED,all,mixed
+juan,yugoslav sfr,linseed,tonnes,1000.000,6,1951,1959,22,1000,300.000,12,,,UNDETERMINED,all,mixed
+juan,yugoslav sfr,sesame seed,ha,1000.000,6,1934,1939,20,1000,200.000,4,,,UNDETERMINED,all,mixed
+mitchell,cameroon,cattle,heads,1250000.000,6,1951,1956,35,10000,291000.000,17,,,EXPLAINED,all,1000
+mitchell,jamaica,goats,heads,350000.000,6,1950,1955,10,10000,224000.000,4,,,EXPLAINED,all,1000
+mitchell,sri lanka,rice paddy,ha,340000.000,6,1931,1936,99,10000,135000.000,83,,,EXPLAINED,all,1000
+iia,angola,sesame seed,ha,2000.000,5,1937,1942,10,1000,2047.000,2,,,EXPLAINED,1934+,1000
+iia,austria,n,tonnes,24000.000,5,1914,1918,12,1000,4500.000,6,1912,4500.000,REFUTED,pre-1934,fine
+iia,chile,raisins,tonnes,2000.000,5,1939,1943,8,1000,800.000,3,1944,800.000,EXPLAINED,1934+,100
+iia,cyprus,sesame seed,ha,1000.000,5,1941,1945,20,1000,562.000,8,,,EXPLAINED,1934+,1000
+iia,czech republic,yarn of true hemp,ha,7000.000,5,1934,1938,13,1000,6240.000,8,,,EXPLAINED,1934+,1000
+iia,egypt,oranges,ha,10000.000,5,1938,1944,13,10000,5325.000,8,1934,9000.000,EXPLAINED,1934+,1000
+iia,grenada,cotton seed,tonnes,300.000,5,1935,1939,18,100,276.000,6,,,EXPLAINED,1934+,100
+iia,guadeloupe,cacao beans,ha,5000.000,5,1918,1925,22,1000,4750.000,1,1912,4750.000,REFUTED,pre-1934,fine
+iia,kenya,tea,ha,6000.000,5,1939,1943,15,1000,4068.000,4,,,EXPLAINED,1934+,1000
+iia,madagascar,wine,tonnes,291.000,5,1934,1941,12,1,261.900,2,,,OFF-GRID,1934+,100
+iia,malawi,tea,ha,8000.000,5,1941,1945,32,1000,210.000,21,,,EXPLAINED,1934+,1000
+iia,martinique,cacao beans,tonnes,100.000,5,1941,1945,29,100,171.900,18,,,EXPLAINED,1934+,100
+iia,mauritius,tea,ha,150.000,5,1911,1915,24,10,45.000,4,1916,125.000,REFUTED,pre-1934,fine
+iia,mauritius,tea,tonnes,38.000,5,1911,1915,27,1,16.200,1,,,REFUTED,pre-1934,fine
+iia,papua new guinea,cacao beans,ha,1000.000,5,1933,1937,15,1000,238.000,10,1930,402.000,NOT ATTRIBUTABLE,straddles-1934,
+iia,saint kitts and nevis,cotton lint,ha,2000.000,5,1936,1940,33,1000,154.000,20,,,EXPLAINED,1934+,1000
+iia,saint kitts and nevis,cotton seed,ha,2000.000,5,1936,1940,20,1000,154.000,7,,,EXPLAINED,1934+,1000
+iia,saint lucia,cacao beans,ha,2400.000,5,1922,1930,28,100,2145.000,1,,,REFUTED,pre-1934,fine
+iia,saint lucia,cacao beans,ha,1000.000,5,1940,1944,28,1000,2145.000,17,,,EXPLAINED,1934+,1000
+iia,saint lucia,cacao beans,tonnes,200.000,5,1940,1944,31,100,307.700,20,,,EXPLAINED,1934+,100
+iia,serbia,sesame seed,ha,1000.000,5,1934,1938,10,1000,350.000,4,,,EXPLAINED,1934+,1000
+iia,sri lanka,tobacco unmanufactured,ha,6000.000,5,1934,1938,22,1000,5109.000,17,,,EXPLAINED,1934+,1000
+iia,united states of america,n,tonnes,58000.000,5,1914,1918,15,1000,62131.000,4,,,REFUTED,pre-1934,fine
+iia,viet nam,coffee green,ha,2000.000,5,1939,1943,13,1000,3190.000,4,,,EXPLAINED,1934+,1000
+juan,argentina,cotton lint,tonnes,400.000,5,1906,1910,61,100,540.000,15,,,UNDETERMINED,all,mixed
+juan,austria,grapes,ha,40000.000,5,1941,1945,92,10000,27000.000,85,,,UNDETERMINED,all,mixed
+juan,belgium,cherries,tonnes,30000.000,5,1952,1956,9,10000,12000.000,1,,,UNDETERMINED,all,mixed
+juan,belgium,tobacco unmanufactured,ha,3000.000,5,1933,1937,52,1000,1400.000,24,,,UNDETERMINED,all,mixed
+juan,belgium,tobacco unmanufactured,ha,1000.000,5,1955,1959,52,1000,1400.000,24,,,UNDETERMINED,all,mixed
+juan,bulgaria,berries nes,ha,4000.000,5,1941,1945,24,1000,2306.000,10,,,UNDETERMINED,all,mixed
+juan,bulgaria,grapes,ha,146000.000,5,1947,1954,56,1000,43400.000,25,,,UNDETERMINED,all,mixed
+juan,chile,grapes,ha,108000.000,5,1955,1960,54,1000,29680.000,25,,,UNDETERMINED,all,mixed
+juan,colombia,cocoa beans,tonnes,4000.000,5,1919,1923,60,1000,3670.900,21,,,UNDETERMINED,all,mixed
+juan,costa rica,sugar cane,tonnes,3000.000,5,1910,1914,26,1000,28240.000,8,,,UNDETERMINED,all,mixed
+juan,costa rica,sugar cane,tonnes,5000.000,5,1919,1923,26,1000,28240.000,8,,,UNDETERMINED,all,mixed
+juan,cuba,grapefruit inc pomelos,tonnes,7000.000,5,1954,1958,21,1000,1178.300,9,,,UNDETERMINED,all,mixed
+juan,czechoslovakia,hemp tow waste,ha,7000.000,5,1934,1938,37,1000,10.117,17,,,UNDETERMINED,all,mixed
+juan,czechoslovakia,hempseed,ha,7000.000,5,1934,1938,37,1000,10.117,17,,,UNDETERMINED,all,mixed
+juan,czechoslovakia,tobacco unmanufactured,ha,10000.000,5,1933,1937,35,10000,1200.000,28,,,UNDETERMINED,all,mixed
+juan,denmark,barley,ha,233700.000,5,1907,1911,85,100,269804.000,4,,,UNDETERMINED,all,mixed
+juan,denmark,rye,ha,276000.000,5,1907,1911,85,1000,120325.000,26,,,UNDETERMINED,all,mixed
+juan,dominican republic,horses,heads,242000.000,5,1955,1959,20,1000,114733.000,6,,,EXPLAINED,all,1000
+juan,ecuador,rye,tonnes,4000.000,5,1956,1960,15,1000,3700.000,3,,,UNDETERMINED,all,mixed
+juan,el salvador,tobacco unmanufactured,ha,1000.000,5,1955,1959,15,1000,400.000,5,,,UNDETERMINED,all,mixed
+juan,finland,sugar beet,ha,3000.000,5,1933,1937,42,1000,600.000,9,,,UNDETERMINED,all,mixed
+juan,france,hops,ha,2000.000,5,1896,1900,86,1000,300.000,57,,,UNDETERMINED,all,mixed
+juan,france,lentils,ha,6000.000,5,1926,1930,51,1000,6471.000,16,,,UNDETERMINED,all,mixed
+juan,france,tobacco unmanufactured,ha,16000.000,5,1895,1899,88,1000,7900.000,42,,,UNDETERMINED,all,mixed
+juan,germany,grapes,ha,120000.000,5,1883,1887,78,10000,53000.000,70,,,UNDETERMINED,all,mixed
+juan,germany,hemp tow waste,ha,1000.000,5,1949,1954,41,1000,200.000,17,,,UNDETERMINED,all,mixed
+juan,germany,hempseed,ha,1000.000,5,1949,1954,41,1000,200.000,17,,,UNDETERMINED,all,mixed
+juan,guatemala,groundnuts with shell,ha,1000.000,5,1939,1944,8,1000,5.000,3,,,UNDETERMINED,all,mixed
+juan,haiti,coffee green,ha,141600.000,5,1928,1932,19,100,141690.000,1,,,UNDETERMINED,all,mixed
+juan,haiti,horses,heads,400000.000,5,1932,1939,10,100000,110000.000,5,,,EXPLAINED,all,1000
+juan,honduras,potatoes,tonnes,2000.000,5,1955,1959,12,1000,10474.200,1,,,UNDETERMINED,all,mixed
+juan,ireland,flax fibre and tow,ha,2000.000,5,1935,1939,58,1000,100.000,37,,,UNDETERMINED,all,mixed
+juan,ireland,linseed,ha,2000.000,5,1935,1939,58,1000,100.000,37,,,UNDETERMINED,all,mixed
+juan,ireland,rye,tonnes,3000.000,5,1950,1955,56,1000,1300.000,43,,,UNDETERMINED,all,mixed
+juan,italy,groundnuts with shell,ha,1000.000,5,1936,1940,26,1000,200.000,1,,,UNDETERMINED,all,mixed
+juan,italy,groundnuts with shell,ha,4000.000,5,1948,1952,26,1000,200.000,1,,,UNDETERMINED,all,mixed
+juan,italy,lentils,ha,26000.000,5,1950,1954,26,1000,20557.000,11,,,UNDETERMINED,all,mixed
+juan,italy,linseed,tonnes,12000.000,5,1947,1951,52,1000,2200.000,34,,,UNDETERMINED,all,mixed
+juan,italy,sesame seed,tonnes,300.000,5,1940,1944,26,100,373.900,1,,,UNDETERMINED,all,mixed
+juan,italy,sesame seed,ha,2000.000,5,1956,1960,26,1000,337.000,10,,,UNDETERMINED,all,mixed
+juan,italy,soybeans,ha,1000.000,5,1949,1953,25,1000,6.000,15,,,UNDETERMINED,all,mixed
+juan,italy,soybeans,ha,300.000,5,1955,1959,25,100,6.000,9,,,UNDETERMINED,all,mixed
+juan,italy,tangerines mandarins clementines satsumas,ha,10250.000,5,1941,1945,27,10,7766.000,5,,,UNDETERMINED,all,mixed
+juan,luxembourg,rye,ha,4000.000,5,1955,1959,48,1000,4100.000,24,,,UNDETERMINED,all,mixed
+juan,malta,potatoes,ha,4000.000,5,1936,1940,49,1000,1300.000,23,,,UNDETERMINED,all,mixed
+juan,mexico,cocoa beans,tonnes,2000.000,5,1919,1923,60,1000,547.200,33,,,UNDETERMINED,all,mixed
+juan,mexico,lentils,tonnes,2000.000,5,1946,1951,27,1000,399.983,16,,,UNDETERMINED,all,mixed
+juan,mexico,lentils,ha,3000.000,5,1946,1951,27,1000,1262.000,16,,,UNDETERMINED,all,mixed
+juan,mexico,peas dry,ha,7000.000,5,1946,1955,24,1000,3480.000,16,,,UNDETERMINED,all,mixed
+juan,mexico,sweet potatoes,ha,12000.000,5,1948,1953,33,1000,5405.000,21,,,UNDETERMINED,all,mixed
+juan,norway,grain mixed,ha,4000.000,5,1947,1951,48,1000,5400.000,15,,,UNDETERMINED,all,mixed
+juan,norway,grain mixed,ha,2000.000,5,1956,1960,48,1000,5400.000,15,,,UNDETERMINED,all,mixed
+juan,norway,rye,ha,6000.000,5,1933,1937,64,1000,500.000,26,,,UNDETERMINED,all,mixed
+juan,norway,rye,ha,1000.000,5,1947,1951,64,1000,500.000,26,,,UNDETERMINED,all,mixed
+juan,norway,rye,ha,1000.000,5,1953,1957,64,1000,500.000,26,,,UNDETERMINED,all,mixed
+juan,paraguay,coffee green,tonnes,100.000,5,1940,1944,20,100,72.500,14,,,UNDETERMINED,all,mixed
+juan,paraguay,groundnuts with shell,tonnes,10000.000,5,1954,1958,29,10000,4000.000,24,,,UNDETERMINED,all,mixed
+juan,puerto rico,grapefruit inc pomelos,tonnes,19000.000,5,1948,1953,25,1000,300.000,11,,,UNDETERMINED,all,mixed
+juan,puerto rico,rice paddy,tonnes,2000.000,5,1955,1959,14,1000,800.000,3,,,UNDETERMINED,all,mixed
+juan,spain,carobs,ha,152000.000,5,1950,1954,98,1000,96333.495,76,,,UNDETERMINED,all,mixed
+juan,spain,cherries,ha,1000.000,5,1941,1945,98,1000,271.845,93,,,UNDETERMINED,all,mixed
+juan,spain,millet,ha,1000.000,5,1955,1959,101,1000,34.792,96,,,UNDETERMINED,all,mixed
+juan,spain,plums and sloes,ha,2400.000,5,1948,1952,98,100,353.571,75,,,UNDETERMINED,all,mixed
+juan,spain,tangerines mandarins clementines satsumas,tonnes,71900.000,5,1939,1943,98,100,23280.161,92,,,UNDETERMINED,all,mixed
+juan,sweden,flax fibre and tow,ha,500.000,5,1929,1933,52,100,2722.000,1,,,UNDETERMINED,all,mixed
+juan,sweden,tobacco unmanufactured,tonnes,300.000,5,1950,1955,55,100,384.000,40,,,UNDETERMINED,all,mixed
+juan,switzerland,maize,tonnes,4000.000,5,1953,1957,53,1000,2100.000,35,,,UNDETERMINED,all,mixed
+juan,united states of america,oil olive virgin,tonnes,700.000,5,1932,1936,46,100,192.913,16,,,UNDETERMINED,all,mixed
+juan,uruguay,grapes,ha,18000.000,5,1943,1949,52,1000,3610.000,29,,,UNDETERMINED,all,mixed
+juan,yugoslav sfr,rice paddy,ha,3000.000,5,1934,1938,29,1000,1100.000,8,,,UNDETERMINED,all,mixed
+mitchell,australia,rice paddy,ha,10000.000,5,1937,1941,35,10000,1000.000,27,,,EXPLAINED,all,1000
+mitchell,dr congo,sheep,heads,300000.000,5,1919,1923,26,100000,244000.000,20,,,EXPLAINED,all,1000
+mitchell,indonesia,tea,tonnes,1000.000,5,1858,1862,104,1000,700.000,39,,,EXPLAINED,all,100
+mitchell,lebanon,wheat,ha,70000.000,5,1953,1957,20,10000,53000.000,11,,,EXPLAINED,all,1000
+mitchell,senegal,rice paddy,ha,50000.000,5,1922,1926,37,10000,31000.000,24,,,EXPLAINED,all,1000
+mitchell,sierra leone,rice paddy,tonnes,190000.000,5,1940,1944,42,10000,102000.000,30,,,EXPLAINED,all,100

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -4582,6 +4582,54 @@ def mutate_constantrun_witness_is_cross_era(root, gpd, make_valid, affinity):
             f"with its {hit['year_first']}-{hit['year_last']} run")
 
 
+def mutate_precision_row_recoarsened(root, gpd, make_valid, affinity):
+    """Re-coarsen ONE row of the precision table, leaving constant_runs.csv untouched.
+
+    The verdict column in `constant_runs.csv` is a JOIN of two committed tables, and the failure a
+    join has that neither table has alone is one side moving without the other. `iia`'s pre-1934 `ha`
+    grid is the load-bearing row: it is measured `fine` (9.8% on a 1000-grid), which is what makes
+    eight of the eleven REFUTED runs refuted -- saint vincent's 400 ha for nine years is only a
+    finding because that volume reported to the hectare. Flip that one word to `coarse_1000` and the
+    innocent explanation covers them, so the residue this issue exists to isolate evaporates.
+
+    The point of mutating the PRECISION table rather than the verdict is that every count stays put:
+    `constant_runs.csv` still says REFUTED eleven times, the 15-run residue is unchanged by identity,
+    and the schema arm is satisfied. Only the arm that RE-DERIVES each verdict from the other table can
+    see it -- which is why that arm restates the rule instead of importing the generator's `judge()`,
+    since an imported rule would move with the table it reads.
+
+    Nothing else in this harness would catch it either: `validate_value_precision.py` re-derives its
+    verdict from the row's own shares and would reject this edit, but it knows nothing about the runs,
+    so a rebuild of the precision table that legitimately moved the row would pass there and silently
+    reclass eight runs here.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/source_value_precision.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    hit = [r for r in rows if (r["source"], r["unit"], r["era"]) == ("iia", "ha", "pre-1934")]
+    if len(hit) != 1 or hit[0]["verdict"] != "fine":
+        raise AssertionError(
+            "iia/ha/pre-1934 is no longer a single `fine` row in source_value_precision.csv, so "
+            "re-coarsening it would not reclass the runs that rest on it and the case would pass "
+            "vacuously")
+    runs = os.path.join(root, "pipelines/polity-autoimprove/state/constant_runs.csv")
+    with open(runs, newline="", encoding="utf-8") as fh:
+        affected = [r for r in csv.DictReader(fh)
+                    if (r["source"], r["unit"], r["precision_era"]) == ("iia", "ha", "pre-1934")]
+    if not any(r["country"] == "fiji" for r in affected):
+        raise AssertionError("no fiji run is judged against iia/ha/pre-1934 any more; the case pins "
+                             "that name, so it would fire without naming the defect")
+    hit[0]["verdict"] = "coarse_1000"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"iia/ha/pre-1934 re-coarsened from `fine` to `coarse_1000`, so the {len(affected)} runs "
+            f"judged against it now have an innocent explanation the committed verdicts deny, with "
+            f"every count and the pinned residue untouched")
+
+
 def mutate_arearevision_second_coincidental_agreement(root, gpd, make_valid, affinity):
     """Give a SECOND polity both verdicts, so one of its agreements is coincidental.
 
@@ -4779,6 +4827,14 @@ CASES = (
         "not one any more",
         "a recorded source seam deleted from the table, so a x100 scale break at a splice goes "
         "unaccounted for and the count ceiling silently gains headroom",
+    ),
+    (
+        "validate_constant_run_verdicts.py",
+        mutate_precision_row_recoarsened,
+        "fiji / tea (ha)",
+        "one side of a two-table join moved without the other, so 8 runs the source's own measured "
+        "precision now explains are still published as REFUTED — the counts, the residue and the "
+        "schema all stay exactly where they were pinned",
     ),
     (
         "validate_constant_runs.py",
@@ -5806,6 +5862,14 @@ WRITABLE = {
     # Two cases rewrite constant_runs.csv in place -- one edits n_values, one moves an in-volume
     # witness year -- so it must be a real copy rather than a symlink into the tracked table.
     "validate_constant_runs.py": (
+        "pipelines/polity-autoimprove/state/constant_runs.csv",
+    ),
+    # The case rewrites source_value_precision.csv in place (it re-coarsens the iia/ha/pre-1934 row),
+    # so that one must be a real copy. constant_runs.csv is read-only for both gate and mutator, but
+    # stage() creates nothing it was not asked for and this gate SKIPS when the table is absent --
+    # exit 0, which the runner reads as "the gate cannot fail". It has to be listed.
+    "validate_constant_run_verdicts.py": (
+        "pipelines/polity-autoimprove/state/source_value_precision.csv",
         "pipelines/polity-autoimprove/state/constant_runs.csv",
     ),
     # The case rewrites isolated_spikes.csv in place (it edits the factor column), so it must be a

--- a/scripts/validate_constant_run_verdicts.py
+++ b/scripts/validate_constant_run_verdicts.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Is each constant run a limit of its source's reporting grid, or is it not? Gate the answer.
+
+`validate_constant_runs.py` gates the runs themselves: 246 series that repeat one value for years in a
+way their OWN series refutes. What it cannot say is whether the repetition is innocent, and that is the
+whole of issue 366's history -- its headline argument was WITHDRAWN because the finer evidence proving
+"this series resolves finer than its constant" turned out to be cross-era in 169 of 170 runs, which is
+what a change of reporting resolution looks like rather than evidence against one.
+
+`state/source_value_precision.csv` (#446, #528) is the table that settles it, per (source, unit, era),
+and `17_constant_runs.py` now joins the two and writes a `verdict` per run. THAT JOIN IS THE THING THIS
+GATE EXISTS FOR. It was first measured by hand and published only in a comment on issue 366 -- 68
+EXPLAINED / 153 UNDETERMINED / 11 REFUTED / 4 OFF-GRID / 10 NOT ATTRIBUTABLE -- where it could not be
+re-run, diffed or gated, and nothing anywhere would have noticed if the counts moved. The 15 REFUTED and
+OFF-GRID runs are the residue the issue exists to isolate: the runs where the innocent explanation
+demonstrably fails.
+
+The panel both tables derive from is gitignored and absent in CI, so this reads the two committed
+tables -- the same arrangement as `validate_constant_runs.py` and `validate_source_splices.py`.
+
+Five arms:
+
+  A  SCHEMA. The three verdict columns exist and are populated, and `verdict` holds one of the five
+     words. A column silently added and never filled would leave every other arm vacuous.
+
+  B  THE VERDICT IS RE-DERIVED from the two tables, independently of the generator. RESTATED HERE
+     RATHER THAN IMPORTED, deliberately: the failure this guards against is one table being edited out
+     from under the other, and a gate importing the generator's own `judge()` would move with it. The
+     era partition is recovered from the precision table's own `<year>+` labels, exactly as the
+     generator does, so a moved boundary is a finding in both places rather than a silent reclassing.
+
+  C  THE FIVE COUNTS ARE PINNED, bidirectionally, the way every other census here is. A run crossing
+     from UNDETERMINED to REFUTED is a NEW FINDING -- the source turned out to report finer in that
+     unit and era after all -- and the point of a baseline is that such a move must be read, not
+     absorbed.
+
+  D  THE 15-RUN RESIDUE IS PINNED BY IDENTITY. Counts alone can stay at 11 and 4 while the membership
+     rotates, and membership is what a repair or a source-page lookup would act on.
+
+  E  CROSS-CHECK AGAINST THE IN-VOLUME WITNESS, which is the other half of issue 366 already in this
+     table. `finer_in_volume_year` names a year where the SAME yearbook volume records a value off the
+     run's own grid. Three runs carry such a witness AND are EXPLAINED, and that is not a contradiction
+     as long as the witness sits on the ERA's grid: `australia wine` repeats 20,000 ha (its own grid is
+     10,000) beside a 19,000 in the same volume, and 19,000 is on the era's 1,000-grid, so the era
+     explains both values. `algeria rye`'s 2,000-beside-1,000 is the same trap one level down, and
+     getting it wrong is how an earlier count of 27 became 17. But a witness OFF the era's grid while
+     the run is called EXPLAINED is a real contradiction: that volume printed a figure the era's grid
+     cannot express, so the grid is not available as the run's explanation.
+
+WHAT THIS GATE DOES NOT ASSERT. Not that an EXPLAINED run is correct: `coarse_1000` is a share (96.3%
+for `iia` `ha` from 1934), not a rule, so EXPLAINED means "consistent with the grid", never "measured".
+And not that a REFUTED run is a fabrication -- it may be a real plateau or a carried-forward figure.
+The verdict separates the runs that need a source page from the runs that do not.
+
+Usage:
+  python3 scripts/validate_constant_run_verdicts.py
+"""
+from __future__ import annotations
+
+import collections
+import csv
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/constant_runs.csv")
+PRECISION = os.path.join(REPO, "pipelines/polity-autoimprove/state/source_value_precision.csv")
+
+VERDICTS = ("EXPLAINED", "UNDETERMINED", "REFUTED", "OFF-GRID", "NOT ATTRIBUTABLE")
+
+# The precision table's verdict word -> the grid it asserts, in the series' own unit. `mixed` and
+# `fine` assert no single grid and are deliberately absent rather than mapped to 1.
+ERA_GRID = {"coarse_1000": 1000, "coarse_100": 100}
+
+SCALE = 10 ** 6      # scaled integers, because float modulo cannot be trusted on 5.390 vs 100
+
+# Measured 2026-08-31, reproducing by code the classification that had lived only in a comment on issue
+# 366. BIDIRECTIONAL: a run moving between buckets is a finding either way and must move this with a
+# note saying which run moved and why.
+BASELINE_COUNTS = {
+    "EXPLAINED": 68,
+    "UNDETERMINED": 153,
+    "REFUTED": 11,
+    "OFF-GRID": 4,
+    "NOT ATTRIBUTABLE": 10,
+}
+
+# The residue: every run whose innocent explanation demonstrably fails. GENERATED FROM THE TABLE, never
+# hand-typed. All 15 are `iia`; the 11 REFUTED are all pre-1934, where `ha` sits at 9.8% on a 1000-grid
+# and `tonnes` carries 53.1% sub-unit precision -- a source reporting to the hectare and the tenth of a
+# tonne, printing one figure for five to nine consecutive years.
+BASELINE_RESIDUE = frozenset({
+    ('iia', 'australia', 'hops', 'ha', '500.000', '1939'),
+    ('iia', 'austria', 'n', 'tonnes', '24000.000', '1914'),
+    ('iia', 'fiji', 'tea', 'ha', '80.000', '1911'),
+    ('iia', 'france', 'eggs hen in shell', 'tonnes', '5.390', '1939'),
+    ('iia', 'guadeloupe', 'cacao beans', 'ha', '5000.000', '1918'),
+    ('iia', 'guadeloupe', 'coffee green', 'ha', '7000.000', '1918'),
+    ('iia', 'madagascar', 'wine', 'tonnes', '291.000', '1934'),
+    ('iia', 'mauritius', 'tea', 'ha', '150.000', '1911'),
+    ('iia', 'mauritius', 'tea', 'tonnes', '38.000', '1911'),
+    ('iia', 'new zealand', 'hops', 'ha', '200.000', '1939'),
+    ('iia', 'saint lucia', 'cacao beans', 'ha', '2400.000', '1910'),
+    ('iia', 'saint lucia', 'cacao beans', 'ha', '2400.000', '1922'),
+    ('iia', 'saint vincent and the grenadines', 'cacao beans', 'ha', '400.000', '1909'),
+    ('iia', 'trinidad and tobago', 'coffee green', 'ha', '1700.000', '1909'),
+    ('iia', 'united states of america', 'n', 'tonnes', '58000.000', '1914'),
+})
+
+
+def key(r):
+    return (r["source"], r["country"], r["item"], r["unit"], r["constant"], r["year_first"])
+
+
+def who(r):
+    return (f"{r['source']} {r['country']} / {r['item']} ({r['unit']}) "
+            f"{r['year_first']}-{r['year_last']}")
+
+
+def load_precision(path):
+    """-> {(source, unit, era): verdict}, {source: era cut}. The cut is read off the era labels."""
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    prec = {(r["source"], r["unit"], r["era"]): r["verdict"] for r in rows}
+    cuts = collections.defaultdict(set)
+    for r in rows:
+        m = re.fullmatch(r"(\d{4})\+", r["era"])
+        if m:
+            cuts[r["source"]].add(int(m.group(1)))
+    return prec, cuts
+
+
+def rederive(r, prec, cuts):
+    """(verdict, precision_era, precision_grid) for one run, from the two tables alone."""
+    src, unit = r["source"], r["unit"]
+    cs = cuts.get(src, set())
+    if len(cs) > 1:
+        return None, None, None      # reported once, by the caller, rather than per run
+    if not cs:
+        era = "all"
+    else:
+        cut = next(iter(cs))
+        if int(r["year_first"]) < cut <= int(r["year_last"]):
+            return "NOT ATTRIBUTABLE", f"straddles-{cut}", ""
+        era = f"{cut}+" if int(r["year_first"]) >= cut else f"pre-{cut}"
+    word = prec.get((src, unit, era))
+    if word is None:
+        return "UNDETERMINED", era, "unmeasured"
+    grid = ERA_GRID.get(word)
+    if grid is None:
+        return ("UNDETERMINED" if word == "mixed" else "REFUTED"), era, word
+    on_grid = int(round(float(r["constant"]) * SCALE)) % (grid * SCALE) == 0
+    return ("EXPLAINED" if on_grid else "OFF-GRID"), era, str(grid)
+
+
+def main() -> int:
+    if not os.path.exists(TABLE):
+        print(f"SKIP: {os.path.relpath(TABLE, REPO)} missing — run 17_constant_runs.py --write")
+        return 0
+    if not os.path.exists(PRECISION):
+        print(f"FAIL {os.path.relpath(PRECISION, REPO)} is missing, so the verdicts in "
+              f"{os.path.relpath(TABLE, REPO)} rest on a table that is no longer here and nothing "
+              f"can re-derive them", file=sys.stderr)
+        return 1
+    with open(TABLE, newline="", encoding="utf-8") as fh:
+        rdr = csv.DictReader(fh)
+        cols = tuple(rdr.fieldnames or ())
+        rows = list(rdr)
+    prec, cuts = load_precision(PRECISION)
+
+    problems = []
+    # --- A: schema ---
+    for c in ("verdict", "precision_era", "precision_grid"):
+        if c not in cols:
+            print(f"FAIL {os.path.relpath(TABLE, REPO)} has no `{c}` column: the classification "
+                  f"issue 366 turns on is not in the table, so it cannot be diffed or gated. Run "
+                  f"17_constant_runs.py --write", file=sys.stderr)
+            return 1
+    multi = sorted(s for s, cs in cuts.items() if len(cs) > 1)
+    if multi:
+        print(f"FAIL {os.path.relpath(PRECISION, REPO)}: {multi} carry more than one era cut, so a "
+              f"run has no single grid to be judged against and every verdict here is ambiguous",
+              file=sys.stderr)
+        return 1
+
+    counts = collections.Counter()
+    for r in rows:
+        if r["verdict"] not in VERDICTS:
+            problems.append(f"{who(r)}: verdict {r['verdict']!r} is not one of {VERDICTS}")
+            continue
+        counts[r["verdict"]] += 1
+        if not r["precision_era"]:
+            problems.append(f"{who(r)}: verdict {r['verdict']} with an empty `precision_era`, so "
+                            f"nothing records which row of the precision table it was read from")
+        # --- B: re-derive ---
+        want_v, want_era, want_grid = rederive(r, prec, cuts)
+        if (r["verdict"], r["precision_era"], r["precision_grid"]) != (want_v, want_era, want_grid):
+            problems.append(
+                f"{who(r)}: the table says verdict={r['verdict']} era={r['precision_era']} "
+                f"grid={r['precision_grid']}, but re-deriving from source_value_precision.csv gives "
+                f"verdict={want_v} era={want_era} grid={want_grid}. One of the two tables moved "
+                f"without the other; regenerate with 17_constant_runs.py --write, or if the "
+                f"precision row changed, say what changed about the source")
+        # --- E: the in-volume witness must not contradict an EXPLAINED verdict ---
+        wv = (r.get("finer_in_volume_value") or "").strip()
+        if wv and r["verdict"] == "EXPLAINED" and r["precision_grid"].isdigit():
+            g = int(r["precision_grid"])
+            if int(round(float(wv) * SCALE)) % (g * SCALE) != 0:
+                problems.append(
+                    f"{who(r)}: called EXPLAINED by a grid of {g}, yet its in-volume witness "
+                    f"{r['finer_in_volume_year']}={wv} is OFF that grid — the same yearbook volume "
+                    f"printed a figure the grid cannot express, so the grid is not available as this "
+                    f"run's explanation and the verdict contradicts its own row")
+
+    print(f"{len(rows)} constant run(s) judged against their source's reporting grid:")
+    for v in VERDICTS:
+        print(f"  {counts[v]:>4}  {v:17} (pinned {BASELINE_COUNTS[v]})  "
+              f"{dict(collections.Counter(r['source'] for r in rows if r['verdict'] == v).most_common())}")
+
+    # --- C: the census, bidirectionally ---
+    for v in VERDICTS:
+        if counts[v] == BASELINE_COUNTS[v]:
+            continue
+        problems.append(
+            f"{v}: {counts[v]} run(s) against the pinned {BASELINE_COUNTS[v]}. This is the split issue "
+            f"366 turns on, so a move is a finding in either direction — a run leaving UNDETERMINED "
+            f"for REFUTED means its source reports finer in that unit and era after all, and one "
+            f"leaving REFUTED means the innocent reading now covers it. Update BASELINE_COUNTS in the "
+            f"same commit and name the run that moved")
+
+    # --- D: the residue, by identity ---
+    residue = {key(r) for r in rows if r["verdict"] in ("REFUTED", "OFF-GRID")}
+    for k in sorted(residue - BASELINE_RESIDUE):
+        problems.append(
+            f"NEW un-explained run: {k[1]} / {k[2]} ({k[3]}) = {k[4]} from {k[5]}, {k[0]}. Its source "
+            f"is not coarse enough in that unit and era to produce the constant by rounding, so the "
+            f"flat years are a carried-forward or placeholder figure being read as data — add it to "
+            f"BASELINE_RESIDUE only with a reading of the run")
+    for k in sorted(BASELINE_RESIDUE - residue):
+        problems.append(
+            f"{k[1]} / {k[2]} = {k[4]} from {k[5]} is pinned as un-explained but is not any more. "
+            f"Either its source's measured precision changed or the run did; remove its entry saying "
+            f"which, because these 15 are the residue issue 366 exists to isolate")
+
+    n_wit = sum(1 for r in rows
+                if (r.get("finer_in_volume_year") or "").strip() and r["verdict"] == "EXPLAINED")
+    print(f"  {n_wit} EXPLAINED run(s) also carry an in-volume witness, each on the era's own grid")
+
+    if problems:
+        print(f"\nFAIL: {len(problems)} problem(s)\n")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print("\nPASS: every run's verdict re-derives from the precision table, the five-way split is "
+          "where it was pinned, and the 15-run residue is unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
*PR by Claude.* Does what I said I would do in the last comment on #366 and did not: **the five-way classification of every constant run is now produced by code, pinned by a gate, and mutation-tested.** It reproduces the comment's counts exactly.

## The gap this closes

`constant_runs.csv` holds 246 series that repeat one value for years in a way their own series refutes. Whether each repetition is *innocent* is the question #366 turns on — a source whose reporting grid in that unit and era is coarser than the constant prints the same figure every year with nothing filled in, which is the ground the issue's headline argument was **withdrawn** on. `source_value_precision.csv` (#446, #528) answers it, and the join between the two tables existed only as a hand measurement in a comment:

```
17_constant_runs.py reads source_value_precision.csv        no
any tool joining constant_runs x source_value_precision     none
```

So re-running the pipeline regenerated the table with no verdict on it, and nothing anywhere would have noticed if the counts moved. The 11 REFUTED and 4 OFF-GRID runs are the residue the issue exists to isolate — the runs where the innocent explanation demonstrably fails — and they were identifiable only by re-deriving a comment by hand.

## The counts, code against comment

| verdict | comment (2026-08-21) | this code | by source |
|---|---|---|---|
| EXPLAINED | 68 | **68** | iia 54, mitchell 11, juan 3 |
| UNDETERMINED | 153 | **153** | juan 153 |
| REFUTED | 11 | **11** | iia 11 |
| OFF-GRID | 4 | **4** | iia 4 |
| NOT ATTRIBUTABLE | 10 | **10** | iia 10 |

All five agree, and so does the membership: the 15 REFUTED/OFF-GRID runs are the same 15 the comment lists, in the same units with the same constants, and the 3 juan EXPLAINED runs are its `heads` — the one juan unit measured `coarse_1000`.

```
246 constant run(s) judged against their source's reporting grid:
    68  EXPLAINED         (pinned 68)  {'iia': 54, 'mitchell': 11, 'juan': 3}
   153  UNDETERMINED      (pinned 153)  {'juan': 153}
    11  REFUTED           (pinned 11)  {'iia': 11}
     4  OFF-GRID          (pinned 4)  {'iia': 4}
    10  NOT ATTRIBUTABLE  (pinned 10)  {'iia': 10}
  3 EXPLAINED run(s) also carry an in-volume witness, each on the era's own grid
```

## What is in the tree

**`17_constant_runs.py`** joins the precision table and writes `verdict`, `precision_era` and `precision_grid`, so a reader sees *which* row of the precision table judged the run and what grid it implies. Two decisions worth stating:

- **The era cut is recovered from the precision table's own `<year>+` labels**, not restated. 37_value_precision.py splits only `iia`, and only because its 1934 handover is independently registered (#445); if that split moves or goes, this file cannot hold a stale boundary.
- **A run crossing the cut is NOT ATTRIBUTABLE**, not assigned to whichever era it spends more years in. Layer B carries no volume provenance, so which volume printed the flat years is not knowable from the row — the same reason `finer_in_volume_year` excludes the five overlap years.

Regenerated with `--write`; `--check` reports the table current. The diff on the CSV is three appended columns and nothing else — 248 of 248 lines are the old line plus a suffix, with the file's CRLF terminators unchanged.

**`scripts/validate_constant_run_verdicts.py`** — five arms: schema; **verdict re-derived** from the two committed tables; the five counts pinned bidirectionally; the 15 residue identities pinned; and a cross-check against the in-volume witness column already in the table.

The rule is **restated in the gate rather than imported** from the generator, deliberately: the failure a join has that neither table has alone is one side moving without the other, and a gate importing the generator's own `judge()` would move with it.

The witness arm is the one I had to measure before asserting. Three EXPLAINED runs *do* carry an in-volume witness, and that is not a contradiction — the witness sits on the **era's** grid even though it is off the **constant's**:

```
iia australia wine    ha  const 20,000 (own grid 10,000)  witness 1934 = 19,000  era grid 1,000
iia egypt oranges     ha  const 10,000 (own grid 10,000)  witness 1934 =  9,000  era grid 1,000
iia chile raisins     t   const  2,000 (own grid  1,000)  witness 1944 =    800  era grid   100
```

That is `algeria rye`'s different-multiple trap one level down — the mistake that once turned a count of 27 into 17 — so the arm asserts the true thing instead: a witness **off** the era's grid while the run is called EXPLAINED is a real contradiction, because that volume printed a figure the era's grid cannot express. It fires on exactly that (verified by mutation, one problem, alone).

## The selftest mutation

Case 10 re-coarsens **one word in the precision table** — `iia`/`ha`/`pre-1934` from `fine` to `coarse_1000` — and touches `constant_runs.csv` not at all. Every count stays at its pin, the residue is unchanged by identity, and the schema is satisfied, so only the re-derivation arm can see it:

```
case 10: validate_constant_run_verdicts.py
   mutation: iia/ha/pre-1934 re-coarsened from `fine` to `coarse_1000`, so the 8 runs judged
             against it now have an innocent explanation the committed verdicts deny, with every
             count and the pinned residue untouched
   detects:  one side of a two-table join moved without the other, so 8 runs the source's own
             measured precision now explains are still published as REFUTED — the counts, the
             residue and the schema all stay exactly where they were pinned
   result:   exit=1 names fiji / tea (ha): True
```

That row is load-bearing: `iia` pre-1934 `ha` is 9.8% on a 1000-grid, which is what makes eight of the eleven REFUTED runs refuted. Saint Vincent's 400 ha for nine years is a finding *because* that volume reported to the hectare.

`validate_value_precision.py` would reject this particular hand edit (it re-derives the verdict from the row's own shares), but it knows nothing about the runs — a legitimate rebuild that moved the row would pass there and silently reclass eight runs here with no other signal moving.

## Checks

- All **85 → 86** `scripts/validate_*.py` gates exit 0 on this branch, and all 85 did on clean `main` in the same environment.
- `python3 scripts/selftest_gates.py` — all 139 cases (the new one is 10), and its registration arms confirm the gate runs in CI and is named in the README.
- `17_constant_runs.py --check` current; `37_value_precision.py --check` untouched and current.

## What this does not claim

No value changes and nothing here is a repair. `coarse_1000` is a **share** (96.3% for `iia` `ha` from 1934), not a rule, so EXPLAINED means "consistent with the grid", never "measured"; and a REFUTED run may still be a real plateau or a carried-forward figure rather than a fabrication. What has changed is that the 15 runs needing a source page are separable by code from the 68 needing no explanation, and that a future precision refresh moving any of the 153 UNDETERMINED into REFUTED now **fails loudly** instead of passing unseen.

This closes no issue on its own. #366's remaining open item is the consumer-facing flag, tracked in #446, and what to do with the 15 refuted runs is a decision for the maintainer either way — the point of the join is that they are now a list the repo produces rather than one I re-derive.
