### PR TITLE
docs: period rows are a second time axis, and five issues have misread them

### DIFF
--- a/site/wiki/README.md
+++ b/site/wiki/README.md
@@ -365,6 +365,52 @@ honoured over the exclusive bound. A **blanket** alias asserts nothing about any
 boundary year, so it gets no such deference and falls through to year-containment
 in the target's family, exactly like an unaliased label.
 
+## Period rows: data with no year
+
+The convention above is about **polity** spans. The *data* has a second time
+axis that has caused more mistakes than the first, and it is documented here
+because it was documented nowhere — five separate issues have now read a period
+row as though it were a dated one.
+
+Two sources publish **multi-year averages** as rows with a NULL `year` and a
+`period` label such as `1934-1938`:
+
+    iia        6,163 period rows    1900-1913, 1909-1913, 1925-1929,
+                                    1928-1932, 1934-1938
+    fao1952    3,702 period rows    mostly 1934-1938
+
+Nothing else in the panel has them. `matchlib.eff_year()` resolves such a row to
+the **END** year of its period — `1934-1938` becomes 1938 — which is why a
+period can straddle a polity's exclusive `end_year` and land one year past the
+polity it describes (`state/period_straddles.csv` records 46 such pairs).
+
+**The trap runs in both directions, and that is what makes it easy to miss:**
+
+- **Filtering or grouping by `year` silently DROPS them.** A count computed with
+  `year.notna()`, or a `groupby` on a key containing `year` with pandas' default
+  `dropna=True`, returns a number that looks complete and is not. This is how
+  `iia-tobacco-implausible-magnitudes` came to record "40 of the 607 iia tobacco
+  rows" when layer B holds 893, and how issue 414's "629 layer-B zeros" missed
+  152 more — 146 of them in the single volume that issue is about.
+- **Sorting or displaying them beside dated rows silently MERGES them.** A period
+  row sorted into a dated series looks like a duplicate year. Issue 443 read
+  `united states / sugar` as carrying 1938 twice, at 2,153,800 and 361,500; the
+  second figure is the `1934-1938` average, and with it set aside the series is
+  an ordinary dated succession.
+
+**A period label names its yearbook EDITION, not just its years.** Across the
+IIA extract's 42,587 multi-year rows there are seven period labels and each is
+printed by exactly one volume, so `period` attributes a row to its edition with
+no crosswalk and no value matching (`state/period_volume_provenance.csv`, all
+6,163 rows). The consequence is not academic: `1928-1932` covers years entirely
+**before** 1934 yet is printed by the late `iia_1938_39`, so a screen keyed on
+the years in the label attributes those rows to the wrong volume — 34 tobacco
+rows above 500,000 t sit there, outside any window written as `1934-1945`.
+
+**So when you write a count, a filter or a screen over source data, say which
+axis it covers.** A figure quoted without that is ambiguous, and in this repo it
+has usually meant dated-only.
+
 ## Which date a boundary year takes
 
 The year convention above says what a boundary year *means*. This says **which

--- a/site/wiki/log.md
+++ b/site/wiki/log.md
@@ -26,6 +26,47 @@ Kinds:
 
 ---
 
+## convention-period-rows-are-a-second-time-axis
+**Date:** 2026-09-01
+**Touched:** none (documents an existing convention; no polity row changed)
+**Source:** none
+**Kind:** convention
+
+**A period row is not a dated row, and reading one as the other has now caused
+five separate mistakes.** `iia` publishes 6,163 multi-year averages and
+`fao1952` 3,702, as rows with a NULL `year` and a `period` label such as
+`1934-1938`. Nothing else in the panel has them.
+
+The trap runs in both directions, which is why it kept recurring. Filtering or
+grouping by `year` silently DROPS them — that is how
+`iia-tobacco-implausible-magnitudes` recorded "40 of the 607 iia tobacco rows"
+when layer B holds 893, and how [issue
+414](https://github.com/eduaguilera/whep-polities/issues/414)'s "629 layer-B
+zeros" missed 152 more, 146 of them in the very volume that issue is about.
+Displaying them beside dated rows silently MERGES them — that is how [issue
+443](https://github.com/eduaguilera/whep-polities/issues/443) read
+`united states / sugar` as carrying 1938 twice, at 2,153,800 and 361,500, when
+the second figure is the `1934-1938` average and the series is an ordinary
+dated succession once it is set aside.
+
+Two further instances: [issue
+411](https://github.com/eduaguilera/whep-polities/issues/411) describes its
+collision at dated 1937 while 84 of the 90 rows carry `period = 1934-1938`, and
+[issue 310](https://github.com/eduaguilera/whep-polities/issues/310)'s straddle
+count was first published against an inclusive `end_year`.
+
+**A period label also names its yearbook EDITION.** Across the IIA extract's
+42,587 multi-year rows there are seven period labels, each printed by exactly
+one volume, so `period` attributes a row to its edition with no crosswalk and no
+value matching. `1928-1932` covers years entirely before 1934 yet comes from the
+late `iia_1938_39`, so a screen keyed on the years in a label attributes those
+rows to the wrong volume.
+
+Recorded in `wiki/README.md` under "Period rows: data with no year", beside the
+year convention it is most often confused with. Like [issue
+131](https://github.com/eduaguilera/whep-polities/issues/131) before it, the
+rule was known in individual issues and stated nowhere central.
+
 ## decision-faithful-territory-for-reporting-units
 **Date:** 2026-08-31
 **Touched:** DEU-1800-1866, DEU-1866-1871, DZA-1902-1919, F51-1938-1945,

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -365,6 +365,52 @@ honoured over the exclusive bound. A **blanket** alias asserts nothing about any
 boundary year, so it gets no such deference and falls through to year-containment
 in the target's family, exactly like an unaliased label.
 
+## Period rows: data with no year
+
+The convention above is about **polity** spans. The *data* has a second time
+axis that has caused more mistakes than the first, and it is documented here
+because it was documented nowhere — five separate issues have now read a period
+row as though it were a dated one.
+
+Two sources publish **multi-year averages** as rows with a NULL `year` and a
+`period` label such as `1934-1938`:
+
+    iia        6,163 period rows    1900-1913, 1909-1913, 1925-1929,
+                                    1928-1932, 1934-1938
+    fao1952    3,702 period rows    mostly 1934-1938
+
+Nothing else in the panel has them. `matchlib.eff_year()` resolves such a row to
+the **END** year of its period — `1934-1938` becomes 1938 — which is why a
+period can straddle a polity's exclusive `end_year` and land one year past the
+polity it describes (`state/period_straddles.csv` records 46 such pairs).
+
+**The trap runs in both directions, and that is what makes it easy to miss:**
+
+- **Filtering or grouping by `year` silently DROPS them.** A count computed with
+  `year.notna()`, or a `groupby` on a key containing `year` with pandas' default
+  `dropna=True`, returns a number that looks complete and is not. This is how
+  `iia-tobacco-implausible-magnitudes` came to record "40 of the 607 iia tobacco
+  rows" when layer B holds 893, and how issue 414's "629 layer-B zeros" missed
+  152 more — 146 of them in the single volume that issue is about.
+- **Sorting or displaying them beside dated rows silently MERGES them.** A period
+  row sorted into a dated series looks like a duplicate year. Issue 443 read
+  `united states / sugar` as carrying 1938 twice, at 2,153,800 and 361,500; the
+  second figure is the `1934-1938` average, and with it set aside the series is
+  an ordinary dated succession.
+
+**A period label names its yearbook EDITION, not just its years.** Across the
+IIA extract's 42,587 multi-year rows there are seven period labels and each is
+printed by exactly one volume, so `period` attributes a row to its edition with
+no crosswalk and no value matching (`state/period_volume_provenance.csv`, all
+6,163 rows). The consequence is not academic: `1928-1932` covers years entirely
+**before** 1934 yet is printed by the late `iia_1938_39`, so a screen keyed on
+the years in the label attributes those rows to the wrong volume — 34 tobacco
+rows above 500,000 t sit there, outside any window written as `1934-1945`.
+
+**So when you write a count, a filter or a screen over source data, say which
+axis it covers.** A figure quoted without that is ambiguous, and in this repo it
+has usually meant dated-only.
+
 ## Which date a boundary year takes
 
 The year convention above says what a boundary year *means*. This says **which

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -26,6 +26,47 @@ Kinds:
 
 ---
 
+## convention-period-rows-are-a-second-time-axis
+**Date:** 2026-09-01
+**Touched:** none (documents an existing convention; no polity row changed)
+**Source:** none
+**Kind:** convention
+
+**A period row is not a dated row, and reading one as the other has now caused
+five separate mistakes.** `iia` publishes 6,163 multi-year averages and
+`fao1952` 3,702, as rows with a NULL `year` and a `period` label such as
+`1934-1938`. Nothing else in the panel has them.
+
+The trap runs in both directions, which is why it kept recurring. Filtering or
+grouping by `year` silently DROPS them — that is how
+`iia-tobacco-implausible-magnitudes` recorded "40 of the 607 iia tobacco rows"
+when layer B holds 893, and how [issue
+414](https://github.com/eduaguilera/whep-polities/issues/414)'s "629 layer-B
+zeros" missed 152 more, 146 of them in the very volume that issue is about.
+Displaying them beside dated rows silently MERGES them — that is how [issue
+443](https://github.com/eduaguilera/whep-polities/issues/443) read
+`united states / sugar` as carrying 1938 twice, at 2,153,800 and 361,500, when
+the second figure is the `1934-1938` average and the series is an ordinary
+dated succession once it is set aside.
+
+Two further instances: [issue
+411](https://github.com/eduaguilera/whep-polities/issues/411) describes its
+collision at dated 1937 while 84 of the 90 rows carry `period = 1934-1938`, and
+[issue 310](https://github.com/eduaguilera/whep-polities/issues/310)'s straddle
+count was first published against an inclusive `end_year`.
+
+**A period label also names its yearbook EDITION.** Across the IIA extract's
+42,587 multi-year rows there are seven period labels, each printed by exactly
+one volume, so `period` attributes a row to its edition with no crosswalk and no
+value matching. `1928-1932` covers years entirely before 1934 yet comes from the
+late `iia_1938_39`, so a screen keyed on the years in a label attributes those
+rows to the wrong volume.
+
+Recorded in `wiki/README.md` under "Period rows: data with no year", beside the
+year convention it is most often confused with. Like [issue
+131](https://github.com/eduaguilera/whep-polities/issues/131) before it, the
+rule was known in individual issues and stated nowhere central.
+
 ## decision-faithful-territory-for-reporting-units
 **Date:** 2026-08-31
 **Touched:** DEU-1800-1866, DEU-1866-1871, DZA-1902-1919, F51-1938-1945,


### PR DESCRIPTION
*This PR was created by Claude.* Documentation only — no polity row, no state table, no gate logic changes.

`wiki/README.md` documents the year convention for **polity spans** and says nothing about the **data's** own time axis. Five separate issues have now read a period row as though it were a dated one, so this states the rule beside the convention it is most often confused with.

## The rule

Two sources publish multi-year averages as rows with a **NULL `year`** and a `period` label:

```
iia        6,163 period rows    1900-1913, 1909-1913, 1925-1929, 1928-1932, 1934-1938
fao1952    3,702 period rows    mostly 1934-1938
```

Nothing else in the panel has them. `matchlib.eff_year()` resolves such a row to the **END** year of its period, which is why a period can straddle a polity's exclusive `end_year` — `state/period_straddles.csv` records 46 such pairs.

## Why it kept recurring: the trap runs in both directions

- **Filtering or grouping by `year` silently DROPS them.** `iia-tobacco-implausible-magnitudes` records *"40 of the 607 iia tobacco rows"* when layer B holds **893**. #414's *"629 layer-B zeros"* misses **152** more — **146 of them in `iia_1938_39`**, the single volume that issue is about.
- **Displaying them beside dated rows silently MERGES them.** #443 read `united states / sugar` as carrying 1938 twice, at 2,153,800 and 361,500. The second is the `1934-1938` average; with it set aside the series is an ordinary dated succession, **which inverts that issue's stated conclusion**.

Two further instances: #411 describes its collision at dated 1937 while 84 of its 90 rows carry `period = 1934-1938`, and #310's straddle count was first published against an inclusive `end_year`.

## And a period label names its EDITION, not just its years

Across the extract's **42,587** multi-year rows there are seven period labels, **each printed by exactly one volume**, so `period` attributes a row to its edition with no crosswalk and no value matching. `1928-1932` covers years entirely **before** 1934 yet comes from the late `iia_1938_39` — so a screen keyed on the years in a label attributes those rows to the wrong volume, and 34 tobacco rows above 500,000 t sit outside any window written as `1934-1945`.

## Verification

All five gates that read `wiki/README.md` pass: `validate_year_semantics`, `validate_citations`, `validate_constants`, `validate_declared_sources`, `validate_polygons`.

**`validate_site_outputs` caught a real leak while I was doing this** — I synced `site/wiki/README.md` but not `site/wiki/log.md`, and it failed with *"a stale copy attributes the current data to the wrong decisions"*. That is precisely the hole it was added to close after #569, working as intended. Both copies are now rebuilt via `site/build_wiki.sh` and the gate passes.

Like **#131** before it — the issue that put the year convention in this file after finding it *"stated NOWHERE"* — the rule was known in individual issues and written down nowhere central.