### PR TITLE
issue 416: a value could not be too small to fail -- two-sided era ratio test, gate arm, and per-row volume attribution

### DIFF
--- a/pipelines/polity-autoimprove/29_era_shift_verdicts.py
+++ b/pipelines/polity-autoimprove/29_era_shift_verdicts.py
@@ -33,6 +33,8 @@ THE CLASSES, strongest evidence first:
                               that item. Weaker than a yield test -- it assumes the label's own history
                               is the right baseline -- but it needs no area, which is what makes the 87
                               unpaired rows reachable at all.
+  no_area_level_drop          the SAME 30x against the same baseline, on the other side: <= 1/30 of the
+                              label's own pre-1934 median. See "THE RATIO TEST WAS ONE-SIDED" below.
   high_yield_3to20            elevated and not impossible. NOT convicted: a 5 t/ha tobacco yield is
                               wrong for a field but not arithmetically impossible, and calling it a
                               defect would be the magnitude argument this repo has been burned by.
@@ -42,9 +44,60 @@ THE CLASSES, strongest evidence first:
                               convicted -- an untestable row is not an innocent one, and saying so is
                               the difference between this table and a correction list.
 
+THE RATIO TEST WAS ONE-SIDED, AND A VALUE COULD NOT BE TOO SMALL TO FAIL. The level arm convicted at
+`ratio >= 30` and filed EVERYTHING else `no_area_level_consistent`. There was no filter to grep for --
+the exoneration was the `else` branch -- so the shape only shows up in what the table says about a
+particular row:
+
+    germany / tobacco, unmanufactured / 1945    production 0    baseline 25,833.9    ratio 0.0
+    verdict: no_area_level_consistent
+
+A production of ZERO filed as consistent with a 25,834 t baseline. Nothing about the row was mislabelled;
+the classifier simply had no way to say "too small", so the maximal disagreement a ratio can express fell
+into the class reserved for agreement. `no_area_level_drop` is that missing arm, at the same 30x, and
+`LEVEL_DROP = 1 / LEVEL_SHIFT` rather than a second tunable so the two sides cannot drift apart.
+
+THE BOUND IS NOT FITTED, and the way to show that is that it does not matter. Measured over all 393 era
+rows that carry a ratio:
+
+    ratio <= 1/100    1 row        ratio <= 1/10     1 row
+    ratio <= 1/30     1 row        ratio <= 1/3      3 rows
+
+and the two extra rows at 1/3 (micronesia 1936 and 1937, at 0.296 and 0.148) are ALREADY convicted by the
+zero-area arm, which runs first. So every bound from 1/100 to 1/3 convicts the same single row today. A
+threshold whose live population is invariant across a 33x range of the threshold is not tuned to its
+population.
+
+WHY THAT ROW IS CONVICTED AND NOT MERELY FLAGGED, on evidence outside this table. In the raw extract
+germany's tobacco production series in `iia_1939_45` runs 1939-1943 and then jumps to a 1945 cell of 0,
+skipping 1944 -- while the AREA series beside it runs 1939-1944 with no gap and no 1945 cell at all. And
+germany has exactly ONE cell at 1945 in that entire volume, against 20 to 36 cells in every other year
+from 1939 to 1944. A country that reported nothing else in 1945 did not report a tobacco harvest of
+precisely zero; the cell sits at the table's edge, and it is the edge rather than a harvest. What is
+convicted is therefore the CELL, not a claim about German output.
+
+The 1945 zeros are NOT a general blank-as-zero artefact of that volume, and the check that would have
+made them one fails: 1945 carries 7 zeros in 973 production cells (0.72%), no higher than 1939-1944
+(0.22%-0.57%), so "the last year was read as blank" is refuted at the volume level. The association is
+with a THIN year-block, not with the year: among labels holding exactly one 1945 cell, 3 of 30 are zero;
+among labels with a populated 1945 block, 10 of 1,607. That is n=3 and stated as an association.
+
+TWO THINGS THIS ARM DOES NOT REACH. `netherlands / tobacco / 1945` is also a zero, sits in a POPULATED
+1945 block (20 cells), and is the only netherlands tobacco cell in the whole corpus -- so it has no
+pre-era baseline, no ratio, and stays `untestable`. And a row with area EXACTLY 0 and production 0 would
+escape the zero-area arm, whose guard is `production > 0`; with this arm it now lands on the ratio test
+instead of on `no_area_level_consistent`, though the live population of that shape is 0 rows today.
+
+The falsy-zero rule matters here and is not decoration: `ratio` for the germany row is 0.0, so any
+`if ratio:` or `ratio or default` writes it out of existence. It is tested with `is not None`
+throughout, and this repo has already turned a real 0.0 into 1.0 in exactly this measurement.
+
 WHAT THIS DOES NOT DO. It does not write corrections and it does not name a factor per row. The implied
 factors run 21x to 293x with a median of 68x, so no single divisor fits, and `yield_series_corrections.csv`
-remains the place a repair is proposed with its anchor. This is the evidence a repair would rest on.
+remains the place a repair is proposed with its anchor. This is the evidence a repair would rest on. The
+per-row VOLUME attribution -- which yearbook edition each era cell came from, and the 100x/10x factor
+measured from that label's own volume overlap -- is `40_era_volume_attribution.py`, which needs the raw
+extract and therefore cannot live here.
 
 Usage:
   python3 pipelines/polity-autoimprove/29_era_shift_verdicts.py            # report only
@@ -72,11 +125,15 @@ ERA_FROM = 1934                 # the boundary issue 414 explains: the last year
 IMPOSSIBLE_YIELD = 20.0         # t/ha; an order of magnitude above the crop's ceiling, not a fitted value
 HIGH_YIELD = 3.0
 LEVEL_SHIFT = 30.0              # x the label's own pre-era median
+# THE OTHER SIDE OF THE SAME TEST, derived rather than tuned. A second free constant could be edited
+# to 0.0 and the low arm would silently stop firing while the high arm kept working.
+LEVEL_DROP = 1.0 / LEVEL_SHIFT
 
 FIELDS = ("source", "label", "whep_code", "item", "year", "period", "unit", "production", "area_ha",
           "implied_yield", "own_pre_era_median", "ratio_to_own", "verdict", "convicted")
 
-CONVICTING = {"impossible_yield_zero_area", "impossible_yield", "no_area_level_shift"}
+CONVICTING = {"impossible_yield_zero_area", "impossible_yield", "no_area_level_shift",
+              "no_area_level_drop"}
 
 
 def _n(x, nd=6):
@@ -151,6 +208,10 @@ def build(matched: str) -> list[dict]:
             v = "plausible_yield"
         elif ratio is not None and ratio >= LEVEL_SHIFT:
             v = "no_area_level_shift"
+        # `ratio is not None`, never `if ratio`: the one row this arm convicts has ratio 0.0, and a
+        # truthiness test here reinstates exactly the exoneration the arm exists to remove.
+        elif ratio is not None and ratio <= LEVEL_DROP:
+            v = "no_area_level_drop"
         elif ratio is not None:
             v = "no_area_level_consistent"
         else:
@@ -199,7 +260,8 @@ def main() -> int:
 
     rows = build(args.matched)
     order = ("impossible_yield_zero_area", "impossible_yield", "no_area_level_shift",
-             "high_yield_3to20", "plausible_yield", "no_area_level_consistent", "untestable")
+             "no_area_level_drop", "high_yield_3to20", "plausible_yield",
+             "no_area_level_consistent", "untestable")
     vc = {k: sum(1 for r in rows if r["verdict"] == k) for k in order}
     conv = sum(1 for r in rows if r["convicted"] == "True")
     print(f"{len(rows)} {SOURCE} tobacco/hops production row(s) from {ERA_FROM}, "

--- a/pipelines/polity-autoimprove/29_era_shift_verdicts.py
+++ b/pipelines/polity-autoimprove/29_era_shift_verdicts.py
@@ -96,7 +96,7 @@ WHAT THIS DOES NOT DO. It does not write corrections and it does not name a fact
 factors run 21x to 293x with a median of 68x, so no single divisor fits, and `yield_series_corrections.csv`
 remains the place a repair is proposed with its anchor. This is the evidence a repair would rest on. The
 per-row VOLUME attribution -- which yearbook edition each era cell came from, and the 100x/10x factor
-measured from that label's own volume overlap -- is `40_era_volume_attribution.py`, which needs the raw
+measured from that label's own volume overlap -- is `41_era_volume_attribution.py`, which needs the raw
 extract and therefore cannot live here.
 
 Usage:

--- a/pipelines/polity-autoimprove/40_era_volume_attribution.py
+++ b/pipelines/polity-autoimprove/40_era_volume_attribution.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Which yearbook EDITION does each row of the 1934+ tobacco/hops era come from, and by what factor?
+
+WHAT THIS ADDS TO 29. `29_era_shift_verdicts.py` convicts 350 of the 427 `iia` tobacco/hops production
+rows from 1934 on the row's own arithmetic -- an impossible yield, a zero area, or a 30x break from the
+label's own pre-era level. What it cannot say is WHERE the number came from or WHAT the factor is, because
+layer B carries no volume provenance and the implied factors run 21x to 293x. Issue 416 has been stuck on
+exactly that: a blanket division by 100 is not supportable, so a repair needs a per-row factor with an
+anchor. This is that per-row attribution.
+
+THE FACTOR IS MEASURED FROM THE SOURCE'S OWN OVERLAP, NOT FITTED. Consecutive IIA volumes re-print the
+same years, so 1932 and 1933 appear in both `iia_1933_34` (clean) and `iia_1938_39` (the first inflated
+one). For a label reporting that item in both, the ratio between the two printings IS the factor, measured
+on the source's own two opinions of one cell with no yield identity and no agronomic assumption:
+
+    germany  tobacco  1933   iia_1933_34: 29,433.4 t   iia_1938_39: 2,943,300 t   ratio 100.00
+
+That ratio is what this tool attaches to every era row of that label and item, and the corrected value it
+implies is written beside the published one so the result can be judged rather than trusted.
+
+WHY THE JOIN IS BY VALUE AND KEY, WITH THE NAME AS CONFIRMATION. A bare NAME join between the raw extract
+and layer B reports "absent in raw" for nearly everything, because the raw labels are colonial
+(`japanese taiwan`, `british nyasaland`, `uk`) and layer B's are modern. `state/iia_label_provenance.csv`
+maps 335 of them but not all -- 32 of the 72 labels in `edition_conflicts.csv` for these two items have no
+entry -- so a provenance-only join reaches 154 era rows where a value join reaches 246. The join used here
+is therefore (raw product, variable, year-or-period, exact value), with the provenance map and a
+colonial-prefix rename test used to CONFIRM the label rather than to find it, and `name_confirmed`
+recording which rows got that second opinion.
+
+POSITIVE CONTROL, printed on every run and required to hold. Over all 2,340 `iia` tobacco/hops rows in
+layer B -- production and area, every year, not just the era -- the join finds an exact raw value at the
+same key for 2,296 (98.1%) and resolves 2,294 to a SINGLE volume. A join that silently matched nothing
+would report a clean "no attribution possible" for every row, and the tell is that the answer looks
+uniform, so the control is a floor (`--min-control`) and not a printed remark.
+
+The item names come from `state/item_equivalences.csv` (`tobacco unmanufactured -> tobacco`,
+`hops -> hops`) rather than being hardcoded, and the lookup strips the comma layer B writes into
+`tobacco, unmanufactured`. If either item stops resolving the tool fails instead of quietly attributing
+half the population.
+
+WHAT THE ATTRIBUTION ESTABLISHES, and it is stronger than the year heuristic already on record:
+
+  * ALL 427 era rows resolve to a volume and ALL 427 come from a LATE one (`iia_1938_39` 147,
+    `iia_1939_45` 280); none from a clean volume. So `year >= 1934` is not a proxy for "from an
+    inflated volume", it is equivalent to it -- now per row, and over period rows too, which the
+    dated-row version of that claim did not cover;
+  * `overlap_100x` (247 rows) carry a label-specific factor within 20% of 100, measured on that
+    label's own two printings of 1932/1933. Dividing by it moves tobacco from 0 of 144 cells inside
+    0.2-3.0 t/ha to 130 of 144 (median implied yield 83.11 -> 0.790) and hops from 0 of 27 to 10 of
+    27 (50.03 -> 5.019), the hops residual being its area rounding floor rather than its factor;
+  * `no_overlap_pair` (158 rows) is the honest limit: the label did not report this item before 1934
+    in a volume that also prints an era year, so the source offers no second opinion and no factor
+    can be derived FOR THAT LABEL. Counted, never assigned a divisor -- 122 of them are convicted by
+    29 on their own arithmetic, which is a separate and sufficient basis;
+  * `ambiguous_raw_label` (6 rows) and `overlap_other` (6 rows) are named rather than folded in.
+
+AND IT REFUTES A BLANKET DIVISION ON TEN ROWS, WHICH IS THE POINT OF DOING IT PER ROW. The 10
+`overlap_10x` rows are all `ivory coast` tobacco, and all 10 carry 29's verdict `plausible_yield` --
+the yield test says the PUBLISHED numbers are already fine. The raw explains why the factor
+disagrees, and the fault is in the clean volume rather than the era:
+
+    iia_1933_34  1933   334 t on 1,640 ha  =  0.20 t/ha
+    iia_1938_39  1933  3,300 t on 2,000 ha =  1.65 t/ha     <- a revision, not an inflation
+    iia_1939_45  1939-45  1,500-6,000 t on 2,000-6,000 ha = 0.75-1.50 t/ha
+
+Dividing those era cells by their measured 9.88x would push a plausible 0.75-1.50 t/ha down to
+0.09-0.19. So where the overlap factor and the physical yield test disagree, the yield test wins: it
+tests the row itself, while the factor tests a neighbouring cell in another edition. A blanket
+divisor would have damaged all ten.
+
+WHAT IT DOES NOT DO. It does not repair anything and it does not write to
+`yield_series_corrections.csv`, which `07_yield_consistency.py` regenerates -- an adjudication typed into
+a generated table is one re-run from being erased. `corrected_*` columns are what the measured factor
+WOULD produce, so that a decision to repair can be judged against agronomy before it is taken.
+
+Usage:
+  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py            # report only
+  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py --write    # refresh the table
+  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py --check    # fail if stale
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import statistics
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+STATE = os.path.join(HERE, "state")
+OUT = os.path.join(STATE, "era_volume_attribution.csv")
+VERDICTS = os.path.join(STATE, "era_shift_verdicts.csv")
+PROVENANCE = os.path.join(STATE, "iia_label_provenance.csv")
+EQUIVALENCES = os.path.join(STATE, "item_equivalences.csv")
+MATCHED = os.path.join(STATE, "matched_rows.parquet")
+DEFAULT_RAW = os.path.expanduser(
+    "~/3itkt6h41pb7jdan/2025-10-06_iia-dataframe/outputs/processed data/harmonized_data.xlsx")
+
+ITEMS = ("hops", "tobacco, unmanufactured")
+# The volumes whose windows END before 1934 print the clean unit; the two later ones print the
+# inflated one. 1933 is the last year a clean volume reaches, which is why the era starts at 1934.
+CLEAN_VOLUMES = ("iia_1909_21", "iia_1925_26", "iia_1929_30", "iia_1933_34")
+LATE_VOLUMES = ("iia_1938_39", "iia_1939_45")
+# t/ha. Tobacco leaf runs 0.5-3 and hops similar, so this is the band a corrected cell must land in
+# for the factor to have been the right one. It judges the correction; it does not choose the factor.
+PLAUSIBLE_LO, PLAUSIBLE_HI = 0.2, 3.0
+FACTOR_BAND = 0.20              # +/-20% around 100x / 10x, the band edition_conflicts.csv already uses
+MIN_CONTROL = 0.90              # the join must find this share of layer-B rows in the raw extract
+
+COLONIAL = ("british", "french", "dutch", "portuguese", "italian", "spanish", "german", "japanese",
+            "danish", "belgian", "american", "us", "soviet", "russian")
+
+FIELDS = ("source", "label", "item", "year", "period", "verdict", "convicted", "production",
+          "area_ha", "raw_label", "n_raw_labels", "volume", "n_volumes", "name_confirmed",
+          "resolution", "overlap_years", "n_overlap_years", "prod_factor", "area_factor",
+          "area_factor_pairs", "corrected_production", "corrected_area", "corrected_yield",
+          "attribution", "plausible_after")
+
+# Raw labels that are not territories: world and hemisphere aggregates, and the extract's own OCR
+# failures. They are excluded from the COMPONENT-SUM search only -- a world total that happens to
+# sum with something else to a country's figure is a coincidence, not a composition -- and never
+# from the single-cell join, where an exact value at an exact key is the evidence.
+NOT_A_TERRITORY = ("total", "[error]")
+
+
+def norm(s) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(s).lower()).strip()
+
+
+def is_rename(raw_label: str, lb_label: str) -> bool:
+    """Is the raw label the layer-B label wearing at most one colonial qualifier?
+
+    Same rule as `15_label_provenance.py`, and deliberately the conservative version: it is used here
+    only to CONFIRM a match the value join already made, so a miss costs a `name_confirmed` flag and
+    never a row.
+    """
+    a, b = norm(raw_label), norm(lb_label)
+    if a == b:
+        return True
+    parts = a.split()
+    if parts and parts[0] in COLONIAL:
+        parts = parts[1:]
+    return " ".join(parts) == b
+
+
+def _n(x, nd=6):
+    if x is None:
+        return ""
+    f = float(x)
+    return str(int(f)) if f == int(f) and abs(f) < 1e15 else repr(round(f, nd))
+
+
+def _f(s):
+    s = (s or "").strip()
+    return None if s == "" else float(s)
+
+
+def raw_product_for(item: str, equivalences: str) -> str | None:
+    """Layer-B item -> raw IIA product, via the tracked equivalence table only.
+
+    `item_equivalences.csv` stores the item WITHOUT the comma layer B writes (`tobacco
+    unmanufactured`), so the lookup is on the normalised name. Returning None is fatal upstream: a
+    silently unresolved item would attribute an empty population and print a clean report.
+    """
+    with open(equivalences, newline="") as fh:
+        for r in csv.DictReader(fh):
+            if norm(r["item"]) == norm(item):
+                return r["raw_product"]
+    return None
+
+
+def build(raw_path: str, matched: str) -> tuple[list[dict], dict]:
+    import pandas as pd
+
+    with open(VERDICTS, newline="") as fh:
+        verdicts = list(csv.DictReader(fh))
+    with open(PROVENANCE, newline="") as fh:
+        raw2lb = {norm(r["raw_label"]): norm(r["layer_b_label"])
+                  for r in csv.DictReader(fh) if r["layer_b_label"]}
+
+    products = {}
+    for item in ITEMS:
+        p = raw_product_for(item, EQUIVALENCES)
+        if p is None:
+            raise SystemExit(f"FAIL: item {item!r} has no raw_product in "
+                             f"{os.path.relpath(EQUIVALENCES, REPO)}; the join would silently "
+                             f"attribute nothing for it")
+        products[item] = p
+
+    raw = pd.read_excel(raw_path)
+    raw = raw[raw["product"].isin(set(products.values()))].copy()
+    # `year` mixes 1934 with '1934-1938'; coerce and keep the string form as the period key.
+    yr = pd.to_numeric(raw.year, errors="coerce")
+    raw["key"] = [int(y) if pd.notna(y) else str(s) for y, s in zip(yr, raw.year)]
+
+    idx = {}
+    for t in raw.itertuples():
+        idx.setdefault((t.product, t.variable, t.key), []).append(
+            (t.country, float(t.value), t.yearbook))
+
+    def resolve(label, product, variable, key, value):
+        cands = idx.get((product, variable, key), [])
+        exact = [c for c in cands if abs(c[1] - value) <= 1e-9 * max(1.0, abs(c[1]))]
+        named = [c for c in exact if is_rename(c[0], label) or raw2lb.get(norm(c[0])) == norm(label)]
+        return (named or exact), bool(named)
+
+    def resolve_pair(product, variable, key, value):
+        """A layer-B cell that is the SUM of two raw sub-labels printed in one volume.
+
+        Five era rows carry a value that appears nowhere in the raw extract, and every one of them is
+        a composition rather than a transcription. Searched within a single volume, over territory
+        labels only, each resolves to EXACTLY ONE exact two-part sum, and each pair is
+        geographically coherent -- which is why this is reported as a composition and not as a
+        numerical coincidence:
+
+            china, mainland  1934-1938  = china + china: manchuria
+            greece           1934-1938  = greece + italian dodecanese islands
+            indonesia        1934-1938  = dutch java and madura + dutch sumatra
+            indonesia        1940       = dutch java and madura + dutch sumatra
+            usa              1934-1938  = usa + us puerto rico
+
+        Uniqueness is the whole safeguard: if more than one pair sums to the value the row is left
+        unresolved rather than assigned the first one found. Two parts only -- a three-part search
+        over ~200 candidates would find something for almost any target, which is the point at which
+        an exact sum stops being evidence.
+        """
+        cands = [c for c in idx.get((product, variable, key), [])
+                 if 0 < c[1] < value and not str(c[0]).startswith(NOT_A_TERRITORY)]
+        hits = []
+        by_volume = {}
+        for c in cands:
+            by_volume.setdefault(c[2], []).append(c)
+        for _vol, group in by_volume.items():
+            for i in range(len(group)):
+                for j in range(i + 1, len(group)):
+                    if abs(group[i][1] + group[j][1] - value) <= 1e-9 * value:
+                        hits.append((group[i], group[j]))
+        if len(hits) != 1:
+            return []
+        return list(hits[0])
+
+    # --- POSITIVE CONTROL over the whole item population, not just the era ---------------------
+    control = {"rows": 0, "value_found": 0, "unique_volume": 0}
+    if os.path.exists(matched):
+        m = pd.read_parquet(matched)
+        m = m[m.source.eq("iia") & m.item.isin(ITEMS)]
+        unitvar = {"tonnes": "production", "ha": "area"}
+        for t in m.itertuples():
+            var = unitvar.get(t.unit)
+            if var is None:
+                continue
+            key = int(t.year) if pd.notna(t.year) else str(t.period)
+            got, _ = resolve(t.country, products[t.item], var, key, float(t.value))
+            control["rows"] += 1
+            control["value_found"] += bool(got)
+            control["unique_volume"] += len({g[2] for g in got}) == 1
+
+    # --- the label's own factor, from the volumes' overlap on the SAME cell --------------------
+    factors = {}
+    for (country, product, variable), g in raw.groupby(["country", "product", "variable"]):
+        clean = g[g.yearbook.isin(CLEAN_VOLUMES)].groupby("key").value.median()
+        late = g[g.yearbook.isin(LATE_VOLUMES)].groupby("key").value.median()
+        pairs = [(k, clean[k], late[k]) for k in clean.index
+                 if k in late.index and float(clean[k]) > 0]
+        if pairs:
+            factors[(country, product, variable)] = (
+                statistics.median(float(l) / float(c) for _k, c, l in pairs),
+                [str(k) for k, _c, _l in pairs])
+
+    rows = []
+    for v in verdicts:
+        item, label = v["item"], v["label"]
+        product = products[item]
+        prod = float(v["production"])
+        area = _f(v["area_ha"])
+        key = int(v["year"]) if v["year"] else str(v["period"])
+        got, named = resolve(label, product, "production", key, prod)
+        resolution = "single_cell" if got else "unresolved"
+        if not got:
+            got = resolve_pair(product, "production", key, prod)
+            if got:
+                resolution = "component_sum"
+        raw_labels = sorted({g[0] for g in got})
+        volumes = sorted({g[2] for g in got})
+
+        # THE FACTOR MUST NOT BE PICKED FROM A COINCIDENCE. Six rows match TWO raw labels, because
+        # two countries printed the same figure in the same year (`british transjordan` and
+        # `german south west africa` both at 1938). Taking the first candidate that happens to own a
+        # factor attributes one territory's factor to another -- measured: `benin` was handed
+        # `french ivory coast`'s 9.88x that way. So a factor is assigned only when every candidate
+        # that has one agrees with the others within the band, and the same rule then serves the
+        # component sums, where the two parts must have moved together for the sum's factor to mean
+        # anything.
+        cand_prod = [(rl, factors[(rl, product, "production")])
+                     for rl in raw_labels if (rl, product, "production") in factors]
+        cand_area = [(rl, factors[(rl, product, "area")])
+                     for rl in raw_labels if (rl, product, "area") in factors]
+
+        def _agree(cands):
+            vals = [c[1][0] for c in cands]
+            if not vals:
+                return None, []
+            lo, hi = min(vals), max(vals)
+            if lo > 0 and (hi - lo) > FACTOR_BAND * lo:
+                return None, []
+            return statistics.median(vals), sorted({y for c in cands for y in c[1][1]})
+
+        ambiguous = len(raw_labels) > 1 and len(cand_prod) != len(raw_labels)
+        pf, overlap = (None, []) if ambiguous else _agree(cand_prod)
+        af, area_years = (None, []) if ambiguous else _agree(cand_area)
+        area_pairs = len(area_years)
+
+        if not got:
+            attribution = "unresolved_in_raw"
+        elif ambiguous:
+            attribution = "ambiguous_raw_label"
+        elif pf is None:
+            attribution = "no_overlap_pair"
+        elif abs(pf - 100.0) <= FACTOR_BAND * 100.0:
+            attribution = "overlap_100x"
+        elif abs(pf - 10.0) <= FACTOR_BAND * 10.0:
+            attribution = "overlap_10x"
+        else:
+            attribution = "overlap_other"
+
+        # `is not None` throughout: a factor or a value of 0 must not be read as absent.
+        cp = (prod / pf) if pf is not None and pf > 0 else None
+        ca = None
+        if area is not None:
+            ca = (area / af) if af is not None and af > 0 else area
+        cy = (cp / ca) if cp is not None and ca is not None and ca > 0 else None
+        plaus = "" if cy is None else str(PLAUSIBLE_LO <= cy <= PLAUSIBLE_HI)
+
+        rows.append({
+            "source": v["source"], "label": label, "item": item, "year": v["year"],
+            "period": v["period"], "verdict": v["verdict"], "convicted": v["convicted"],
+            "production": v["production"], "area_ha": v["area_ha"],
+            "raw_label": "|".join(raw_labels), "n_raw_labels": str(len(raw_labels)),
+            "volume": "|".join(volumes), "n_volumes": str(len(volumes)),
+            "name_confirmed": str(named), "resolution": resolution,
+            "overlap_years": "|".join(overlap), "n_overlap_years": str(len(overlap)),
+            "prod_factor": _n(pf, 4), "area_factor": _n(af, 4),
+            "area_factor_pairs": str(area_pairs),
+            "corrected_production": _n(cp, 4), "corrected_area": _n(ca, 4),
+            "corrected_yield": _n(cy, 4), "attribution": attribution,
+            "plausible_after": plaus,
+        })
+    rows.sort(key=lambda r: (r["attribution"], r["label"], r["item"], r["year"], r["period"]))
+    return rows, control
+
+
+def write(rows: list[dict], path: str) -> None:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=FIELDS)
+            w.writeheader()
+            for r in rows:
+                w.writerow(r)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--raw", default=DEFAULT_RAW, help="raw IIA harmonized extract (xlsx)")
+    ap.add_argument("--matched", default=MATCHED, help="layer-B panel, for the positive control")
+    ap.add_argument("--min-control", type=float, default=MIN_CONTROL)
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.raw):
+        print(f"raw extract absent ({args.raw}); nothing to do", file=sys.stderr)
+        return 0
+    if not os.path.exists(VERDICTS):
+        print(f"FAIL: missing {os.path.relpath(VERDICTS, REPO)}", file=sys.stderr)
+        return 1
+
+    rows, control = build(args.raw, args.matched)
+
+    if control["rows"]:
+        share = control["value_found"] / control["rows"]
+        print(f"positive control: {control['value_found']} of {control['rows']} layer-B "
+              f"tobacco/hops rows found in the raw extract at the same key ({100 * share:.1f}%), "
+              f"{control['unique_volume']} resolved to one volume")
+        if share < args.min_control:
+            print(f"FAIL: the raw join found only {100 * share:.1f}% of layer-B rows, below "
+                  f"{100 * args.min_control:.0f}%. A join this thin reports 'no attribution' "
+                  f"uniformly, which reads like a finding and is not one", file=sys.stderr)
+            return 1
+    else:
+        print("positive control SKIPPED: layer-B panel absent, so the join is unverified",
+              file=sys.stderr)
+
+    order = ("overlap_100x", "overlap_10x", "overlap_other", "ambiguous_raw_label",
+             "no_overlap_pair", "unresolved_in_raw")
+    ac = {k: sum(1 for r in rows if r["attribution"] == k) for k in order}
+    print(f"{len(rows)} era row(s), {len({r['label'] for r in rows})} label(s)")
+    for k in order:
+        print(f"  {k:20} {ac[k]:4}")
+    res = {}
+    for r in rows:
+        res[r["resolution"]] = res.get(r["resolution"], 0) + 1
+    print("  resolution: " + ", ".join(f"{k}={n}" for k, n in sorted(res.items())))
+    vols = {}
+    for r in rows:
+        for v in (r["volume"].split("|") if r["volume"] else ["(unresolved)"]):
+            vols[v] = vols.get(v, 0) + 1
+    print("  volume of origin: " + ", ".join(f"{k}={n}" for k, n in sorted(vols.items())))
+    late = sum(n for k, n in vols.items() if k in LATE_VOLUMES)
+    clean = sum(n for k, n in vols.items() if k in CLEAN_VOLUMES)
+    print(f"  from a late volume {late}, from a clean volume {clean}")
+    testable = [r for r in rows if r["plausible_after"]]
+    ok = sum(1 for r in testable if r["plausible_after"] == "True")
+    print(f"  corrected yield inside {PLAUSIBLE_LO}-{PLAUSIBLE_HI} t/ha: {ok} of {len(testable)} "
+          f"rows that have both a factor and an area")
+
+    if args.check:
+        if not os.path.exists(OUT):
+            print(f"MISSING {os.path.relpath(OUT, REPO)}", file=sys.stderr)
+            return 1
+        with open(OUT, newline="") as fh:
+            have = list(csv.DictReader(fh))
+        if have != [{k: str(v) for k, v in r.items()} for r in rows]:
+            print(f"STALE {os.path.relpath(OUT, REPO)}: rerun with --write", file=sys.stderr)
+            return 1
+        print("table is current")
+        return 0
+    if args.write:
+        write(rows, OUT)
+        print(f"wrote {os.path.relpath(OUT, REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipelines/polity-autoimprove/40_era_volume_attribution.py
+++ b/pipelines/polity-autoimprove/40_era_volume_attribution.py
@@ -22,7 +22,7 @@ WHY THE JOIN IS BY VALUE AND KEY, WITH THE NAME AS CONFIRMATION. A bare NAME joi
 and layer B reports "absent in raw" for nearly everything, because the raw labels are colonial
 (`japanese taiwan`, `british nyasaland`, `uk`) and layer B's are modern. `state/iia_label_provenance.csv`
 maps 335 of them but not all -- 32 of the 72 labels in `edition_conflicts.csv` for these two items have no
-entry -- so a provenance-only join reaches 154 era rows where a value join reaches 246. The join used here
+entry -- so a provenance-only join reaches 154 era rows where a value join reaches 247. The join used here
 is therefore (raw product, variable, year-or-period, exact value), with the provenance map and a
 colonial-prefix rename test used to CONFIRM the label rather than to find it, and `name_confirmed`
 recording which rows got that second opinion.
@@ -52,7 +52,8 @@ WHAT THE ATTRIBUTION ESTABLISHES, and it is stronger than the year heuristic alr
     in a volume that also prints an era year, so the source offers no second opinion and no factor
     can be derived FOR THAT LABEL. Counted, never assigned a divisor -- 122 of them are convicted by
     29 on their own arithmetic, which is a separate and sufficient basis;
-  * `ambiguous_raw_label` (6 rows) and `overlap_other` (6 rows) are named rather than folded in.
+  * `ambiguous_raw_label` (3 rows), `component_factor_incomplete` (3) and `overlap_other` (6) are
+    named rather than folded in.
 
 AND IT REFUTES A BLANKET DIVISION ON TEN ROWS, WHICH IS THE POINT OF DOING IT PER ROW. The 10
 `overlap_10x` rows are all `ivory coast` tobacco, and all 10 carry 29's verdict `plausible_yield` --
@@ -304,7 +305,16 @@ def build(raw_path: str, matched: str) -> tuple[list[dict], dict]:
             if not vals:
                 return None, []
             lo, hi = min(vals), max(vals)
-            if lo > 0 and (hi - lo) > FACTOR_BAND * lo:
+            # A NON-POSITIVE FACTOR IS A MEASUREMENT, NOT A MISSING VALUE: 84 rows have an AREA
+            # factor of exactly 0, because the late volume printed a zero area where the clean one
+            # printed a positive one (`edition_conflicts.csv` calls that `zero_contradicted`). It is
+            # kept and reported, and the division guards on `> 0` so it is never used as a divisor.
+            # What must not happen is averaging a 0 with a 10: `lo > 0` would skip the band test
+            # entirely and return a median of 5, a number describing neither candidate.
+            if lo <= 0:
+                if hi != lo:
+                    return None, []
+            elif (hi - lo) > FACTOR_BAND * lo:
                 return None, []
             return statistics.median(vals), sorted({y for c in cands for y in c[1][1]})
 
@@ -316,7 +326,13 @@ def build(raw_path: str, matched: str) -> tuple[list[dict], dict]:
         if not got:
             attribution = "unresolved_in_raw"
         elif ambiguous:
-            attribution = "ambiguous_raw_label"
+            # Two shapes, kept apart because they mean different things. A COMPONENT SUM whose parts
+            # do not both carry a factor is incomplete evidence about a known composition; two
+            # candidate labels for one value is a genuine ambiguity about which territory the cell
+            # belongs to. Calling both "ambiguous" would hide that the china and indonesia rows have
+            # a settled provenance and only lack one part's overlap.
+            attribution = ("component_factor_incomplete" if resolution == "component_sum"
+                           else "ambiguous_raw_label")
         elif pf is None:
             attribution = "no_overlap_pair"
         elif abs(pf - 100.0) <= FACTOR_BAND * 100.0:
@@ -401,7 +417,7 @@ def main() -> int:
               file=sys.stderr)
 
     order = ("overlap_100x", "overlap_10x", "overlap_other", "ambiguous_raw_label",
-             "no_overlap_pair", "unresolved_in_raw")
+             "component_factor_incomplete", "no_overlap_pair", "unresolved_in_raw")
     ac = {k: sum(1 for r in rows if r["attribution"] == k) for k in order}
     print(f"{len(rows)} era row(s), {len({r['label'] for r in rows})} label(s)")
     for k in order:

--- a/pipelines/polity-autoimprove/41_era_volume_attribution.py
+++ b/pipelines/polity-autoimprove/41_era_volume_attribution.py
@@ -75,9 +75,9 @@ a generated table is one re-run from being erased. `corrected_*` columns are wha
 WOULD produce, so that a decision to repair can be judged against agronomy before it is taken.
 
 Usage:
-  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py            # report only
-  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py --write    # refresh the table
-  python3 pipelines/polity-autoimprove/40_era_volume_attribution.py --check    # fail if stale
+  python3 pipelines/polity-autoimprove/41_era_volume_attribution.py            # report only
+  python3 pipelines/polity-autoimprove/41_era_volume_attribution.py --write    # refresh the table
+  python3 pipelines/polity-autoimprove/41_era_volume_attribution.py --check    # fail if stale
 """
 from __future__ import annotations
 

--- a/pipelines/polity-autoimprove/state/era_shift_verdicts.csv
+++ b/pipelines/polity-autoimprove/state/era_shift_verdicts.csv
@@ -311,7 +311,6 @@ iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1936,,tonnes,71700,0,,294.7,
 iia,tunisia,TUN-1881-2025,"tobacco, unmanufactured",1937,,tonnes,55900,0,,294.7,189.684425,impossible_yield_zero_area,True
 iia,austria,AUT-1919-2025,hops,,1934-1938,tonnes,4900,,,327.5,14.961832,no_area_level_consistent,False
 iia,ecuador,ECU-1800-1942,"tobacco, unmanufactured",,1934-1938,tonnes,69000,,,12751.05,5.411319,no_area_level_consistent,False
-iia,germany,DEU-1945-1949,"tobacco, unmanufactured",1945,,tonnes,0,,,25833.9,0,no_area_level_consistent,False
 iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1939,,tonnes,5800,,,654,8.868502,no_area_level_consistent,False
 iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1940,,tonnes,2900,,,654,4.434251,no_area_level_consistent,False
 iia,guinea,GIN-1894-1958,"tobacco, unmanufactured",1942,,tonnes,2800,,,654,4.281346,no_area_level_consistent,False
@@ -331,6 +330,7 @@ iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1943,,tonnes,18400,,,20000,0
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1944,,tonnes,16900,,,20000,0.845,no_area_level_consistent,False
 iia,reunion,REU-1816-1946,"tobacco, unmanufactured",1945,,tonnes,22300,,,20000,1.115,no_area_level_consistent,False
 iia,romania,ROU-1920-1940,hops,,1934-1938,tonnes,1900,,,1770.3,1.073264,no_area_level_consistent,False
+iia,germany,DEU-1945-1949,"tobacco, unmanufactured",1945,,tonnes,0,,,25833.9,0,no_area_level_drop,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1943,,tonnes,271300,,,1903.2,142.549391,no_area_level_shift,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1944,,tonnes,256500,,,1903.2,134.773014,no_area_level_shift,True
 iia,angola,ANG-1905-1975,"tobacco, unmanufactured",1945,,tonnes,267800,,,1903.2,140.710383,no_area_level_shift,True

--- a/pipelines/polity-autoimprove/state/era_volume_attribution.csv
+++ b/pipelines/polity-autoimprove/state/era_volume_attribution.csv
@@ -1,0 +1,428 @@
+source,label,item,year,period,verdict,convicted,production,area_ha,raw_label,n_raw_labels,volume,n_volumes,name_confirmed,resolution,overlap_years,n_overlap_years,prod_factor,area_factor,area_factor_pairs,corrected_production,corrected_area,corrected_yield,attribution,plausible_after
+iia,benin,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,4000,0,french dahomey|french ivory coast,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
+iia,benin,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,4000,0,french dahomey|french ivory coast,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
+iia,"china, mainland","tobacco, unmanufactured",,1934-1938,impossible_yield,True,64152300,566000,china|china: manchuria,2,iia_1939_45,1,False,component_sum,,0,,,0,,566000,,ambiguous_raw_label,
+iia,indonesia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3471000,41000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,41000,,ambiguous_raw_label,
+iia,indonesia,"tobacco, unmanufactured",1940,,impossible_yield,True,2079600,19000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,19000,,ambiguous_raw_label,
+iia,micronesia (federated states of),"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,200,0,french mauritania|japanese south pacific,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
+iia,angola,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,237100,4000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1934,,impossible_yield,True,201700,3000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1935,,impossible_yield,True,241400,4000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1936,,impossible_yield,True,249100,4000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1937,,impossible_yield,True,218300,4000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1939,,impossible_yield,True,204900,3000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1940,,impossible_yield,True,220200,4000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1941,,impossible_yield,True,273700,5000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1942,,impossible_yield,True,357800,6000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,6000,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1943,,no_area_level_shift,True,271300,,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1944,,no_area_level_shift,True,256500,,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,angola,"tobacco, unmanufactured",1945,,no_area_level_shift,True,267800,,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,argentina,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1552200,16000,argentina,1,iia_1939_45,1,True,single_cell,,0,,,0,,16000,,no_overlap_pair,
+iia,australia,hops,,1934-1938,impossible_yield,True,104500,400,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,400,,no_overlap_pair,
+iia,australia,hops,1934,,impossible_yield,True,93700,4000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,hops,1935,,impossible_yield,True,109000,4000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,hops,1936,,impossible_yield,True,107800,5000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,australia,hops,1937,,impossible_yield,True,103300,4000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,hops,1939,,impossible_yield,True,90400,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,hops,1940,,impossible_yield,True,146400,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,hops,1941,,impossible_yield,True,137500,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,hops,1942,,impossible_yield,True,126000,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,hops,1943,,impossible_yield,True,133900,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,hops,1944,,impossible_yield,True,118500,500,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,500,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,215700,4000,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1934,,impossible_yield,True,141200,3000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1935,,impossible_yield,True,252100,4000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1936,,impossible_yield,True,235800,5000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1937,,impossible_yield,True,271200,4000,australia,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1939,,impossible_yield,True,224800,3000,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,australia,"tobacco, unmanufactured",1940,,impossible_yield,True,248400,3000,australia,1,iia_1939_45,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,5200,,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,4000,0,french dahomey,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,4000,0,french dahomey,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1939,,no_area_level_shift,True,6900,,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1940,,no_area_level_shift,True,6600,,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1941,,no_area_level_shift,True,7300,,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1942,,high_yield_3to20,False,15800,1000,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1943,,impossible_yield,True,22900,1000,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1944,,impossible_yield,True,56600,1000,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,benin,"tobacco, unmanufactured",1945,,impossible_yield,True,56200,2000,french dahomey,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,bolivia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,353500,3000,bolivia,1,iia_1939_45,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",,1934-1938,untestable,False,900,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",1939,,untestable,False,900,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",1940,,untestable,False,800,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",1941,,untestable,False,500,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",1943,,untestable,False,27200,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cabo verde,"tobacco, unmanufactured",1944,,untestable,False,5500,,portuguese cape verde,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,cameroon,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,4400,0,british‑french cameroon,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,cameroon,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,10000,0,british‑french cameroon,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,cameroon,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,7000,0,british‑french cameroon,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,chile,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,691800,3000,chile,1,iia_1939_45,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,chile,"tobacco, unmanufactured",1939,,impossible_yield,True,956500,5000,chile,1,iia_1939_45,1,True,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,"china, mainland","tobacco, unmanufactured",1940,,impossible_yield,True,51345800,442000,china,1,iia_1939_45,1,True,single_cell,,0,,,0,,442000,,no_overlap_pair,
+iia,colombia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1224100,11000,colombia,1,iia_1939_45,1,True,single_cell,,0,,,0,,11000,,no_overlap_pair,
+iia,costa rica,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,26500,1000,costa rica,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,dominican republic,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,696394900,,dominican republic,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,dr congo,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,404600,5000,belgian congo,1,iia_1939_45,1,True,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,ecuador,"tobacco, unmanufactured",,1934-1938,no_area_level_consistent,False,69000,,ecuador,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,el salvador,"tobacco, unmanufactured",,1934-1938,plausible_yield,False,21000,63000,el salvador,1,iia_1939_45,1,True,single_cell,,0,,,0,,63000,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,13700,4000,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,11900,0,british swaziland,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,12800,0,british swaziland,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,9100,0,british swaziland,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,10600,0,british swaziland,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1939,,no_area_level_shift,True,19200,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1940,,no_area_level_shift,True,15600,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1941,,no_area_level_shift,True,13200,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1942,,no_area_level_shift,True,26300,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1943,,no_area_level_shift,True,16000,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,eswatini,"tobacco, unmanufactured",1944,,no_area_level_shift,True,15600,,british swaziland,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,honduras,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,337300,6000,honduras,1,iia_1939_45,1,True,single_cell,,0,,,0,,6000,,no_overlap_pair,
+iia,iran,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1500000,12000,iran,1,iia_1939_45,1,True,single_cell,,0,,,0,,12000,,no_overlap_pair,
+iia,iran,"tobacco, unmanufactured",1940,,impossible_yield,True,1270000,13000,iran,1,iia_1939_45,1,True,single_cell,,0,,,0,,13000,,no_overlap_pair,
+iia,iraq,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,510700,4000,british iraq,1,iia_1939_45,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,iraq,"tobacco, unmanufactured",1940,,impossible_yield,True,422000,7000,british iraq,1,iia_1939_45,1,True,single_cell,,0,,,0,,7000,,no_overlap_pair,
+iia,ireland,"tobacco, unmanufactured",,1934-1938,untestable,False,18500,,ireland,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,108000,2000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1939,,impossible_yield,True,62400,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1940,,impossible_yield,True,76000,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1941,,impossible_yield,True,49700,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1942,,impossible_yield,True,44800,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1943,,impossible_yield,True,23600,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1944,,impossible_yield,True,74900,1000,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,lebanon,"tobacco, unmanufactured",1945,,untestable,False,121400,,french lebanon,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,libya,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,75000,,italian libya,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,30200,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,27600,0,british mauritius,1,iia_1938_39,1,True,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,32000,0,british mauritius,1,iia_1938_39,1,True,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,47800,0,british mauritius,1,iia_1938_39,1,True,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1939,,no_area_level_shift,True,26900,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1940,,no_area_level_shift,True,36300,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1941,,no_area_level_shift,True,36000,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1942,,no_area_level_shift,True,39900,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1943,,no_area_level_shift,True,32000,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,mauritius,"tobacco, unmanufactured",1944,,no_area_level_shift,True,28700,,british mauritius,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,micronesia (federated states of),"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,1000,0,japanese south pacific,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,micronesia (federated states of),"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,1100,0,japanese south pacific,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,micronesia (federated states of),"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,400,0,japanese south pacific,1,iia_1938_39,1,False,single_cell,,0,,,0,,0,,no_overlap_pair,
+iia,mozambique,"tobacco, unmanufactured",1935,,high_yield_3to20,False,18700,1000,portuguese mozambique: company concession,1,iia_1938_39,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,mozambique,"tobacco, unmanufactured",1936,,high_yield_3to20,False,18700,1000,portuguese mozambique: province,1,iia_1938_39,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,myanmar,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,4519600,40000,british burma,1,iia_1939_45,1,False,single_cell,,0,,,0,,40000,,no_overlap_pair,
+iia,myanmar,"tobacco, unmanufactured",1940,,impossible_yield,True,6247200,56000,british burma,1,iia_1939_45,1,False,single_cell,,0,,,0,,56000,,no_overlap_pair,
+iia,netherlands,"tobacco, unmanufactured",1945,,untestable,False,0,,netherlands,1,iia_1939_45,1,True,single_cell,,0,,0,1,,,,no_overlap_pair,
+iia,new zealand,hops,,1934-1938,impossible_yield,True,39700,300,new zealand,1,iia_1939_45,1,True,single_cell,,0,,9.7087,1,,30.9,,no_overlap_pair,
+iia,paraguay,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,765300,9000,paraguay,1,iia_1939_45,1,True,single_cell,,0,,,0,,9000,,no_overlap_pair,
+iia,peru,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,92500,,peru,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",,1934-1938,plausible_yield,False,19700,108000,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,108000,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1934,,no_area_level_consistent,False,20000,,french reunion,1,iia_1938_39,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1935,,no_area_level_consistent,False,20000,,french reunion,1,iia_1938_39,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1936,,no_area_level_consistent,False,20000,,french reunion,1,iia_1938_39,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1939,,no_area_level_consistent,False,16500,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1940,,no_area_level_consistent,False,15200,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1941,,no_area_level_consistent,False,17600,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1942,,no_area_level_consistent,False,19600,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1943,,no_area_level_consistent,False,18400,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1944,,no_area_level_consistent,False,16900,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,reunion,"tobacco, unmanufactured",1945,,no_area_level_consistent,False,22300,,french reunion,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,russian federation,hops,,1934-1938,impossible_yield,True,100000,2000,ussr,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,sri lanka,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,95400,6000,british ceylon,1,iia_1939_45,1,False,single_cell,,0,,1.0526,1,,5700,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",,1934-1938,untestable,False,1000,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1939,,untestable,False,2200,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1940,,untestable,False,1200,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1941,,untestable,False,1800,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1943,,untestable,False,400,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1944,,untestable,False,900,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,suriname,"tobacco, unmanufactured",1945,,untestable,False,300,,dutch guiana,1,iia_1939_45,1,True,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,272200,4000,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",1940,,no_area_level_shift,True,553500,,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",1941,,impossible_yield,True,474500,7000,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,7000,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",1942,,high_yield_3to20,False,60400,6000,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,6000,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",1943,,impossible_yield,True,287500,5000,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,5000,,no_overlap_pair,
+iia,syrian arab republic,"tobacco, unmanufactured",1944,,impossible_yield,True,392500,6000,french syria,1,iia_1939_45,1,False,single_cell,,0,,,0,,6000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,24800,2000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1939,,impossible_yield,True,44700,2000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1940,,impossible_yield,True,52400,2000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1941,,impossible_yield,True,65900,3000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1942,,impossible_yield,True,83000,3000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,3000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1943,,impossible_yield,True,106900,4000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1944,,impossible_yield,True,104000,4000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,tanzania,"tobacco, unmanufactured",1945,,impossible_yield,True,95000,4000,british tanganyika,1,iia_1939_45,1,False,single_cell,,0,,,0,,4000,,no_overlap_pair,
+iia,thailand,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,882800,10000,siam,1,iia_1939_45,1,True,single_cell,,0,,,0,,10000,,no_overlap_pair,
+iia,thailand,"tobacco, unmanufactured",1940,,impossible_yield,True,937900,8000,siam,1,iia_1939_45,1,True,single_cell,,0,,,0,,8000,,no_overlap_pair,
+iia,uruguay,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,54000,1000,uruguay,1,iia_1939_45,1,True,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,venezuela,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,322100,8000,venezuela,1,iia_1939_45,1,True,single_cell,,0,,,0,,8000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,73800,2000,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1934,,impossible_yield,True,70600,1000,british northern rhodesia,1,iia_1938_39,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1935,,impossible_yield,True,57800,1000,british northern rhodesia,1,iia_1938_39,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1936,,impossible_yield,True,57200,1000,british northern rhodesia,1,iia_1938_39,1,False,single_cell,,0,,,0,,1000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1937,,impossible_yield,True,93700,2000,british northern rhodesia,1,iia_1938_39,1,False,single_cell,,0,,,0,,2000,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1939,,no_area_level_shift,True,100900,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1940,,no_area_level_shift,True,104300,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1941,,no_area_level_shift,True,122500,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1942,,no_area_level_shift,True,98400,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1943,,no_area_level_shift,True,107900,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zambia,"tobacco, unmanufactured",1944,,no_area_level_shift,True,131500,,british northern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,,,no_overlap_pair,
+iia,zimbabwe,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1050600,19000,british southern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,19000,,no_overlap_pair,
+iia,zimbabwe,"tobacco, unmanufactured",1945,,impossible_yield,True,2141800,35000,british southern rhodesia,1,iia_1939_45,1,False,single_cell,,0,,,0,,35000,,no_overlap_pair,
+iia,albania,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,161200,2000,albania,1,iia_1939_45,1,True,single_cell,1933,1,99.9724,0.9597,1,1612.4449,2084,0.7737,overlap_100x,True
+iia,algeria,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1913900,23000,french algeria,1,iia_1939_45,1,True,single_cell,1933,1,99.9159,1.0048,1,19155.1016,22889.0588,0.8369,overlap_100x,True
+iia,algeria,"tobacco, unmanufactured",1945,,impossible_yield,True,680400,10000,french algeria,1,iia_1939_45,1,True,single_cell,1933,1,99.9159,1.0048,1,6809.7242,9951.7647,0.6843,overlap_100x,True
+iia,american samoa,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,2000,0,us samoa,1,iia_1938_39,1,False,single_cell,1933,1,100,0,1,20,0,,overlap_100x,
+iia,austria,hops,,1934-1938,no_area_level_consistent,False,4900,,austria,1,iia_1939_45,1,True,single_cell,1933,1,99.7024,17.8571,1,49.1463,,,overlap_100x,
+iia,belgium,hops,,1934-1938,impossible_yield,True,120600,900,belgium,1,iia_1939_45,1,True,single_cell,1933,1,100.0419,10.0503,1,1205.4954,89.55,13.4617,overlap_100x,False
+iia,belgium,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,633800,3000,belgium,1,iia_1939_45,1,True,single_cell,1933,1,99.9984,1.1161,1,6338.0993,2688,2.3579,overlap_100x,True
+iia,brazil,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,9265800,99000,brazil,1,iia_1939_45,1,True,single_cell,1933,1,90.4909,,0,102394.8162,99000,1.0343,overlap_100x,True
+iia,bulgaria,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,13056700,34000,bulgaria,1,iia_1939_45,1,True,single_cell,1933,1,100.0016,0.9923,1,130564.8645,34263.1852,3.8106,overlap_100x,False
+iia,burundi,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,34800,,belgian ruanda-urundi,1,iia_1939_45,1,False,single_cell,1933,1,100,0,1,348,,,overlap_100x,
+iia,burundi,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,52500,0,belgian ruanda-urundi,1,iia_1938_39,1,False,single_cell,1933,1,100,0,1,525,0,,overlap_100x,
+iia,burundi,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,52500,0,belgian ruanda-urundi,1,iia_1938_39,1,False,single_cell,1933,1,100,0,1,525,0,,overlap_100x,
+iia,burundi,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,23000,0,belgian ruanda-urundi,1,iia_1938_39,1,False,single_cell,1933,1,100,0,1,230,0,,overlap_100x,
+iia,canada,hops,,1934-1938,impossible_yield,True,73100,400,canada,1,iia_1939_45,1,True,single_cell,1933,1,99.9851,10.0503,1,731.1091,39.8,18.3696,overlap_100x,False
+iia,canada,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,2846800,24000,canada,1,iia_1939_45,1,True,single_cell,1933,1,100.0688,1.0217,1,28448.4324,23489.6842,1.2111,overlap_100x,True
+iia,"china, taiwan province of","tobacco, unmanufactured",,1934-1938,impossible_yield,True,225300,1000,japanese taiwan,1,iia_1939_45,1,False,single_cell,1933,1,100.0195,1.287,1,2252.5602,777,2.899,overlap_100x,True
+iia,"china, taiwan province of","tobacco, unmanufactured",1934,,impossible_yield,True,214000,1000,japanese taiwan,1,iia_1938_39,1,False,single_cell,1933,1,100.0195,1.287,1,2139.5823,777,2.7536,overlap_100x,True
+iia,"china, taiwan province of","tobacco, unmanufactured",1935,,impossible_yield,True,203500,1000,japanese taiwan,1,iia_1938_39,1,False,single_cell,1933,1,100.0195,1.287,1,2034.6028,777,2.6185,overlap_100x,True
+iia,"china, taiwan province of","tobacco, unmanufactured",1936,,no_area_level_shift,True,222400,,japanese taiwan,1,iia_1938_39,1,False,single_cell,1933,1,100.0195,1.287,1,2223.5659,,,overlap_100x,
+iia,"china, taiwan province of","tobacco, unmanufactured",1937,,impossible_yield,True,261100,1000,japanese taiwan,1,iia_1938_39,1,False,single_cell,1933,1,100.0195,1.287,1,2610.4904,777,3.3597,overlap_100x,False
+iia,"china, taiwan province of","tobacco, unmanufactured",1940,,impossible_yield,True,471700,4000,japanese taiwan,1,iia_1939_45,1,False,single_cell,1933,1,100.0195,1.287,1,4716.0793,3108,1.5174,overlap_100x,True
+iia,congo,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,102100,7000,french equatorial africa,1,iia_1939_45,1,True,single_cell,1933,1,100,0.973,1,1021,7194.4444,0.1419,overlap_100x,False
+iia,congo,"tobacco, unmanufactured",1934,,high_yield_3to20,False,108500,7000,french equatorial africa,1,iia_1938_39,1,True,single_cell,1933,1,100,0.973,1,1085,7194.4444,0.1508,overlap_100x,False
+iia,congo,"tobacco, unmanufactured",1935,,high_yield_3to20,False,100000,6000,french equatorial africa,1,iia_1938_39,1,True,single_cell,1933,1,100,0.973,1,1000,6166.6667,0.1622,overlap_100x,False
+iia,cuba,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,2192100,45000,cuba,1,iia_1939_45,1,True,single_cell,1933,1,101.4137,0.9896,1,21615.4274,45474,0.4753,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,23600,1000,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,235.5462,1000,0.2355,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",1934,,impossible_yield,True,72500,2000,british cyprus,1,iia_1938_39,1,True,single_cell,1933,1,100.1927,0,1,723.6058,2000,0.3618,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",1935,,no_area_level_shift,True,26800,,british cyprus,1,iia_1938_39,1,True,single_cell,1933,1,100.1927,0,1,267.4846,,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,13700,0,british cyprus,1,iia_1938_39,1,True,single_cell,1933,1,100.1927,0,1,136.7365,0,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,3400,0,british cyprus,1,iia_1938_39,1,True,single_cell,1933,1,100.1927,0,1,33.9346,0,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1938,,no_area_level_shift,True,1600,,british cyprus,1,iia_1938_39,1,True,single_cell,1933,1,100.1927,0,1,15.9692,,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1939,,no_area_level_shift,True,5200,,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,51.9,,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1940,,no_area_level_shift,True,16500,,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,164.6827,,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1941,,impossible_yield,True,21300,1000,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,212.5904,1000,0.2126,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",1942,,no_area_level_shift,True,46500,,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,464.1058,,,overlap_100x,
+iia,cyprus,"tobacco, unmanufactured",1943,,impossible_yield,True,68100,2000,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,679.6904,2000,0.3398,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",1944,,impossible_yield,True,56800,1000,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,566.9077,1000,0.5669,overlap_100x,True
+iia,cyprus,"tobacco, unmanufactured",1945,,impossible_yield,True,81300,2000,british cyprus,1,iia_1939_45,1,True,single_cell,1933,1,100.1927,0,1,811.4365,2000,0.4057,overlap_100x,True
+iia,czech republic,hops,,1934-1938,impossible_yield,True,973500,11300,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,9734.5341,1126.3796,8.6423,overlap_100x,False
+iia,czech republic,hops,1934,,high_yield_3to20,False,707400,109000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0048,10.0321,1,7073.6614,10865.0777,0.651,overlap_100x,True
+iia,czech republic,hops,1935,,high_yield_3to20,False,761900,112000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0048,10.0321,1,7618.6353,11164.1165,0.6824,overlap_100x,True
+iia,czech republic,hops,1936,,high_yield_3to20,False,1208100,114000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0048,10.0321,1,12080.4218,11363.4757,1.0631,overlap_100x,True
+iia,czech republic,hops,1937,,high_yield_3to20,False,1216500,113000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0048,10.0321,1,12164.4178,11263.7961,1.08,overlap_100x,True
+iia,czech republic,hops,1939,,impossible_yield,True,763400,10500,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,7633.6346,1046.6359,7.2935,overlap_100x,False
+iia,czech republic,hops,1940,,impossible_yield,True,457600,8900,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,4575.781,887.1485,5.1579,overlap_100x,False
+iia,czech republic,hops,1941,,impossible_yield,True,352700,7500,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,3526.8312,747.5971,4.7176,overlap_100x,False
+iia,czech republic,hops,1942,,impossible_yield,True,310700,7300,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,3106.8513,727.6612,4.2696,overlap_100x,False
+iia,czech republic,hops,1943,,impossible_yield,True,315200,6300,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,3151.8491,627.9816,5.019,overlap_100x,False
+iia,czech republic,hops,1944,,high_yield_3to20,False,46100,7000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,460.9779,697.7573,0.6607,overlap_100x,True
+iia,czech republic,hops,1945,,impossible_yield,True,372100,8300,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,10.0321,1,3720.8219,827.3408,4.4973,overlap_100x,False
+iia,czech republic,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,41410600,10000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,414091.9363,10030,41.2853,overlap_100x,False
+iia,czech republic,"tobacco, unmanufactured",1934,,impossible_yield,True,1368300,10000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.997,1,13682.5353,10030,1.3642,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1935,,impossible_yield,True,1363100,10000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.997,1,13630.5371,10030,1.359,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1936,,impossible_yield,True,1507200,10000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.997,1,15071.4881,10030,1.5026,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1937,,impossible_yield,True,1403600,10000,czechoslovakia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.997,1,14035.5233,10030,1.3994,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1939,,impossible_yield,True,933000,6000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,9329.6831,6018,1.5503,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1940,,impossible_yield,True,780000,6000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,7799.7351,6018,1.2961,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1941,,impossible_yield,True,691400,5000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,6913.7652,5015,1.3786,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1942,,impossible_yield,True,746800,5000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,7467.7464,5015,1.4891,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1943,,impossible_yield,True,542900,2000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,5428.8156,2006,2.7063,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1944,,impossible_yield,True,392800,3000,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,3927.8666,3009,1.3054,overlap_100x,True
+iia,czech republic,"tobacco, unmanufactured",1945,,no_area_level_shift,True,250000,,czechoslovakia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.997,1,2499.9151,,,overlap_100x,
+iia,eritrea,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,2600,,italian eritrea,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,26,,,overlap_100x,
+iia,eritrea,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,3500,0,italian eritrea,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,35,0,,overlap_100x,
+iia,eritrea,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,2500,0,italian eritrea,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,25,0,,overlap_100x,
+iia,eritrea,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,2700,0,italian eritrea,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,27,0,,overlap_100x,
+iia,eritrea,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,2100,0,italian eritrea,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,21,0,,overlap_100x,
+iia,france,hops,,1934-1938,impossible_yield,True,223900,1800,france,1,iia_1939_45,1,True,single_cell,1933,1,100.0208,9.9532,1,2238.5342,180.8471,12.3781,overlap_100x,False
+iia,france,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3566700,18000,france,1,iia_1939_45,1,True,single_cell,1933,1,99.9986,1.0177,1,35667.5018,17687,2.0166,overlap_100x,True
+iia,germany,hops,,1934-1938,impossible_yield,True,908700,9600,germany,1,iia_1939_45,1,True,single_cell,1933,1,100.0059,10.0355,1,9086.465,956.6,9.4987,overlap_100x,False
+iia,germany,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3360700,13000,germany,1,iia_1939_45,1,True,single_cell,1933,1,99.9986,1.0019,1,33607.4567,12975.0833,2.5902,overlap_100x,True
+iia,germany,"tobacco, unmanufactured",1945,,no_area_level_drop,True,0,,germany,1,iia_1939_45,1,True,single_cell,1933,1,99.9986,1.0019,1,0,,,overlap_100x,
+iia,greece,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,5737600,89000,greece|italian dodecanese islands,2,iia_1939_45,1,False,component_sum,1933,1,99.7978,1.0057,1,57492.2774,88493.3846,0.6497,overlap_100x,True
+iia,guatemala,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,82200,2000,guatemala,1,iia_1939_45,1,True,single_cell,1933,1,99.6678,,0,824.74,2000,0.4124,overlap_100x,True
+iia,guinea,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,20700,3000,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,207,3000,0.069,overlap_100x,False
+iia,guinea,"tobacco, unmanufactured",1934,,high_yield_3to20,False,27600,3000,french guinea,1,iia_1938_39,1,True,single_cell,1933,1,100,,0,276,3000,0.092,overlap_100x,False
+iia,guinea,"tobacco, unmanufactured",1935,,high_yield_3to20,False,22100,3000,french guinea,1,iia_1938_39,1,True,single_cell,1933,1,100,,0,221,3000,0.0737,overlap_100x,False
+iia,guinea,"tobacco, unmanufactured",1936,,high_yield_3to20,False,22000,3000,french guinea,1,iia_1938_39,1,True,single_cell,1933,1,100,,0,220,3000,0.0733,overlap_100x,False
+iia,guinea,"tobacco, unmanufactured",1937,,high_yield_3to20,False,23500,3000,french guinea,1,iia_1938_39,1,True,single_cell,1933,1,100,,0,235,3000,0.0783,overlap_100x,False
+iia,guinea,"tobacco, unmanufactured",1939,,no_area_level_consistent,False,5800,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,58,,,overlap_100x,
+iia,guinea,"tobacco, unmanufactured",1940,,no_area_level_consistent,False,2900,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,29,,,overlap_100x,
+iia,guinea,"tobacco, unmanufactured",1942,,no_area_level_consistent,False,2800,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,28,,,overlap_100x,
+iia,guinea,"tobacco, unmanufactured",1943,,no_area_level_consistent,False,3100,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,31,,,overlap_100x,
+iia,guinea,"tobacco, unmanufactured",1944,,no_area_level_consistent,False,2100,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,21,,,overlap_100x,
+iia,guinea,"tobacco, unmanufactured",1945,,no_area_level_consistent,False,7700,,french guinea,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,77,,,overlap_100x,
+iia,hungary,hops,,1934-1938,impossible_yield,True,6600,100,hungary,1,iia_1939_45,1,True,single_cell,1933,1,99.8308,9.3458,1,66.1119,10.7,6.1787,overlap_100x,False
+iia,hungary,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,2047600,15000,hungary,1,iia_1939_45,1,True,single_cell,1933,1,99.9992,0.9838,1,20476.1717,15246.6667,1.343,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,138600,3000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,1384.6831,2799,0.4947,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1934,,impossible_yield,True,101100,2000,british palestine,1,iia_1938_39,1,False,single_cell,1933,1,100.0951,1.0718,1,1010.0394,1866,0.5413,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1935,,impossible_yield,True,100000,2000,british palestine|french equatorial africa,2,iia_1938_39,1,False,single_cell,1933,1,100.0476,1.0224,1,999.5247,1956.1965,0.511,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1936,,impossible_yield,True,123700,3000,british palestine,1,iia_1938_39,1,False,single_cell,1933,1,100.0951,1.0718,1,1235.8247,2799,0.4415,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1937,,impossible_yield,True,250400,6000,british palestine,1,iia_1938_39,1,False,single_cell,1933,1,100.0951,1.0718,1,2501.6209,5598,0.4469,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1939,,impossible_yield,True,52300,2000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,522.5031,1866,0.28,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1940,,impossible_yield,True,98500,2000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,984.0641,1866,0.5274,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1941,,impossible_yield,True,58900,1000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,588.4404,933,0.6307,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1942,,impossible_yield,True,141900,3000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,1417.6518,2799,0.5065,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1943,,impossible_yield,True,128900,3000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,1287.7753,2799,0.4601,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1944,,impossible_yield,True,168300,3000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,1681.401,2799,0.6007,overlap_100x,True
+iia,israel,"tobacco, unmanufactured",1945,,impossible_yield,True,136000,3000,british palestine,1,iia_1939_45,1,False,single_cell,1933,1,100.0951,1.0718,1,1358.7078,2799,0.4854,overlap_100x,True
+iia,italy,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,4375800,33000,italy,1,iia_1939_45,1,True,single_cell,1933,1,99.9993,0.9874,1,43758.2958,33421.4571,1.3093,overlap_100x,True
+iia,japan,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,6410500,35000,japan,1,iia_1939_45,1,True,single_cell,1933,1,99.9998,1.0043,1,64105.0963,34850.7353,1.8394,overlap_100x,True
+iia,japan,"tobacco, unmanufactured",1940,,impossible_yield,True,8705400,49000,japan,1,iia_1939_45,1,True,single_cell,1933,1,99.9998,1.0043,1,87054.1308,48791.0294,1.7842,overlap_100x,True
+iia,jordan,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,4000,,british transjordan,1,iia_1939_45,1,False,single_cell,1933,1,100.5025,,0,39.8,,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1934,,no_area_level_shift,True,1400,,british transjordan,1,iia_1938_39,1,False,single_cell,1933,1,100.5025,,0,13.93,,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1935,,no_area_level_shift,True,4100,,british transjordan,1,iia_1938_39,1,False,single_cell,1933,1,100.5025,,0,40.795,,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1936,,no_area_level_consistent,False,500,,british transjordan,1,iia_1938_39,1,False,single_cell,1933,1,100.5025,,0,4.975,,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,9700,0,british transjordan,1,iia_1938_39,1,False,single_cell,1933,1,100.5025,,0,96.515,0,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1938,,no_area_level_shift,True,4300,,british transjordan|german south west africa,2,iia_1938_39,1,False,single_cell,1933,1,99.6809,,0,43.1376,,,overlap_100x,
+iia,jordan,"tobacco, unmanufactured",1939,,no_area_level_shift,True,3600,,british transjordan,1,iia_1939_45,1,False,single_cell,1933,1,100.5025,,0,35.82,,,overlap_100x,
+iia,libya,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,69600,0,italian libya: tripolitania,1,iia_1938_39,1,False,single_cell,1933,1,99.8514,0,1,697.0357,0,,overlap_100x,
+iia,libya,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,68400,0,italian libya: tripolitania,1,iia_1938_39,1,False,single_cell,1933,1,99.8514,0,1,685.0179,0,,overlap_100x,
+iia,libya,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,85000,0,italian libya: tripolitania,1,iia_1938_39,1,False,single_cell,1933,1,99.8514,0,1,851.2649,0,,overlap_100x,
+iia,madagascar,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,559200,7000,french madagascar,1,iia_1939_45,1,True,single_cell,1933,1,100,1,1,5592,7000,0.7989,overlap_100x,True
+iia,madagascar,"tobacco, unmanufactured",1945,,impossible_yield,True,193300,3000,french madagascar,1,iia_1939_45,1,True,single_cell,1933,1,100,1,1,1933,3000,0.6443,overlap_100x,True
+iia,malaysia,"tobacco, unmanufactured",,1934-1938,high_yield_3to20,False,16000,2000,british borneo,1,iia_1939_45,1,False,single_cell,1933,1,99.8884,0,1,160.1788,2000,0.0801,overlap_100x,False
+iia,malaysia,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,12600,0,british borneo,1,iia_1938_39,1,False,single_cell,1933,1,99.8884,0,1,126.1408,0,,overlap_100x,
+iia,malaysia,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,13500,0,british borneo,1,iia_1938_39,1,False,single_cell,1933,1,99.8884,0,1,135.1508,0,,overlap_100x,
+iia,malaysia,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,14300,0,british borneo,1,iia_1938_39,1,False,single_cell,1933,1,99.8884,0,1,143.1598,0,,overlap_100x,
+iia,malaysia,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,21100,0,british borneo,1,iia_1938_39,1,False,single_cell,1933,1,99.8884,0,1,211.2358,0,,overlap_100x,
+iia,mali,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,139000,2000,french sudan,1,iia_1939_45,1,False,single_cell,1933,1,111.245,1.3423,1,1249.4946,1490,0.8386,overlap_100x,True
+iia,mali,"tobacco, unmanufactured",1934,,impossible_yield,True,150000,3000,french sudan,1,iia_1938_39,1,False,single_cell,1933,1,111.245,1.3423,1,1348.3755,2235,0.6033,overlap_100x,True
+iia,mali,"tobacco, unmanufactured",1935,,impossible_yield,True,155000,3000,french sudan,1,iia_1938_39,1,False,single_cell,1933,1,111.245,1.3423,1,1393.3213,2235,0.6234,overlap_100x,True
+iia,mali,"tobacco, unmanufactured",1936,,impossible_yield,True,150000,1000,french sudan,1,iia_1938_39,1,False,single_cell,1933,1,111.245,1.3423,1,1348.3755,745,1.8099,overlap_100x,True
+iia,mali,"tobacco, unmanufactured",1937,,impossible_yield,True,120000,1000,french sudan,1,iia_1938_39,1,False,single_cell,1933,1,111.245,1.3423,1,1078.7004,745,1.4479,overlap_100x,True
+iia,mauritania,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,1600,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,16,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,500,0,french mauritania,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,5,0,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,700,0,french mauritania,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,7,0,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1936,,no_area_level_shift,True,6500,,french mauritania,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,65,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,200,0,french mauritania,1,iia_1938_39,1,True,single_cell,1933,1,100,0,1,2,0,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1939,,no_area_level_consistent,False,100,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,1,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1940,,no_area_level_shift,True,200,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,2,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1941,,no_area_level_shift,True,300,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,3,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1942,,no_area_level_shift,True,200,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,2,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1943,,no_area_level_shift,True,400,,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,4,,,overlap_100x,
+iia,mauritania,"tobacco, unmanufactured",1944,,high_yield_3to20,False,5200,1000,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,52,1000,0.052,overlap_100x,False
+iia,mauritania,"tobacco, unmanufactured",1945,,high_yield_3to20,False,5000,1000,french mauritania,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,50,1000,0.05,overlap_100x,False
+iia,mexico,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1543100,18000,mexico,1,iia_1939_45,1,True,single_cell,1933,1,102.4023,1.0346,1,15068.9973,17397.6923,0.8661,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,34700,,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,346.7845,,,overlap_100x,
+iia,morocco,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,32100,0,french morocco,1,iia_1938_39,1,True,single_cell,1933,1,100.0622,0,1,320.8006,0,,overlap_100x,
+iia,morocco,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,17600,0,french morocco,1,iia_1938_39,1,True,single_cell,1933,1,100.0622,0,1,175.8907,0,,overlap_100x,
+iia,morocco,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,47400,0,french morocco,1,iia_1938_39,1,True,single_cell,1933,1,100.0622,0,1,473.7056,0,,overlap_100x,
+iia,morocco,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,41700,0,french morocco,1,iia_1938_39,1,True,single_cell,1933,1,100.0622,0,1,416.741,0,,overlap_100x,
+iia,morocco,"tobacco, unmanufactured",1939,,impossible_yield,True,41100,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,410.7447,1000,0.4107,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",1940,,impossible_yield,True,60100,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,600.6267,1000,0.6006,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",1941,,impossible_yield,True,60500,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,604.6242,1000,0.6046,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",1942,,impossible_yield,True,51700,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,516.6789,1000,0.5167,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",1943,,impossible_yield,True,103400,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,1033.3578,1000,1.0334,overlap_100x,True
+iia,morocco,"tobacco, unmanufactured",1944,,impossible_yield,True,100500,1000,french morocco,1,iia_1939_45,1,True,single_cell,1933,1,100.0622,0,1,1004.3758,1000,1.0044,overlap_100x,True
+iia,namibia,"tobacco, unmanufactured",1934,,no_area_level_shift,True,3100,,german south west africa,1,iia_1938_39,1,False,single_cell,1933,1,98.8593,,0,31.3577,,,overlap_100x,
+iia,namibia,"tobacco, unmanufactured",1935,,no_area_level_shift,True,2100,,german south west africa,1,iia_1938_39,1,False,single_cell,1933,1,98.8593,,0,21.2423,,,overlap_100x,
+iia,namibia,"tobacco, unmanufactured",1936,,no_area_level_shift,True,7300,,german south west africa,1,iia_1938_39,1,False,single_cell,1933,1,98.8593,,0,73.8423,,,overlap_100x,
+iia,namibia,"tobacco, unmanufactured",1937,,no_area_level_shift,True,18100,,german south west africa,1,iia_1938_39,1,False,single_cell,1933,1,98.8593,,0,183.0885,,,overlap_100x,
+iia,namibia,"tobacco, unmanufactured",1938,,no_area_level_shift,True,4300,,british transjordan|german south west africa,2,iia_1938_39,1,False,single_cell,1933,1,99.6809,,0,43.1376,,,overlap_100x,
+iia,new zealand,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,62000,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,620.4413,730,0.8499,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1934,,impossible_yield,True,50200,1000,new zealand,1,iia_1938_39,1,True,single_cell,1933,1,99.9289,1.3699,1,502.3573,730,0.6882,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1935,,impossible_yield,True,48300,1000,new zealand,1,iia_1938_39,1,True,single_cell,1933,1,99.9289,1.3699,1,483.3438,730,0.6621,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1936,,impossible_yield,True,68700,1000,new zealand,1,iia_1938_39,1,True,single_cell,1933,1,99.9289,1.3699,1,687.489,730,0.9418,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1937,,impossible_yield,True,79300,1000,new zealand,1,iia_1938_39,1,True,single_cell,1933,1,99.9289,1.3699,1,793.5644,730,1.0871,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1939,,impossible_yield,True,99800,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,998.7103,730,1.3681,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1940,,impossible_yield,True,142100,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1422.0114,730,1.948,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1941,,impossible_yield,True,123400,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1234.8783,730,1.6916,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1942,,impossible_yield,True,144500,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1446.0285,730,1.9809,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1943,,impossible_yield,True,139100,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1391.99,730,1.9068,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1944,,impossible_yield,True,149100,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1492.0612,730,2.0439,overlap_100x,True
+iia,new zealand,"tobacco, unmanufactured",1945,,impossible_yield,True,158800,1000,new zealand,1,iia_1939_45,1,True,single_cell,1933,1,99.9289,1.3699,1,1589.1302,730,2.1769,overlap_100x,True
+iia,nicaragua,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,55000,1000,nicaragua,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,550,1000,0.55,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,44900,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,510.2273,1000,0.5102,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1934,,impossible_yield,True,42400,1000,french niger,1,iia_1938_39,1,True,single_cell,1933,1,88,0,1,481.8182,1000,0.4818,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1935,,impossible_yield,True,50000,1000,french niger,1,iia_1938_39,1,True,single_cell,1933,1,88,0,1,568.1818,1000,0.5682,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1936,,no_area_level_shift,True,65000,,french niger,1,iia_1938_39,1,True,single_cell,1933,1,88,0,1,738.6364,,,overlap_100x,
+iia,niger,"tobacco, unmanufactured",1937,,impossible_yield,True,35000,1000,french niger,1,iia_1938_39,1,True,single_cell,1933,1,88,0,1,397.7273,1000,0.3977,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1939,,impossible_yield,True,36000,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,409.0909,1000,0.4091,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1940,,impossible_yield,True,43000,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,488.6364,1000,0.4886,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1941,,impossible_yield,True,50500,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,573.8636,1000,0.5739,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1942,,impossible_yield,True,39800,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,452.2727,1000,0.4523,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1943,,impossible_yield,True,48000,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,545.4545,1000,0.5455,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1944,,impossible_yield,True,47000,1000,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,534.0909,1000,0.5341,overlap_100x,True
+iia,niger,"tobacco, unmanufactured",1945,,no_area_level_shift,True,50000,,french niger,1,iia_1939_45,1,True,single_cell,1933,1,88,0,1,568.1818,,,overlap_100x,
+iia,philippines,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3212700,65000,us philippines,1,iia_1939_45,1,True,single_cell,1933,1,99.9993,1.0052,1,32127.2309,64662.0,0.4968,overlap_100x,True
+iia,philippines,"tobacco, unmanufactured",1940,,impossible_yield,True,3440600,72000,us philippines,1,iia_1939_45,1,True,single_cell,1933,1,99.9993,1.0052,1,34406.2472,71625.6,0.4804,overlap_100x,True
+iia,poland,hops,,1934-1938,impossible_yield,True,177200,3200,poland,1,iia_1939_45,1,True,single_cell,1933,1,100.026,10.0228,1,1771.5389,319.2727,5.5487,overlap_100x,False
+iia,poland,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1137200,6000,poland,1,iia_1939_45,1,True,single_cell,1933,1,100.0042,1.06,1,11371.5279,5660.4,2.009,overlap_100x,True
+iia,romania,hops,,1934-1938,no_area_level_consistent,False,1900,,romania,1,iia_1939_45,1,True,single_cell,1933,1,94.7368,500,1,20.0556,,,overlap_100x,
+iia,romania,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1132300,16000,romania,1,iia_1939_45,1,True,single_cell,1933,1,100.0048,0.9898,1,11322.4591,16164.8,0.7004,overlap_100x,True
+iia,russian federation,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,22403500,199000,ussr,1,iia_1939_45,1,False,single_cell,1933,1,87.6101,1.042,1,255718.244,190979.0816,1.339,overlap_100x,True
+iia,russian federation,"tobacco, unmanufactured",1934,,impossible_yield,True,17207000,191000,ussr,1,iia_1938_39,1,False,single_cell,1933,1,87.6101,1.042,1,196404.304,183301.5306,1.0715,overlap_100x,True
+iia,russian federation,"tobacco, unmanufactured",1936,,impossible_yield,True,27600000,203000,ussr,1,iia_1938_39,1,False,single_cell,1933,1,87.6101,1.042,1,315032.1841,194817.8571,1.6171,overlap_100x,True
+iia,serbia,hops,,1934-1938,impossible_yield,True,180400,2700,yugoslavia,1,iia_1939_45,1,True,single_cell,1933,1,99.9795,10.0354,1,1804.3697,269.0471,6.7065,overlap_100x,False
+iia,serbia,hops,1934,,high_yield_3to20,False,143300,24000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,99.9795,10.0354,1,1433.2936,2391.5294,0.5993,overlap_100x,True
+iia,serbia,hops,1935,,high_yield_3to20,False,189100,26000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,99.9795,10.0354,1,1891.3875,2590.8235,0.73,overlap_100x,True
+iia,serbia,hops,1936,,high_yield_3to20,False,196200,27000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,99.9795,10.0354,1,1962.402,2690.4706,0.7294,overlap_100x,True
+iia,serbia,hops,1937,,high_yield_3to20,False,213200,29000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,99.9795,10.0354,1,2132.4369,2889.7647,0.7379,overlap_100x,True
+iia,serbia,hops,1938,,high_yield_3to20,False,160000,28000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,99.9795,10.0354,1,1600.3279,2790.1176,0.5736,overlap_100x,True
+iia,serbia,hops,1939,,impossible_yield,True,181500,2800,yugoslavia,1,iia_1939_45,1,True,single_cell,1933,1,99.9795,10.0354,1,1815.3719,279.0118,6.5064,overlap_100x,False
+iia,serbia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,1348200,15000,yugoslavia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.9871,1,13481.5378,15196.3636,0.8872,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1934,,impossible_yield,True,604900,7000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.9871,1,6048.7926,7091.6364,0.8529,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1935,,impossible_yield,True,924900,12000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.9871,1,9248.6829,12157.0909,0.7608,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1936,,impossible_yield,True,1662400,18000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.9871,1,16623.4301,18235.6364,0.9116,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1937,,impossible_yield,True,2078300,21000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.9871,1,20782.2875,21274.9091,0.9768,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1938,,impossible_yield,True,1470800,16000,yugoslavia,1,iia_1938_39,1,True,single_cell,1933,1,100.0034,0.9871,1,14707.4958,16209.4545,0.9073,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1939,,impossible_yield,True,1543300,18000,yugoslavia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.9871,1,15432.4709,18235.6364,0.8463,overlap_100x,True
+iia,serbia,"tobacco, unmanufactured",1945,,impossible_yield,True,1270100,14000,yugoslavia,1,iia_1939_45,1,True,single_cell,1933,1,100.0034,0.9871,1,12700.5646,14183.2727,0.8955,overlap_100x,True
+iia,south africa,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,913100,14000,union of south africa,1,iia_1939_45,1,True,single_cell,1933,1,92.0866,,0,9915.6706,14000,0.7083,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,2252500,17000,japanese korea,1,iia_1939_45,1,False,single_cell,1933,1,99.997,0.9668,1,22525.6804,17583.2308,1.2811,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1934,,impossible_yield,True,1540400,15000,japanese korea,1,iia_1938_39,1,False,single_cell,1933,1,99.997,0.9668,1,15404.4653,15514.6154,0.9929,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1935,,impossible_yield,True,2192100,16000,japanese korea,1,iia_1938_39,1,False,single_cell,1933,1,99.997,0.9668,1,21921.6621,16548.9231,1.3247,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1936,,impossible_yield,True,2062600,17000,japanese korea,1,iia_1938_39,1,False,single_cell,1933,1,99.997,0.9668,1,20626.623,17583.2308,1.1731,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1937,,impossible_yield,True,2648800,19000,japanese korea,1,iia_1938_39,1,False,single_cell,1933,1,99.997,0.9668,1,26488.8001,19651.8462,1.3479,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1938,,impossible_yield,True,2798400,20000,japanese korea,1,iia_1938_39,1,False,single_cell,1933,1,99.997,0.9668,1,27984.8453,20686.1538,1.3528,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1939,,impossible_yield,True,3101900,22000,japanese korea,1,iia_1939_45,1,False,single_cell,1933,1,99.997,0.9668,1,31019.937,22754.7692,1.3632,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1940,,impossible_yield,True,2924900,22000,japanese korea,1,iia_1939_45,1,False,single_cell,1933,1,99.997,0.9668,1,29249.8835,22754.7692,1.2854,overlap_100x,True
+iia,south korea,"tobacco, unmanufactured",1941,,impossible_yield,True,3512000,23000,japanese korea,1,iia_1939_45,1,False,single_cell,1933,1,99.997,0.9668,1,35121.0608,23789.0769,1.4764,overlap_100x,True
+iia,spain,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,707100,4000,spain,1,iia_1939_45,1,True,single_cell,1933,1,100.0179,0.8,1,7069.7337,5000,1.4139,overlap_100x,True
+iia,sweden,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,50300,,sweden,1,iia_1939_45,1,True,single_cell,1933,1,100,0,1,503,,,overlap_100x,
+iia,switzerland,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,106700,1000,switzerland,1,iia_1939_45,1,True,single_cell,1933,1,100,,0,1067,1000,1.067,overlap_100x,True
+iia,syrian arab republic,"tobacco, unmanufactured",1934,,impossible_yield,True,335600,5000,french syria and lebanon,1,iia_1938_39,1,False,single_cell,1933,1,99.9836,1.0116,1,3356.5512,4942.8571,0.6791,overlap_100x,True
+iia,syrian arab republic,"tobacco, unmanufactured",1935,,impossible_yield,True,201400,4000,french syria and lebanon,1,iia_1938_39,1,False,single_cell,1933,1,99.9836,1.0116,1,2014.3308,3954.2857,0.5094,overlap_100x,True
+iia,syrian arab republic,"tobacco, unmanufactured",1936,,impossible_yield,True,540900,7000,french syria and lebanon,1,iia_1938_39,1,False,single_cell,1933,1,99.9836,1.0116,1,5409.8885,6920.0,0.7818,overlap_100x,True
+iia,syrian arab republic,"tobacco, unmanufactured",1937,,impossible_yield,True,517900,6000,french syria and lebanon,1,iia_1938_39,1,False,single_cell,1933,1,99.9836,1.0116,1,5179.8507,5931.4286,0.8733,overlap_100x,True
+iia,syrian arab republic,"tobacco, unmanufactured",1938,,impossible_yield,True,341000,4000,french syria and lebanon,1,iia_1938_39,1,False,single_cell,1933,1,99.9836,1.0116,1,3410.5601,3954.2857,0.8625,overlap_100x,True
+iia,tunisia,"tobacco, unmanufactured",,1934-1938,no_area_level_shift,True,58100,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,581.5696,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1934,,impossible_yield,True,65000,1000,french tunisia,1,iia_1938_39,1,True,single_cell,1933,1,99.9021,0,1,650.6373,1000,0.6506,overlap_100x,True
+iia,tunisia,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,59500,0,french tunisia,1,iia_1938_39,1,True,single_cell,1933,1,99.9021,0,1,595.5833,0,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,71700,0,french tunisia,1,iia_1938_39,1,True,single_cell,1933,1,99.9021,0,1,717.7029,0,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,55900,0,french tunisia,1,iia_1938_39,1,True,single_cell,1933,1,99.9021,0,1,559.548,0,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1939,,no_area_level_shift,True,53600,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,536.5255,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1940,,no_area_level_shift,True,53200,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,532.5216,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1941,,no_area_level_shift,True,56900,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,569.5578,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1942,,no_area_level_shift,True,38100,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,381.3735,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1943,,no_area_level_shift,True,49700,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,497.4873,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1944,,no_area_level_shift,True,40900,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,409.401,,,overlap_100x,
+iia,tunisia,"tobacco, unmanufactured",1945,,no_area_level_shift,True,25900,,french tunisia,1,iia_1939_45,1,True,single_cell,1933,1,99.9021,0,1,259.2539,,,overlap_100x,
+iia,turkey,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,5543300,72000,turkey,1,iia_1939_45,1,True,single_cell,1933,1,113.5179,0.9994,1,48831.9332,72045.1765,0.6778,overlap_100x,True
+iia,turkey,"tobacco, unmanufactured",1940,,impossible_yield,True,7135600,78000,turkey,1,iia_1939_45,1,True,single_cell,1933,1,113.5179,0.9994,1,62858.7922,78048.9412,0.8054,overlap_100x,True
+iia,united kingdom,hops,,1934-1938,impossible_yield,True,1271100,7400,uk,1,iia_1939_45,1,False,single_cell,1933,1,99.9982,9.9459,1,12711.2317,744.0265,17.0844,overlap_100x,False
+iia,united states of america,hops,,1934-1938,impossible_yield,True,1768000,14000,usa,1,iia_1939_45,1,False,single_cell,1933,1,100.0017,10.031,1,17679.7074,1395.6748,12.6675,overlap_100x,False
+iia,united states of america,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,60387500,627000,us puerto rico|usa,2,iia_1939_45,1,False,component_sum,1933,1,99.1283,0.9835,1,609185.1694,637524.7308,0.9555,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,168700,2000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,1687,2906,0.5805,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1934,,impossible_yield,True,124500,1000,french tonkin,1,iia_1938_39,1,False,single_cell,1933,1,100,0.6882,1,1245,1453,0.8568,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1935,,impossible_yield,True,111200,1000,french tonkin,1,iia_1938_39,1,False,single_cell,1933,1,100,0.6882,1,1112,1453,0.7653,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1936,,impossible_yield,True,140100,1000,french tonkin,1,iia_1938_39,1,False,single_cell,1933,1,100,0.6882,1,1401,1453,0.9642,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1937,,impossible_yield,True,270000,3000,french tonkin,1,iia_1938_39,1,False,single_cell,1933,1,100,0.6882,1,2700,4359,0.6194,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1939,,impossible_yield,True,170000,2000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,1700,2906,0.585,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1940,,impossible_yield,True,165100,2000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,1651,2906,0.5681,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1941,,impossible_yield,True,240000,3000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,2400,4359,0.5506,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1942,,impossible_yield,True,249000,3000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,2490,4359,0.5712,overlap_100x,True
+iia,viet nam,"tobacco, unmanufactured",1943,,impossible_yield,True,250000,3000,french tonkin,1,iia_1939_45,1,False,single_cell,1933,1,100,0.6882,1,2500,4359,0.5735,overlap_100x,True
+iia,ivory coast,"tobacco, unmanufactured",,1934-1938,plausible_yield,False,3000,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,303.6364,1640,0.1851,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1934,,plausible_yield,False,4000,2000,french ivory coast,1,iia_1938_39,1,True,single_cell,1933,1,9.8802,1.2195,1,404.8485,1640,0.2469,overlap_10x,True
+iia,ivory coast,"tobacco, unmanufactured",1935,,plausible_yield,False,4000,2000,french ivory coast,1,iia_1938_39,1,True,single_cell,1933,1,9.8802,1.2195,1,404.8485,1640,0.2469,overlap_10x,True
+iia,ivory coast,"tobacco, unmanufactured",1939,,plausible_yield,False,1500,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,151.8182,1640,0.0926,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1940,,plausible_yield,False,1500,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,151.8182,1640,0.0926,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1941,,plausible_yield,False,3000,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,303.6364,1640,0.1851,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1942,,plausible_yield,False,3000,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,303.6364,1640,0.1851,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1943,,plausible_yield,False,3000,2000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,303.6364,1640,0.1851,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1944,,plausible_yield,False,4500,4000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,455.4545,3280,0.1389,overlap_10x,False
+iia,ivory coast,"tobacco, unmanufactured",1945,,plausible_yield,False,6000,6000,french ivory coast,1,iia_1939_45,1,True,single_cell,1933,1,9.8802,1.2195,1,607.2727,4920,0.1234,overlap_10x,False
+iia,french polynesia,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,300,0,french oceania,1,iia_1938_39,1,False,single_cell,1933,1,13.6364,0,1,22,0,,overlap_other,
+iia,french polynesia,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,300,0,french oceania,1,iia_1938_39,1,False,single_cell,1933,1,13.6364,0,1,22,0,,overlap_other,
+iia,french polynesia,"tobacco, unmanufactured",1936,,impossible_yield_zero_area,True,300,0,french oceania,1,iia_1938_39,1,False,single_cell,1933,1,13.6364,0,1,22,0,,overlap_other,
+iia,french polynesia,"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,300,0,french oceania,1,iia_1938_39,1,False,single_cell,1933,1,13.6364,0,1,22,0,,overlap_other,
+iia,malawi,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,129900,3000,british nyasaland,1,iia_1939_45,1,False,single_cell,1933,1,180.8988,2.0427,1,718.081,1468.6154,0.489,overlap_other,True
+iia,malawi,"tobacco, unmanufactured",1945,,impossible_yield,True,101200,2000,british nyasaland,1,iia_1939_45,1,False,single_cell,1933,1,180.8988,2.0427,1,559.4288,979.0769,0.5714,overlap_other,True

--- a/pipelines/polity-autoimprove/state/era_volume_attribution.csv
+++ b/pipelines/polity-autoimprove/state/era_volume_attribution.csv
@@ -1,10 +1,10 @@
 source,label,item,year,period,verdict,convicted,production,area_ha,raw_label,n_raw_labels,volume,n_volumes,name_confirmed,resolution,overlap_years,n_overlap_years,prod_factor,area_factor,area_factor_pairs,corrected_production,corrected_area,corrected_yield,attribution,plausible_after
 iia,benin,"tobacco, unmanufactured",1934,,impossible_yield_zero_area,True,4000,0,french dahomey|french ivory coast,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
 iia,benin,"tobacco, unmanufactured",1935,,impossible_yield_zero_area,True,4000,0,french dahomey|french ivory coast,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
-iia,"china, mainland","tobacco, unmanufactured",,1934-1938,impossible_yield,True,64152300,566000,china|china: manchuria,2,iia_1939_45,1,False,component_sum,,0,,,0,,566000,,ambiguous_raw_label,
-iia,indonesia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3471000,41000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,41000,,ambiguous_raw_label,
-iia,indonesia,"tobacco, unmanufactured",1940,,impossible_yield,True,2079600,19000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,19000,,ambiguous_raw_label,
 iia,micronesia (federated states of),"tobacco, unmanufactured",1937,,impossible_yield_zero_area,True,200,0,french mauritania|japanese south pacific,2,iia_1938_39,1,False,single_cell,,0,,,0,,0,,ambiguous_raw_label,
+iia,"china, mainland","tobacco, unmanufactured",,1934-1938,impossible_yield,True,64152300,566000,china|china: manchuria,2,iia_1939_45,1,False,component_sum,,0,,,0,,566000,,component_factor_incomplete,
+iia,indonesia,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,3471000,41000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,41000,,component_factor_incomplete,
+iia,indonesia,"tobacco, unmanufactured",1940,,impossible_yield,True,2079600,19000,dutch java and madura|dutch sumatra,2,iia_1939_45,1,False,component_sum,,0,,,0,,19000,,component_factor_incomplete,
 iia,angola,"tobacco, unmanufactured",,1934-1938,impossible_yield,True,237100,4000,portuguese angola,1,iia_1939_45,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,
 iia,angola,"tobacco, unmanufactured",1934,,impossible_yield,True,201700,3000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,3000,,no_overlap_pair,
 iia,angola,"tobacco, unmanufactured",1935,,impossible_yield,True,241400,4000,portuguese angola,1,iia_1938_39,1,True,single_cell,,0,,,0,,4000,,no_overlap_pair,

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -2152,6 +2152,58 @@ def mutate_era_zero_area_exonerated(root, gpd, make_valid, affinity):
             f"ZERO hectares -- from {before} to no_area_level_consistent, i.e. reported as fine, with "
             f"`convicted` flipped to match so every other arm stays quiet")
 
+def mutate_era_level_drop_exonerated(root, gpd, make_valid, affinity):
+    """Put the low-side row back where the ONE-SIDED ratio test left it: reported as fine.
+
+    Until issue 416, `29_era_shift_verdicts.py` convicted a no-area row at `>= 30x` the label's own
+    pre-1934 median and filed everything else `no_area_level_consistent`. There was no filter to grep
+    for -- the exoneration was the `else` branch -- so a value could not be too SMALL to fail:
+
+        germany / tobacco, unmanufactured / 1945   production 0   baseline 25,833.9   ratio 0.0
+        verdict: no_area_level_consistent
+
+    A production of ZERO reported as consistent with a 25,834 t baseline, which is the LARGEST
+    disagreement a ratio can express rather than a small one.
+
+    WHY THIS CASE IS NEEDED AND THE OBVIOUS ONE IS NOT ENOUGH. The tempting case is a
+    `no_area_level_drop` row whose ratio has been pushed above 1/30 -- the class contradicting its own
+    number. That fires, but it only protects the new class from being MISLABELLED. It does nothing
+    about the low arm being DELETED: drop it from the tool and its row goes back to
+    `no_area_level_consistent`, exactly the pre-fix state, and a gate that only checks the drop class
+    has no drop rows left to check and passes. So this mutation reproduces the DELETION rather than a
+    typo, and the only arm that can see it is the one requiring `no_area_level_consistent` to sit
+    strictly between 1/30 and 30x.
+
+    Every other arm stays quiet BY CONSTRUCTION. `convicted` is flipped to False so arm A agrees with
+    the new verdict; the row carries no area and therefore no implied_yield, so arms B and D have
+    nothing to say; its year is 1945, so arm E is satisfied; and `ratio_to_own` is left untouched at
+    its true 0.0, because the whole point is that the NUMBER was always there and the classifier had
+    no way to say "too small" about it.
+
+    It picks the row by verdict rather than by name, since which label occupies this class moves when
+    the panel is rebuilt, and it refuses to pass vacuously if the class is empty.
+    """
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/era_shift_verdicts.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+        fields = list(rows[0])
+    drops = [r for r in rows if r["verdict"] == "no_area_level_drop"]
+    if not drops:
+        raise AssertionError("no no_area_level_drop rows in era_shift_verdicts.csv, so this mutation "
+                             "has nothing to exonerate and the case would pass vacuously")
+    # The most absurd one to clear: the ratio furthest below the line, which is the smallest ratio.
+    hit = min(drops, key=lambda r: float(r["ratio_to_own"]))
+    hit["verdict"] = "no_area_level_consistent"
+    hit["convicted"] = "False"
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        w.writerows(rows)
+    return (f"refiled {hit['label']} {hit['item']!r} {hit['year']} -- production "
+            f"{hit['production']} against a pre-era median of {hit['own_pre_era_median']}, ratio "
+            f"{hit['ratio_to_own']} -- as no_area_level_consistent, i.e. reported as fine, which is "
+            f"the state the one-sided ratio test left it in")
+
 def mutate_overlap_code_not_a_polity(root, gpd, make_valid, affinity):
     """Point an overlap row at a polity code that does not exist.
 
@@ -5065,6 +5117,15 @@ CASES = (
         "a row with 85,000 tonnes of production on ZERO hectares reclassified as fine, with "
         "`convicted` flipped to match so arms A, B and C stay quiet -- only the zero-area rule stands "
         "between the `if area > 0` guard and 14 exonerated impossible rows",
+    ),
+    (
+        "validate_era_shift_verdicts.py",
+        mutate_era_level_drop_exonerated,
+        "outside the band",
+        "a production of ZERO refiled as consistent with a 25,834 t pre-era median -- the state the "
+        "one-sided ratio test left it in, where a value could not be too SMALL to fail. It reproduces "
+        "the low arm being DELETED rather than mislabelled, which the class's own threshold clause "
+        "cannot see: with the arm gone there are no drop rows left for that clause to check",
     ),
     (
         "validate_derived_counts.py",

--- a/scripts/validate_era_shift_verdicts.py
+++ b/scripts/validate_era_shift_verdicts.py
@@ -27,15 +27,26 @@ blank cells as 0 and its window is exactly this era -- so two open defects inter
 area disables the yield test for the production row beside it.
 
 Checks:
-  A. VOCABULARY -- seven verdicts, and `convicted` agrees with which of them convict.
+  A. VOCABULARY -- eight verdicts, and `convicted` agrees with which of them convict.
   B. ARITHMETIC -- `implied_yield` is production/area where area > 0, `ratio_to_own` is
      production/own_pre_era_median, and a row with no area carries no yield.
   C. THRESHOLD COHERENCE -- each verdict's own numbers must place it in that class: nothing called
-     impossible below 20 t/ha, nothing called plausible above 3, nothing called a level shift below 30x.
-     This is what stops a threshold being edited in the tool while the table keeps its old labels.
+     impossible below 20 t/ha, nothing called plausible above 3, nothing called a level shift below 30x,
+     nothing called a level DROP above 1/30, and nothing called level-CONSISTENT outside the band
+     between the two. This is what stops a threshold being edited in the tool while the table keeps
+     its old labels.
   D. ZERO AREA IS A VERDICT, NOT A SKIP (see above).
   E. THE ERA FLOOR -- every row is 1934 or later, since 1933 is the last year a second yearbook volume
      offers an opinion (issue 414) and a row before it belongs to a different question.
+
+THE RATIO TEST WAS ONE-SIDED IN BOTH THE TOOL AND THIS GATE (issue 416). The level arm convicted at
+`ratio >= 30` and filed everything else `no_area_level_consistent`, so a value could not be too SMALL
+to fail: `germany / tobacco, unmanufactured / 1945` carried production 0 against a pre-era median of
+25,833.9 t and was reported as consistent with it. The tool could not be fixed alone -- arm A here
+pins the verdict names and the header check forbids adding a column -- so `no_area_level_drop` and
+the two clauses that hold it landed in the same change. What that adds to the earlier lesson about
+dead arms is a narrower shape: EVERY arm here fired, on the half of the ratio axis it could see. A
+mutation test proves an arm is live; it does not prove the arm's rule is complete.
 
 ALL 5 ARMS WERE VERIFIED TO FIRE on 2026-08-20, by mutating this table to trigger each in turn.
 An arm that cannot fire passes every run while asserting nothing, and this repo has shipped three of
@@ -43,6 +54,15 @@ those (issues 407, 412, 420), so "the gate is green" is only meaningful once eac
 Verified: an unknown verdict (A); an implied_yield disagreeing with production/area (B); an
 `impossible_yield` row pushed below the 20 t/ha line (C); a zero-area row reclassified (D, which
 also carries the permanent selftest case); a row dated before 1934 (E).
+
+RE-VERIFIED on 2026-08-31 for the two-sided clauses, and the second one is the load-bearing test. It
+is not enough to check that a `no_area_level_drop` row really sits below 1/30: with only that clause,
+DELETING the low arm from the tool would send its row back to `no_area_level_consistent` and this
+gate would pass -- the pre-fix state restored with nothing objecting. The consistent-band clause is
+what closes that, and it carries the second permanent selftest case
+(`mutate_era_level_drop_exonerated`). Both were confirmed by mutating the committed table: the
+germany row reclassified to `no_area_level_consistent` is reported, and so is a `no_area_level_drop`
+row whose ratio is raised above 1/30.
 
 The class COUNTS are printed, not pinned: they move whenever the panel or the matcher legitimately moves.
 What is pinned is arithmetic and the zero-area rule, neither of which can legitimately break.
@@ -57,9 +77,31 @@ TABLE = os.path.join(REPO, "pipelines/polity-autoimprove/state/era_shift_verdict
 
 FIELDS = ["source", "label", "whep_code", "item", "year", "period", "unit", "production", "area_ha",
           "implied_yield", "own_pre_era_median", "ratio_to_own", "verdict", "convicted"]
-CONVICTING = {"impossible_yield_zero_area", "impossible_yield", "no_area_level_shift"}
+# THIS SET IS RESTATED HERE RATHER THAN IMPORTED from `29_era_shift_verdicts.py`, deliberately: an
+# imported rule moves with the table it is meant to check, so the two copies must change in lockstep
+# and this is the line that was missed when the low arm was added. That is also the reason the arm-C
+# clauses below restate the thresholds instead of reading the tool's.
+#
+# `no_area_level_drop` CONVICTS, and the choice is deliberate rather than symmetric-for-tidiness.
+# What the level arm asserts is that a row disagreeing with the label's own pre-era level by 30x is
+# not a usable observation of that label in that year. That claim does not depend on the sign: a
+# production of 0 against a pre-era median of 25,833.9 t is the LARGEST disagreement a ratio can
+# express, not a small one, and filing it as a neutral class would say the screen looked at the row
+# and found nothing -- which is exactly the failure the arm was added to remove. The alternative
+# reading, that a crop can genuinely collapse in a war year, is a claim about the WORLD; this table's
+# verdicts are claims about a CELL, and the sole live member is independently corroborated (germany
+# holds one cell in the whole of 1945 in `iia_1939_45` against 20-36 in every other year, and the
+# tobacco area series beside it has no 1945 cell at all). If a future member of this class turns out
+# to be a real collapse, the honest fix is a new non-convicting verdict for it, not a silent
+# demotion of the whole arm back to one side.
+CONVICTING = {"impossible_yield_zero_area", "impossible_yield", "no_area_level_shift",
+              "no_area_level_drop"}
 NOT_CONVICTING = {"high_yield_3to20", "plausible_yield", "no_area_level_consistent", "untestable"}
 IMPOSSIBLE_YIELD, HIGH_YIELD, LEVEL_SHIFT, ERA_FROM = 20.0, 3.0, 30.0, 1934
+# DERIVED, NOT A SECOND TUNABLE. Two independent constants can be edited apart, and an arm whose
+# threshold has drifted to 0.0 stops firing while its twin keeps working -- silently, because each
+# arm is checked on its own rows.
+LEVEL_DROP = 1.0 / LEVEL_SHIFT
 
 
 def _f(s):
@@ -144,6 +186,29 @@ def main() -> int:
         if v == "no_area_level_shift" and (ratio is None or ratio < LEVEL_SHIFT):
             problems.append(f"C {w}: classed no_area_level_shift with ratio_to_own {ratio}, not at "
                             f"least {LEVEL_SHIFT}")
+        # ARM C WAS ITSELF ONE-SIDED, and that is why the tool could not be fixed alone. It pinned
+        # the high class at `ratio >= 30` and offered no low counterpart, so a low-side conviction
+        # was not merely unimplemented -- it was unrepresentable: arm A rejects any verdict name
+        # outside its set and the header check forbids adding a column instead. Note this is a
+        # narrower failure than a dead arm and a mutation test cannot see it: every arm here DID
+        # fire, on the half of the ratio axis it could see.
+        if v == "no_area_level_drop" and (ratio is None or ratio > LEVEL_DROP):
+            problems.append(f"C {w}: classed no_area_level_drop with ratio_to_own {ratio}, not at "
+                            f"most {LEVEL_DROP:.6f}; a value is convicted for being too SMALL "
+                            f"against the label's own pre-era median, at the same {LEVEL_SHIFT}x "
+                            f"the high arm uses")
+        # AND THE CONSISTENT CLASS MUST NOW SIT BETWEEN THE TWO, which is the arm that stops the
+        # low side from being deleted later: with only the clause above, dropping the low arm from
+        # the tool would send its row back to `no_area_level_consistent` and nothing would object.
+        # Verified by mutation -- reclassifying the germany row to `no_area_level_consistent` (the
+        # exact pre-fix state) is reported here, which the vocabulary and threshold arms cannot see.
+        if v == "no_area_level_consistent" and ratio is not None and not (
+                LEVEL_DROP < ratio < LEVEL_SHIFT):
+            problems.append(f"C {w}: classed no_area_level_consistent with ratio_to_own {ratio}, "
+                            f"outside the band {LEVEL_DROP:.6f}-{LEVEL_SHIFT} it names. A "
+                            f"production of 0 against a positive baseline is the MAXIMAL "
+                            f"disagreement a ratio can express, and it sat in this class until the "
+                            f"level arm became two-sided (issue 416)")
         if v == "untestable" and (yld is not None or ratio is not None):
             problems.append(f"C {w}: classed untestable but carries yield {yld} / ratio {ratio}")
 


### PR DESCRIPTION
*Created by Claude.* Advances #416. Rebased on current `main`; the gate and its selftest case are
now part of this branch, so nothing external is pending.

## The ratio test was one-sided, in the tool AND in the gate

`29_era_shift_verdicts.py` convicted a no-area row at `>= 30x` the label's own pre-1934 median and
filed everything else `no_area_level_consistent`. There is no filter to grep for -- the exoneration
was the `else` branch -- so **a value could not be too small to fail**:

```
germany / tobacco, unmanufactured / 1945   production 0   baseline 25,833.9   ratio 0.0
verdict: no_area_level_consistent
```

A production of **zero** filed as consistent with a 25,834 t baseline. `no_area_level_drop` is the
missing arm, at `LEVEL_DROP = 1 / LEVEL_SHIFT` rather than a second tunable so the two sides cannot
drift apart.

```
                             before   after
convicted                       349     350
no_area_level_consistent         22      21
no_area_level_drop                -       1
```

The gate mattered as much as the tool. `scripts/validate_era_shift_verdicts.py` pins the verdict
names (arm A) and pinned `no_area_level_shift` at `ratio >= 30` with **no low counterpart** (arm C),
while the header check forbids adding a column instead -- so a low-side conviction was not merely
unimplemented, it was **unrepresentable**. That is a narrower failure than a dead arm and a mutation
test cannot see it: every arm here *did* fire, on the half of the ratio axis it could see.

**The bound is not fitted, and the way to show that is that it does not matter.** Over all 393 era
rows carrying a ratio: `<= 1/100` 1 row, `<= 1/30` 1 row, `<= 1/10` 1 row, `<= 1/3` 3 rows -- and
the two extra rows at 1/3 (micronesia 1936 and 1937, at 0.296 and 0.148) are already convicted by
the zero-area arm, which runs first. Every bound across a 33x range convicts the same single row.

### Why it convicts rather than merely flags

Argued in the gate itself rather than assumed symmetric. What the level arm asserts is that a row
disagreeing with its label's own pre-era level by 30x is not a usable observation, and that claim
does not depend on the sign -- a production of 0 against 25,833.9 t is the *largest* disagreement a
ratio can express. The alternative reading (a crop can genuinely collapse in a war year) is a claim
about the **world**; this table's verdicts are claims about a **cell**. And the sole live member is
independently corroborated:

```
germany in iia_1939_45, cells per year
  1939  36   1941  21   1943  27   1945   1   <- and it IS the zero
  1940  32   1942  24   1944  20

germany tobacco in that volume
  area        1939 1940 1941 1942 1943 1944          (no 1945 cell at all)
  production  1939 1940 1941 1942 1943      1945     (no 1944 cell)
```

A country that reported nothing else in 1945 did not report a tobacco harvest of precisely zero.
**The cell is convicted; German output is not claimed.**

The tempting general story is refuted rather than assumed: 1945 carries 7 zeros in 973 production
cells (0.72%), no higher than 1939-1944 (0.22%-0.57%), so *"the volume read its last year as blank"*
does not hold at the volume level. The association is with a **thin year-block** -- among labels
with exactly one 1945 cell, 3 of 30 are zero; among labels with a populated 1945 block, 10 of 1,607.
n=3, stated as an association. `netherlands / tobacco / 1945` is also a zero but sits in a populated
block (20 cells) and has no pre-era baseline, so it stays `untestable` and I am not claiming it.

## Gate: two arm-C clauses, and the second is the load-bearing one

```python
if v == "no_area_level_drop" and (ratio is None or ratio > LEVEL_DROP): ...
if v == "no_area_level_consistent" and ratio is not None and not (LEVEL_DROP < ratio < LEVEL_SHIFT): ...
```

The first only protects the new class from being **mislabelled**. It does nothing about the low arm
being **deleted**: drop it from the tool and its row returns to `no_area_level_consistent` -- the
exact pre-fix state -- and a gate holding only the first clause has no drop rows left to check and
passes. The consistent-band clause closes that. Both were verified live by mutating the committed
table and restoring it byte-identically.

`selftest_gates.py` gains `mutate_era_level_drop_exonerated` as **case 41** (a second case on this
gate; `WRITABLE` already stages the table). It reproduces the deletion rather than a typo, for that
reason, and refuses to pass vacuously if the drop class is empty.

**No baseline moves.** The gate pins no class COUNT (`no_area_level_consistent` 22 -> 21 needed no
edit), `BASELINE_GATES_WITHOUT_A_CASE` stays 0, and nothing pins the case count. @lbm364dl's
`46851eb` -- the minimal arm-A registration pushed onto this branch while I was working -- is
subsumed; its point about the set being *restated rather than imported* is folded into the comment
here so it is not lost.

## `41_era_volume_attribution.py` -- per-row volume attribution (new)

Joins the raw IIA extract to the era population by (product, variable, year-or-period, **exact
value**), using `iia_label_provenance.csv` and `item_equivalences.csv` to **confirm** the label
rather than to find it -- a provenance-only join reaches 154 era rows where the value join reaches
247, because 32 of the 72 raw labels for these items have no provenance entry. Positive control,
printed every run and floored: **2,296 of 2,340** layer-B tobacco/hops rows (98.1%) are found in raw
at the same key, 2,294 resolving to a single volume.

```
427 era rows, 93 labels
  overlap_100x                 247
  overlap_10x                   10
  overlap_other                  6
  ambiguous_raw_label            3
  component_factor_incomplete    3
  no_overlap_pair              158
  unresolved_in_raw              0
  resolution: single_cell=422, component_sum=5
  volume of origin: iia_1938_39=147, iia_1939_45=280
  from a late volume 427, from a clean volume 0
```

* **All 427 rows come from a late volume and none from a clean one.** So `year >= 1934` is not a
  proxy for "from an inflated volume" -- it is equivalent to it, now per row and over period rows,
  which the dated-row version of that claim could not cover.
* Dividing the 247 `overlap_100x` rows by their own label's factor moves tobacco from **0 of 144**
  cells inside 0.2-3.0 t/ha to **130 of 144** (median implied yield 83.11 -> 0.790), and hops from 0
  of 27 to 10 of 27 (50.03 -> 5.019) -- the hops residual being its area rounding floor, not its
  factor.
* **158 rows have no overlap pair** and are never assigned a divisor. 122 of them are convicted by
  `29` on their own arithmetic, which is a separate and sufficient basis.
* **Five rows are layer-B component sums**, each resolving to exactly one two-part sum within one
  volume: `usa + us puerto rico`, `dutch java and madura + dutch sumatra` (x2),
  `china + china: manchuria`, `greece + italian dodecanese islands`. Every pair is geographically
  coherent, which is why this reads as a composition and not as arithmetic coincidence. Note for the
  separate `iia`/`usa` scope question: layer B's `usa` here **includes Puerto Rico**, by arithmetic.

### The per-row work refutes a blanket division on ten rows

All 10 `overlap_10x` rows are `ivory coast` tobacco, and all 10 already carry `plausible_yield`. The
raw says the fault is in the **clean** volume, not the era:

```
iia_1933_34  1933       334 t on 1,640 ha  = 0.20 t/ha
iia_1938_39  1933     3,300 t on 2,000 ha  = 1.65 t/ha   <- a revision, not an inflation
iia_1939_45  1939-45  1,500-6,000 t on 2,000-6,000 ha = 0.75-1.50 t/ha
```

Dividing by their measured 9.88x would push a plausible 0.75-1.50 t/ha down to 0.09-0.19. **Where
the overlap factor and the physical yield test disagree, the yield test wins** -- it tests the row
itself, while the factor tests a neighbouring cell in another edition.

A factor is also refused where two raw labels print the same value in the same year and disagree:
`benin` was being handed `french ivory coast`'s 9.88x that way. And a latent averaging bug was
fixed -- 84 rows carry an area factor of exactly 0 (`zero_contradicted`), and the band check read
`if lo > 0`, which **skipped the test entirely** when a zero was present and would have returned a
median of 5 for candidates of 0 and 10.

The tool is numbered 41 rather than 40 because another branch in flight adds
`40_zero_grid_floor.py`.

## Verification

* all 86 `scripts/validate_*.py`: **PASS**
* `python3 scripts/selftest_gates.py`: **PASS**, 140 cases; mine is case 41, exit=1, names
  `outside the band`
* both tools current under `--check`; atomic writes (mkstemp + `os.replace`), CRLF matching the
  sibling tables
* `git status` clean apart from the four files this branch touches

## What I am not claiming

* No repair is applied and nothing is written to `yield_series_corrections.csv`, which
  `07_yield_consistency.py` regenerates -- an adjudication typed into a generated table is one
  re-run from being erased. The `corrected_*` columns say what the measured factor *would* produce.
* The 158 `no_overlap_pair` rows get no factor, and I am not inferring one from a peer label.
* `netherlands / tobacco / 1945` stays `untestable`.
* The 17 hops rows still implausible after correction are the area rounding floor, already on
  record; no treatment proposed.
* A figure in #416 reconciled rather than re-asserted: its hops "27 paired cells, median 27.25 t/ha"
  is the **dated** subset. The era table now holds 40 hops rows with a positive area (27 dated +
  13 period, the period rows at a median of 124.4), so a fresh median over all of them is 53.4. The
  dated-only median reproduces 27.25 exactly -- a population difference introduced by #465, not a
  defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAxP2LSXPx67DDTWKERXiQ
