### PR TITLE
Make coverage() honour polity_code, and pin that the zero ceiling stays reachable (#635)

### DIFF
--- a/pipelines/polity-autoimprove/39_cross_source_agreement.py
+++ b/pipelines/polity-autoimprove/39_cross_source_agreement.py
@@ -73,6 +73,21 @@ def coverage(row, errors):
     for e in errors:
         if e["source"] and not any(s in e["source"].split(";") for s in row["sources"].split(";")):
             continue
+        # POLITY SCOPE (issue 635). An entry that names polity codes concerns THOSE polities, and
+        # this filter is what makes that true of the matching as well as of the entry. Without it
+        # `layerb-nested-reporting-levels-one-polity` -- 17 declared codes, `commodity = (all)`, a
+        # placeholder label, all four sources, 1909-1960 -- matched 804 of 804 cells, so
+        # BASELINE_UNEXPLAINED = 0 could never be exceeded and the gate's headline arm was dead.
+        # It also attributed 8 real disagreements to itself: czech `beans, dry` x7 (two raw series,
+        # layer B keeps one) and yugoslav `sunflower seed` (production x10), on polities absent from
+        # its own list and commodities its summary never mentions. Both are now registered in their
+        # own right (#636), which is why this filter does not turn the gate red.
+        #
+        # An entry that legitimately covers broadly leaves `polity_code` BLANK; declaring codes is
+        # what opts an entry into being scoped.
+        codes = [c for c in (e.get("polity_code") or "").split(";") if c.strip()]
+        if codes and row["polity_code"] not in [c.strip() for c in codes]:
+            continue
         try:
             if e["year_min"] and e["year_max"] and not (
                     int(e["year_min"]) <= int(row["year"]) <= int(e["year_max"])):

--- a/pipelines/polity-autoimprove/state/cross_source_agreement.csv
+++ b/pipelines/polity-autoimprove/state/cross_source_agreement.csv
@@ -1,273 +1,273 @@
 polity_code,item,unit,year,sources,labels,indicators,value_min,value_max,ratio,known_defect
-F51-1918-1938,wheat,tonnes,1930,iia;juan,czech republic;czechoslovakia,,311.9,1.377e+06,4415.7743,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1930,iia;juan,czech republic;czechoslovakia,,239,7.95e+05,3326.3598,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1933,iia;juan,czech republic;czechoslovakia,,700.2,1.984e+06,2833.3333,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1930,iia;juan,czech republic;czechoslovakia,,8,1.75e+04,2187.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1933,iia;juan,czech republic;czechoslovakia,,440,9.19e+05,2088.6364,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1931,iia;juan,czech republic;czechoslovakia,,553.6,1.122e+06,2027.0051,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1012,1.462e+06,1444.7101,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1931,iia;juan,czech republic;czechoslovakia,,607,8.284e+05,1364.7446,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1932,iia;juan,czech republic;czechoslovakia,,829,8.354e+05,1007.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1932,iia;juan,czech republic;czechoslovakia,,20,1.91e+04,955.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,1.773e+06,886.7000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1931,iia;juan,czech republic;czechoslovakia,,23,1.88e+04,817.3913,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1925,iia;juan,czech republic;czechoslovakia,,1615,6.174e+05,382.2910,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9580,2.689e+06,280.6493,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.17e+04,2.876e+06,245.7778,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1938,iia;juan,czech republic;czechoslovakia,,9800,1.814e+06,185.1020,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1.442e+04,2.629e+06,182.3492,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1938,iia;juan,czech republic;czechoslovakia,,5000,8.98e+05,179.6000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.248e+04,2.186e+06,175.1919,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1935,iia;juan,czech republic;czechoslovakia,,9900,1.69e+06,170.7071,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1936,iia;juan,czech republic;czechoslovakia,,9100,1.513e+06,166.2308,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1935,iia;juan,czech republic;czechoslovakia,,6000,9.63e+05,160.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8700,1.395e+06,160.3793,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1936,iia;juan,czech republic;czechoslovakia,,6000,9.27e+05,154.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1939,iia;juan,serbia;yugoslav sfr,,1.5e+04,2.203e+06,146.8667,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.482e+04,2.14e+06,144.4226,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.561e+06,143.2110,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.49e+05,141.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1934,iia;juan,czech republic;czechoslovakia,,9800,1.361e+06,138.8980,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,9.31e+05,133.0000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1931,iia;juan,serbia;yugoslav sfr,,1.652e+04,2.14e+06,129.5467,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.138e+04,1.455e+06,127.8359,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1922,iia;juan,serbia;yugoslav sfr,,9489,1.21e+06,127.5508,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1933,iia;juan,serbia;yugoslav sfr,,1.672e+04,2.079e+06,124.3719,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1932,iia;juan,serbia;yugoslav sfr,,1.639e+04,1.95e+06,119.0345,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1930,iia;juan,serbia;yugoslav sfr,,1.843e+04,2.123e+06,115.1730,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1934,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.54e+06,102.6933,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1943,iia;juan,czech republic;czechoslovakia,,9000,9.1e+05,101.1111,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1941,iia;mitchell,korea;south korea,;page_13_table_1,3.5e+04,3.512e+06,100.3429,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1939,iia;mitchell,korea;south korea,;page_12_table_1,3.1e+04,3.102e+06,100.0613,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1891,1.891e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1962,1.962e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2132,2.132e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1600,1.6e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1815,1.815e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1934,iia;juan,serbia;yugoslav sfr,,6049,6.049e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1935,iia;juan,serbia;yugoslav sfr,,9249,9.249e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.662e+04,1.662e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.078e+04,2.078e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1938,iia;juan,serbia;yugoslav sfr,,1.471e+04,1.471e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.543e+04,1.543e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.27e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1934,iia;juan,czech republic;czechoslovakia,,7074,7.074e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1935,iia;juan,czech republic;czechoslovakia,,7619,7.619e+05,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.208e+04,1.208e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.216e+04,1.216e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.368e+04,1.368e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.363e+04,1.363e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.507e+04,1.507e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.404e+04,1.404e+06,100.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1940,iia;juan,czech republic;czechoslovakia,,4576,4.576e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3527,3.527e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3107,3.107e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3152,3.152e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1939,iia;juan,czech republic;czechoslovakia,,9330,9.33e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1941,iia;juan,czech republic;czechoslovakia,,6914,6.914e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1942,iia;juan,czech republic;czechoslovakia,,7468,7.468e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5429,5.429e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1944,iia;juan,czech republic;czechoslovakia,,3928,3.928e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hops,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3721,3.721e+05,100.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,czech republic;czechoslovakia,,2500,2.5e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7635,7.634e+05,99.9869,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",tonnes,1940,iia;juan,czech republic;czechoslovakia,,7803,7.8e+05,99.9616,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1938,iia;mitchell,korea;south korea,;page_12_table_1,2.8e+04,2.798e+06,99.9429,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1935,iia;mitchell,korea;south korea,;page_12_table_1,2.2e+04,2.192e+06,99.6409,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1455,1.433e+05,98.4880,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1936,iia;mitchell,korea;south korea,;page_12_table_1,2.1e+04,2.063e+06,98.2190,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1937,iia;mitchell,korea;south korea,;page_12_table_1,2.7e+04,2.649e+06,98.1037,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.604e+04,1.572e+06,97.9986,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.26e+04,1.21e+06,96.0317,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.828e+04,1.662e+06,90.9181,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,wheat,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1.29e+04,1.122e+06,86.9380,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,wheat,ha,1945,iia;juan,czech republic;czechoslovakia,,1e+04,8.43e+05,84.3000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1944,iia;juan,czech republic;czechoslovakia,,1.1e+04,9.12e+05,82.9091,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1924,iia;juan,serbia;yugoslav sfr,,2.209e+04,1.717e+06,77.7270,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.96e+04,1.451e+06,74.0102,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2.18e+04,1.572e+06,72.1147,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1922,iia;juan,serbia;yugoslav sfr,,2.108e+04,1.48e+06,70.2296,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1923,iia;juan,serbia;yugoslav sfr,,2.295e+04,1.555e+06,67.7648,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1939,iia;juan,czech republic;czechoslovakia,,1.4e+04,8.5e+05,60.7143,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1942,iia;juan,czech republic;czechoslovakia,,1.6e+04,8.71e+05,54.4375,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1936,iia;juan,serbia;yugoslav sfr,,5.48e+04,2.924e+06,53.3504,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2.17e+04,1.111e+06,51.1797,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1938,iia;juan,serbia;yugoslav sfr,,6.05e+04,3.03e+06,50.0810,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.777e+04,8.774e+05,49.3851,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1925,iia;juan,czech republic;czechoslovakia,,2.246e+04,1.07e+06,47.6231,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1940,iia;juan,czech republic;czechoslovakia,,1.7e+04,7.46e+05,43.8824,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,1.536e+06,42.6667,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1935,iia;juan,serbia;yugoslav sfr,,4.67e+04,1.99e+06,42.6017,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2.95e+04,1.231e+06,41.7288,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1923,iia;juan,czech republic;czechoslovakia,,2.376e+04,9.859e+05,41.4924,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1937,iia;juan,serbia;yugoslav sfr,,5.77e+04,2.347e+06,40.6759,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.96e+04,1.16e+06,39.1993,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1924,iia;juan,czech republic;czechoslovakia,,1.578e+04,6.057e+05,38.3938,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,tonnes,1922,iia;juan,czech republic;czechoslovakia,,2.398e+04,9.15e+05,38.1618,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.93e+04,1.86e+06,37.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3.25e+04,1.214e+06,37.3538,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1923,iia;juan,czech republic;czechoslovakia,,1.687e+04,6.097e+05,36.1497,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1936,iia;juan,serbia;yugoslav sfr,,6.2e+04,2.211e+06,35.6613,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1943,iia;juan,czech republic;czechoslovakia,,2.6e+04,9.26e+05,35.6154,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1935,iia;juan,serbia;yugoslav sfr,,6.1e+04,2.15e+06,35.2459,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rye,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.8e+04,9.81e+05,35.0357,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1934,iia;juan,serbia;yugoslav sfr,,5.8e+04,2.024e+06,34.8966,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,wheat,ha,1922,iia;juan,czech republic;czechoslovakia,,1.8e+04,6.179e+05,34.3278,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1937,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,wheat,ha,1938,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,wheat,ha,1941,iia;juan,czech republic;czechoslovakia,,2.8e+04,8e+05,28.5714,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1938,iia;juan,czech republic;czechoslovakia,,5000,7.2e+04,14.4000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sunflower seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1900,2.73e+04,14.3684,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.3e+04,13.8333,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3461,4.61e+04,13.3198,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1934,iia;juan,serbia;yugoslav sfr,,800,1.06e+04,13.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4500,5.59e+04,12.4222,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1935,iia;juan,czech republic;czechoslovakia,,8600,1.022e+05,11.8837,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1935,iia;juan,czech republic;czechoslovakia,,6000,7e+04,11.6667,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1935,iia;juan,serbia;yugoslav sfr,,900,1.01e+04,11.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1936,iia;juan,czech republic;czechoslovakia,,8400,9.39e+04,11.1786,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1932,iia;juan,czech republic;czechoslovakia,,6671,7.418e+04,11.1193,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4.3e+04,10.7500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1936,iia;juan,czech republic;czechoslovakia,,7000,7.5e+04,10.7143,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1945,iia;juan,serbia;yugoslav sfr,,9.2e+04,9.799e+05,10.6511,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3000,3.18e+04,10.6000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2900,3.06e+04,10.5517,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3000,3.16e+04,10.5333,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3900,4.1e+04,10.5128,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3500,3.67e+04,10.4857,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3600,3.76e+04,10.4444,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,grapes,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3800,3.95e+04,10.3947,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1940,iia;juan,czech republic;czechoslovakia,,4000,4.1e+04,10.2500,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1941,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.84e+05,10.0513,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1939,iia;juan,czech republic;czechoslovakia,,9.8e+04,9.84e+05,10.0408,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1934,iia;juan,serbia;yugoslav sfr,,2400,2.4e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1935,iia;juan,serbia;yugoslav sfr,,2600,2.6e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1936,iia;juan,serbia;yugoslav sfr,,2700,2.7e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1937,iia;juan,serbia;yugoslav sfr,,2900,2.9e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1938,iia;juan,serbia;yugoslav sfr,,2800,2.8e+04,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1931,iia;juan,serbia;yugoslav sfr,,2.442e+04,2.442e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1932,iia;juan,serbia;yugoslav sfr,,2.43e+04,2.43e+05,10.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1934,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.09e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1935,iia;juan,czech republic;czechoslovakia,,1.12e+04,1.12e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1936,iia;juan,czech republic;czechoslovakia,,1.14e+04,1.14e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1941,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1938,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.16e+05,10.0000,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1937,iia;juan,czech republic;czechoslovakia,,1.15e+04,1.13e+05,9.8261,iia-1933-x10-wrong-volume-cells;iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1939,iia;juan,czech republic;czechoslovakia,,4000,3.9e+04,9.7500,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1400,1.29e+04,9.2143,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1940,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.08e+05,9.0769,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.11e+04,1.006e+05,9.0631,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6800,6.05e+04,8.8971,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1300,1.11e+04,8.5385,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1939,iia;juan,czech republic;czechoslovakia,,2000,1.7e+04,8.5000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1934,iia;juan,czech republic;czechoslovakia,,7000,5.8e+04,8.2857,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1943,iia;juan,czech republic;czechoslovakia,,5000,3.5e+04,7.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",ha,1944,iia;juan,czech republic;czechoslovakia,,5000,3e+04,6.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1935,iia;juan,serbia;yugoslav sfr,,2.25e+04,1.147e+05,5.0978,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1940,iia;juan,czech republic;czechoslovakia,,4700,2.29e+04,4.8723,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"beans, dry",ha,1945,iia;juan,czech republic;czechoslovakia,,6000,2.8e+04,4.6667,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1937,iia;juan,czech republic;czechoslovakia,,6900,3.04e+04,4.4058,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1936,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.335e+05,4.3627,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1937,iia;juan,serbia;yugoslav sfr,,3.56e+04,1.55e+05,4.3539,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1941,iia;juan,czech republic;czechoslovakia,,4500,1.95e+04,4.3333,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1939,iia;juan,czech republic;czechoslovakia,,5700,2.43e+04,4.2632,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.69e+04,1.141e+05,4.2416,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1942,iia;juan,czech republic;czechoslovakia,,6100,2.46e+04,4.0328,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.48e+04,9.82e+04,3.9597,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.04e+04,1.582e+05,3.9158,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1936,iia;juan,czech republic;czechoslovakia,,7600,2.91e+04,3.8289,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",tonnes,1933,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.166e+05,3.8105,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1938,iia;juan,czech republic;czechoslovakia,,5900,2.19e+04,3.7119,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1935,iia;juan,czech republic;czechoslovakia,,4900,1.67e+04,3.4082,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1934,iia;juan,czech republic;czechoslovakia,,7100,2.31e+04,3.2535,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5000,1.54e+04,3.0800,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1920,iia;mitchell,korea;south korea,;page_12_table_1,5508,1.6e+04,2.9047,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"beans, dry",tonnes,1944,iia;juan,czech republic;czechoslovakia,,5100,1.46e+04,2.8627,layerb-nested-reporting-levels-one-polity
+F51-1918-1938,wheat,tonnes,1930,iia;juan,czech republic;czechoslovakia,,311.9,1.377e+06,4415.7743,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1930,iia;juan,czech republic;czechoslovakia,,239,7.95e+05,3326.3598,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1933,iia;juan,czech republic;czechoslovakia,,700.2,1.984e+06,2833.3333,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,grapes,ha,1930,iia;juan,czech republic;czechoslovakia,,8,1.75e+04,2187.5000,iia-item-series-switch-raw-products
+F51-1918-1938,wheat,ha,1933,iia;juan,czech republic;czechoslovakia,,440,9.19e+05,2088.6364,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1931,iia;juan,czech republic;czechoslovakia,,553.6,1.122e+06,2027.0051,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1012,1.462e+06,1444.7101,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1931,iia;juan,czech republic;czechoslovakia,,607,8.284e+05,1364.7446,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1932,iia;juan,czech republic;czechoslovakia,,829,8.354e+05,1007.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,grapes,ha,1932,iia;juan,czech republic;czechoslovakia,,20,1.91e+04,955.0000,iia-item-series-switch-raw-products
+F248-1920-1947,wheat,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,1.773e+06,886.7000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,grapes,ha,1931,iia;juan,czech republic;czechoslovakia,,23,1.88e+04,817.3913,iia-item-series-switch-raw-products
+F51-1918-1938,wheat,ha,1925,iia;juan,czech republic;czechoslovakia,,1615,6.174e+05,382.2910,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9580,2.689e+06,280.6493,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.17e+04,2.876e+06,245.7778,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1938,iia;juan,czech republic;czechoslovakia,,9800,1.814e+06,185.1020,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1.442e+04,2.629e+06,182.3492,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1938,iia;juan,czech republic;czechoslovakia,,5000,8.98e+05,179.6000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.248e+04,2.186e+06,175.1919,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1935,iia;juan,czech republic;czechoslovakia,,9900,1.69e+06,170.7071,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1936,iia;juan,czech republic;czechoslovakia,,9100,1.513e+06,166.2308,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1935,iia;juan,czech republic;czechoslovakia,,6000,9.63e+05,160.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8700,1.395e+06,160.3793,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1936,iia;juan,czech republic;czechoslovakia,,6000,9.27e+05,154.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1939,iia;juan,serbia;yugoslav sfr,,1.5e+04,2.203e+06,146.8667,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.482e+04,2.14e+06,144.4226,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.561e+06,143.2110,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.49e+05,141.5000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1934,iia;juan,czech republic;czechoslovakia,,9800,1.361e+06,138.8980,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,9.31e+05,133.0000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1931,iia;juan,serbia;yugoslav sfr,,1.652e+04,2.14e+06,129.5467,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.138e+04,1.455e+06,127.8359,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1922,iia;juan,serbia;yugoslav sfr,,9489,1.21e+06,127.5508,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1933,iia;juan,serbia;yugoslav sfr,,1.672e+04,2.079e+06,124.3719,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1932,iia;juan,serbia;yugoslav sfr,,1.639e+04,1.95e+06,119.0345,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1930,iia;juan,serbia;yugoslav sfr,,1.843e+04,2.123e+06,115.1730,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1934,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.54e+06,102.6933,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,wheat,ha,1943,iia;juan,czech republic;czechoslovakia,,9000,9.1e+05,101.1111,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1941,iia;mitchell,korea;south korea,;page_13_table_1,3.5e+04,3.512e+06,100.3429,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1939,iia;mitchell,korea;south korea,;page_12_table_1,3.1e+04,3.102e+06,100.0613,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,hops,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1891,1.891e+05,100.0000,iia-hops-x100
+F248-1920-1947,hops,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1962,1.962e+05,100.0000,iia-hops-x100
+F248-1920-1947,hops,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2132,2.132e+05,100.0000,iia-hops-x100
+F248-1920-1947,hops,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1600,1.6e+05,100.0000,iia-hops-x100
+F248-1920-1947,hops,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1815,1.815e+05,100.0000,iia-hops-x100
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1934,iia;juan,serbia;yugoslav sfr,,6049,6.049e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1935,iia;juan,serbia;yugoslav sfr,,9249,9.249e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.662e+04,1.662e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.078e+04,2.078e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1938,iia;juan,serbia;yugoslav sfr,,1.471e+04,1.471e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1939,iia;juan,serbia;yugoslav sfr,,1.543e+04,1.543e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.27e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,hops,tonnes,1934,iia;juan,czech republic;czechoslovakia,,7074,7.074e+05,100.0000,iia-hops-x100
+F51-1918-1938,hops,tonnes,1935,iia;juan,czech republic;czechoslovakia,,7619,7.619e+05,100.0000,iia-hops-x100
+F51-1918-1938,hops,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.208e+04,1.208e+06,100.0000,iia-hops-x100
+F51-1918-1938,hops,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.216e+04,1.216e+06,100.0000,iia-hops-x100
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.368e+04,1.368e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.363e+04,1.363e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.507e+04,1.507e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.404e+04,1.404e+06,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,hops,tonnes,1940,iia;juan,czech republic;czechoslovakia,,4576,4.576e+05,100.0000,iia-hops-x100
+F51-1938-1945,hops,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3527,3.527e+05,100.0000,iia-hops-x100
+F51-1938-1945,hops,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3107,3.107e+05,100.0000,iia-hops-x100
+F51-1938-1945,hops,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3152,3.152e+05,100.0000,iia-hops-x100
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1939,iia;juan,czech republic;czechoslovakia,,9330,9.33e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1941,iia;juan,czech republic;czechoslovakia,,6914,6.914e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1942,iia;juan,czech republic;czechoslovakia,,7468,7.468e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5429,5.429e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1944,iia;juan,czech republic;czechoslovakia,,3928,3.928e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1945-1947,hops,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3721,3.721e+05,100.0000,iia-hops-x100
+F51-1945-1947,"tobacco, unmanufactured",tonnes,1945,iia;juan,czech republic;czechoslovakia,,2500,2.5e+05,100.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,hops,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7635,7.634e+05,99.9869,iia-hops-x100
+F51-1938-1945,"tobacco, unmanufactured",tonnes,1940,iia;juan,czech republic;czechoslovakia,,7803,7.8e+05,99.9616,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1938,iia;mitchell,korea;south korea,;page_12_table_1,2.8e+04,2.798e+06,99.9429,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1935,iia;mitchell,korea;south korea,;page_12_table_1,2.2e+04,2.192e+06,99.6409,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,hops,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1455,1.433e+05,98.4880,iia-hops-x100
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1936,iia;mitchell,korea;south korea,;page_12_table_1,2.1e+04,2.063e+06,98.2190,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1937,iia;mitchell,korea;south korea,;page_12_table_1,2.7e+04,2.649e+06,98.1037,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,wheat,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.604e+04,1.572e+06,97.9986,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.26e+04,1.21e+06,96.0317,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.828e+04,1.662e+06,90.9181,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1945-1947,wheat,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1.29e+04,1.122e+06,86.9380,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1945-1947,wheat,ha,1945,iia;juan,czech republic;czechoslovakia,,1e+04,8.43e+05,84.3000,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1944,iia;juan,czech republic;czechoslovakia,,1.1e+04,9.12e+05,82.9091,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1924,iia;juan,serbia;yugoslav sfr,,2.209e+04,1.717e+06,77.7270,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.96e+04,1.451e+06,74.0102,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2.18e+04,1.572e+06,72.1147,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1922,iia;juan,serbia;yugoslav sfr,,2.108e+04,1.48e+06,70.2296,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1923,iia;juan,serbia;yugoslav sfr,,2.295e+04,1.555e+06,67.7648,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1939,iia;juan,czech republic;czechoslovakia,,1.4e+04,8.5e+05,60.7143,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1942,iia;juan,czech republic;czechoslovakia,,1.6e+04,8.71e+05,54.4375,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1936,iia;juan,serbia;yugoslav sfr,,5.48e+04,2.924e+06,53.3504,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2.17e+04,1.111e+06,51.1797,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1938,iia;juan,serbia;yugoslav sfr,,6.05e+04,3.03e+06,50.0810,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.777e+04,8.774e+05,49.3851,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1925,iia;juan,czech republic;czechoslovakia,,2.246e+04,1.07e+06,47.6231,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1940,iia;juan,czech republic;czechoslovakia,,1.7e+04,7.46e+05,43.8824,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,rye,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,1.536e+06,42.6667,iia-attributable-single-cell-errors
+F248-1920-1947,wheat,tonnes,1935,iia;juan,serbia;yugoslav sfr,,4.67e+04,1.99e+06,42.6017,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,rye,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2.95e+04,1.231e+06,41.7288,iia-attributable-single-cell-errors
+F51-1918-1938,wheat,tonnes,1923,iia;juan,czech republic;czechoslovakia,,2.376e+04,9.859e+05,41.4924,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1937,iia;juan,serbia;yugoslav sfr,,5.77e+04,2.347e+06,40.6759,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.96e+04,1.16e+06,39.1993,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1924,iia;juan,czech republic;czechoslovakia,,1.578e+04,6.057e+05,38.3938,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,tonnes,1922,iia;juan,czech republic;czechoslovakia,,2.398e+04,9.15e+05,38.1618,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.93e+04,1.86e+06,37.7201,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,rye,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3.25e+04,1.214e+06,37.3538,iia-attributable-single-cell-errors
+F51-1918-1938,wheat,ha,1923,iia;juan,czech republic;czechoslovakia,,1.687e+04,6.097e+05,36.1497,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1936,iia;juan,serbia;yugoslav sfr,,6.2e+04,2.211e+06,35.6613,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,rye,ha,1943,iia;juan,czech republic;czechoslovakia,,2.6e+04,9.26e+05,35.6154,iia-attributable-single-cell-errors
+F248-1920-1947,wheat,ha,1935,iia;juan,serbia;yugoslav sfr,,6.1e+04,2.15e+06,35.2459,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1945-1947,rye,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.8e+04,9.81e+05,35.0357,iia-attributable-single-cell-errors
+F248-1920-1947,wheat,ha,1934,iia;juan,serbia;yugoslav sfr,,5.8e+04,2.024e+06,34.8966,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1918-1938,wheat,ha,1922,iia;juan,czech republic;czechoslovakia,,1.8e+04,6.179e+05,34.3278,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1937,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F248-1920-1947,wheat,ha,1938,iia;juan,serbia;yugoslav sfr,,6.8e+04,2.13e+06,31.3235,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,wheat,ha,1941,iia;juan,czech republic;czechoslovakia,,2.8e+04,8e+05,28.5714,iia-item-series-switch-raw-products;iia-layerb-magnitude-scale-inconsistent;iia-wheat-is-spelt-and-meslin
+F51-1938-1945,"beans, dry",ha,1938,iia;juan,czech republic;czechoslovakia,,5000,7.2e+04,14.4000,iia-czechoslovakia-beans-component-only
+F248-1920-1947,sunflower seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1900,2.73e+04,14.3684,iia-yugoslavia-sunflower-production-x10
+F51-1918-1938,"beans, dry",ha,1937,iia;juan,czech republic;czechoslovakia,,6000,8.3e+04,13.8333,iia-czechoslovakia-beans-component-only
+F51-1938-1945,hops,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3461,4.61e+04,13.3198,iia-hops-x100
+F248-1920-1947,flax fibre and tow,tonnes,1934,iia;juan,serbia;yugoslav sfr,,800,1.06e+04,13.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,grapes,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4500,5.59e+04,12.4222,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,tonnes,1935,iia;juan,czech republic;czechoslovakia,,8600,1.022e+05,11.8837,iia-item-series-switch-raw-products
+F51-1918-1938,"beans, dry",ha,1935,iia;juan,czech republic;czechoslovakia,,6000,7e+04,11.6667,iia-czechoslovakia-beans-component-only
+F248-1920-1947,flax fibre and tow,tonnes,1935,iia;juan,serbia;yugoslav sfr,,900,1.01e+04,11.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,grapes,tonnes,1936,iia;juan,czech republic;czechoslovakia,,8400,9.39e+04,11.1786,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,tonnes,1932,iia;juan,czech republic;czechoslovakia,,6671,7.418e+04,11.1193,iia-item-series-switch-raw-products
+F51-1938-1945,flax fibre and tow,ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4.3e+04,10.7500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,"beans, dry",ha,1936,iia;juan,czech republic;czechoslovakia,,7000,7.5e+04,10.7143,iia-czechoslovakia-beans-component-only
+F248-1920-1947,rye,tonnes,1945,iia;juan,serbia;yugoslav sfr,,9.2e+04,9.799e+05,10.6511,iia-attributable-single-cell-errors
+F51-1938-1945,grapes,tonnes,1941,iia;juan,czech republic;czechoslovakia,,3000,3.18e+04,10.6000,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2900,3.06e+04,10.5517,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,tonnes,1944,iia;juan,czech republic;czechoslovakia,,3000,3.16e+04,10.5333,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3900,4.1e+04,10.5128,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3500,3.67e+04,10.4857,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3600,3.76e+04,10.4444,iia-item-series-switch-raw-products
+F51-1945-1947,grapes,tonnes,1945,iia;juan,czech republic;czechoslovakia,,3800,3.95e+04,10.3947,iia-item-series-switch-raw-products
+F51-1938-1945,"beans, dry",ha,1940,iia;juan,czech republic;czechoslovakia,,4000,4.1e+04,10.2500,iia-czechoslovakia-beans-component-only
+F51-1938-1945,rye,ha,1941,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.84e+05,10.0513,iia-attributable-single-cell-errors
+F51-1938-1945,rye,ha,1939,iia;juan,czech republic;czechoslovakia,,9.8e+04,9.84e+05,10.0408,iia-attributable-single-cell-errors
+F248-1920-1947,hops,ha,1934,iia;juan,serbia;yugoslav sfr,,2400,2.4e+04,10.0000,iia-hops-x100
+F248-1920-1947,hops,ha,1935,iia;juan,serbia;yugoslav sfr,,2600,2.6e+04,10.0000,iia-hops-x100
+F248-1920-1947,hops,ha,1936,iia;juan,serbia;yugoslav sfr,,2700,2.7e+04,10.0000,iia-hops-x100
+F248-1920-1947,hops,ha,1937,iia;juan,serbia;yugoslav sfr,,2900,2.9e+04,10.0000,iia-hops-x100
+F248-1920-1947,hops,ha,1938,iia;juan,serbia;yugoslav sfr,,2800,2.8e+04,10.0000,iia-hops-x100
+F248-1920-1947,rye,ha,1931,iia;juan,serbia;yugoslav sfr,,2.442e+04,2.442e+05,10.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1932,iia;juan,serbia;yugoslav sfr,,2.43e+04,2.43e+05,10.0000,iia-attributable-single-cell-errors
+F51-1918-1938,hops,ha,1934,iia;juan,czech republic;czechoslovakia,,1.09e+04,1.09e+05,10.0000,iia-hops-x100
+F51-1918-1938,hops,ha,1935,iia;juan,czech republic;czechoslovakia,,1.12e+04,1.12e+05,10.0000,iia-hops-x100
+F51-1918-1938,hops,ha,1936,iia;juan,czech republic;czechoslovakia,,1.14e+04,1.14e+05,10.0000,iia-hops-x100
+F51-1938-1945,"beans, dry",ha,1941,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,iia-czechoslovakia-beans-component-only
+F51-1938-1945,"beans, dry",ha,1942,iia;juan,czech republic;czechoslovakia,,4000,4e+04,10.0000,iia-czechoslovakia-beans-component-only
+F51-1938-1945,hops,ha,1938,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.16e+05,10.0000,iia-hops-x100
+F51-1918-1938,hops,ha,1937,iia;juan,czech republic;czechoslovakia,,1.15e+04,1.13e+05,9.8261,iia-hops-x100
+F51-1938-1945,"beans, dry",ha,1939,iia;juan,czech republic;czechoslovakia,,4000,3.9e+04,9.7500,iia-czechoslovakia-beans-component-only
+F248-1920-1947,flax fibre and tow,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1400,1.29e+04,9.2143,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,rye,ha,1940,iia;juan,czech republic;czechoslovakia,,7.8e+04,7.08e+05,9.0769,iia-attributable-single-cell-errors
+F51-1918-1938,grapes,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.11e+04,1.006e+05,9.0631,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6800,6.05e+04,8.8971,iia-item-series-switch-raw-products
+F248-1920-1947,flax fibre and tow,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1300,1.11e+04,8.5385,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,grapes,ha,1939,iia;juan,czech republic;czechoslovakia,,2000,1.7e+04,8.5000,iia-item-series-switch-raw-products
+F51-1918-1938,"beans, dry",ha,1934,iia;juan,czech republic;czechoslovakia,,7000,5.8e+04,8.2857,iia-czechoslovakia-beans-component-only
+F248-1920-1947,flax fibre and tow,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1500,1.2e+04,8.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,"beans, dry",ha,1943,iia;juan,czech republic;czechoslovakia,,5000,3.5e+04,7.0000,iia-czechoslovakia-beans-component-only
+F51-1938-1945,"beans, dry",ha,1944,iia;juan,czech republic;czechoslovakia,,5000,3e+04,6.0000,iia-czechoslovakia-beans-component-only
+F248-1920-1947,"beans, dry",tonnes,1935,iia;juan,serbia;yugoslav sfr,,2.25e+04,1.147e+05,5.0978,
+F51-1938-1945,"beans, dry",tonnes,1940,iia;juan,czech republic;czechoslovakia,,4700,2.29e+04,4.8723,iia-czechoslovakia-beans-component-only
+F51-1945-1947,"beans, dry",ha,1945,iia;juan,czech republic;czechoslovakia,,6000,2.8e+04,4.6667,
+F51-1918-1938,"beans, dry",tonnes,1937,iia;juan,czech republic;czechoslovakia,,6900,3.04e+04,4.4058,iia-czechoslovakia-beans-component-only
+F248-1920-1947,"beans, dry",tonnes,1936,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.335e+05,4.3627,
+F248-1920-1947,"beans, dry",tonnes,1937,iia;juan,serbia;yugoslav sfr,,3.56e+04,1.55e+05,4.3539,
+F51-1938-1945,"beans, dry",tonnes,1941,iia;juan,czech republic;czechoslovakia,,4500,1.95e+04,4.3333,iia-czechoslovakia-beans-component-only
+F51-1938-1945,"beans, dry",tonnes,1939,iia;juan,czech republic;czechoslovakia,,5700,2.43e+04,4.2632,iia-czechoslovakia-beans-component-only
+F248-1920-1947,"beans, dry",tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.69e+04,1.141e+05,4.2416,
+F51-1938-1945,"beans, dry",tonnes,1942,iia;juan,czech republic;czechoslovakia,,6100,2.46e+04,4.0328,iia-czechoslovakia-beans-component-only
+F248-1920-1947,"beans, dry",tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.48e+04,9.82e+04,3.9597,
+F248-1920-1947,"beans, dry",tonnes,1934,iia;juan,serbia;yugoslav sfr,,4.04e+04,1.582e+05,3.9158,
+F51-1918-1938,"beans, dry",tonnes,1936,iia;juan,czech republic;czechoslovakia,,7600,2.91e+04,3.8289,iia-czechoslovakia-beans-component-only
+F248-1920-1947,"beans, dry",tonnes,1933,iia;juan,serbia;yugoslav sfr,,3.06e+04,1.166e+05,3.8105,
+F51-1938-1945,"beans, dry",tonnes,1938,iia;juan,czech republic;czechoslovakia,,5900,2.19e+04,3.7119,iia-czechoslovakia-beans-component-only
+F51-1918-1938,"beans, dry",tonnes,1935,iia;juan,czech republic;czechoslovakia,,4900,1.67e+04,3.4082,iia-czechoslovakia-beans-component-only
+F51-1918-1938,"beans, dry",tonnes,1934,iia;juan,czech republic;czechoslovakia,,7100,2.31e+04,3.2535,iia-czechoslovakia-beans-component-only
+F51-1938-1945,"beans, dry",tonnes,1943,iia;juan,czech republic;czechoslovakia,,5000,1.54e+04,3.0800,iia-czechoslovakia-beans-component-only
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1920,iia;mitchell,korea;south korea,;page_12_table_1,5508,1.6e+04,2.9047,iia-corrupted-country-labels
+F51-1938-1945,"beans, dry",tonnes,1944,iia;juan,czech republic;czechoslovakia,,5100,1.46e+04,2.8627,iia-czechoslovakia-beans-component-only
 PAL-1920-1948,wine,tonnes,1932,iia;mitchell,israel;palestine,;page_38_table_1,3019,8118,2.6887,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,"beans, dry",tonnes,1945,iia;juan,czech republic;czechoslovakia,,6500,1.32e+04,2.0308,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1929,3900,2.0217,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1000,2000,2.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,50.9,100,1.9646,layerb-nested-reporting-levels-one-polity
+F51-1945-1947,"beans, dry",tonnes,1945,iia;juan,czech republic;czechoslovakia,,6500,1.32e+04,2.0308,
+F248-1920-1947,rapeseed,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1929,3900,2.0217,iia-attributable-single-cell-errors
+F248-1920-1947,sesame seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1000,2000,2.0000,
+F248-1920-1947,sesame seed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,50.9,100,1.9646,
 PAL-1920-1948,wine,tonnes,1933,iia;mitchell,israel;palestine,;page_38_table_1,1584,2890,1.8245,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1930,iia;mitchell,israel;palestine,;page_38_table_1,1980,3569,1.8024,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1933,iia;juan,serbia;yugoslav sfr,,200,350,1.7500,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,180,1.6364,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1933,iia;juan,serbia;yugoslav sfr,,68.4,100,1.4620,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,121.6,170,1.3980,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,sesame seed,ha,1933,iia;juan,serbia;yugoslav sfr,,200,350,1.7500,
+F248-1920-1947,sesame seed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,180,1.6364,
+F248-1920-1947,cotton lint,tonnes,1933,iia;juan,serbia;yugoslav sfr,,68.4,100,1.4620,iia-item-series-switch-raw-products
+F248-1920-1947,sesame seed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,121.6,170,1.3980,
 PAL-1920-1948,wine,tonnes,1931,iia;mitchell,israel;palestine,;page_38_table_1,2772,3854,1.3904,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1925,iia;mitchell,korea;south korea,;page_12_table_1,1.017e+04,1.4e+04,1.3765,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,3406,4567,1.3406,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1.61e+04,2.15e+04,1.3354,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1931,iia;juan,serbia;yugoslav sfr,,300,395,1.3167,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4300,5600,1.3023,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7300,9500,1.3014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.72e+04,2.21e+04,1.2849,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.176e+06,1.476e+06,1.2552,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1923,iia;juan,serbia;yugoslav sfr,,2300,2885,1.2543,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.88e+04,2.35e+04,1.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,flax fibre and tow,tonnes,1945,iia;juan,czech republic;czechoslovakia,,5800,7100,1.2241,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1937,iia;juan,czech republic;czechoslovakia,,9000,1.1e+04,1.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.61e+04,1.2197,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1939,iia;juan,czech republic;czechoslovakia,,8300,1e+04,1.2048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1935,iia;juan,czech republic;czechoslovakia,,5700,6800,1.1930,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1919,iia;juan,czech republic;czechoslovakia,,400,477,1.1925,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1933,iia;juan,czech republic;czechoslovakia,,1.73e+04,2e+04,1.1562,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1922,iia;juan,serbia;yugoslav sfr,,6020,6925,1.1503,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1932,iia;juan,serbia;yugoslav sfr,,400,459,1.1475,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1930,iia;juan,serbia;yugoslav sfr,,400,454,1.1350,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1933,iia;juan,serbia;yugoslav sfr,,3000,3383,1.1277,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,5185,5832,1.1248,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1922,iia;juan,serbia;yugoslav sfr,,50,56.1,1.1220,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1921,iia;juan,czech republic;czechoslovakia,,2260,2509,1.1100,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1923,iia;juan,serbia;yugoslav sfr,,40,44.1,1.1025,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1923,iia;juan,czech republic;czechoslovakia,,1.107e+04,1.19e+04,1.0746,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,117.6,1.0691,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1941,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1925,iia;mitchell,korea;south korea,;page_12_table_1,1.017e+04,1.4e+04,1.3765,iia-corrupted-country-labels
+F51-1918-1938,hempseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,3406,4567,1.3406,
+F51-1938-1945,flax fibre and tow,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1.61e+04,2.15e+04,1.3354,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,sesame seed,ha,1931,iia;juan,serbia;yugoslav sfr,,300,395,1.3167,
+F51-1918-1938,flax fibre and tow,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4300,5600,1.3023,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7300,9500,1.3014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.72e+04,2.21e+04,1.2849,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rye,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.176e+06,1.476e+06,1.2552,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1923,iia;juan,serbia;yugoslav sfr,,2300,2885,1.2543,iia-attributable-single-cell-errors
+F51-1938-1945,flax fibre and tow,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.88e+04,2.35e+04,1.2500,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1945-1947,flax fibre and tow,tonnes,1945,iia;juan,czech republic;czechoslovakia,,5800,7100,1.2241,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1937,iia;juan,czech republic;czechoslovakia,,9000,1.1e+04,1.2222,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,tonnes,1944,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.61e+04,1.2197,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,tonnes,1939,iia;juan,czech republic;czechoslovakia,,8300,1e+04,1.2048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1935,iia;juan,czech republic;czechoslovakia,,5700,6800,1.1930,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hemp tow waste,ha,1919,iia;juan,czech republic;czechoslovakia,,400,477,1.1925,
+F51-1918-1938,grapes,ha,1933,iia;juan,czech republic;czechoslovakia,,1.73e+04,2e+04,1.1562,iia-item-series-switch-raw-products
+F248-1920-1947,flax fibre and tow,tonnes,1922,iia;juan,serbia;yugoslav sfr,,6020,6925,1.1503,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,sesame seed,ha,1932,iia;juan,serbia;yugoslav sfr,,400,459,1.1475,
+F248-1920-1947,sesame seed,ha,1930,iia;juan,serbia;yugoslav sfr,,400,454,1.1350,
+F248-1920-1947,rapeseed,ha,1933,iia;juan,serbia;yugoslav sfr,,3000,3383,1.1277,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,5185,5832,1.1248,iia-attributable-single-cell-errors
+F248-1920-1947,cotton lint,tonnes,1922,iia;juan,serbia;yugoslav sfr,,50,56.1,1.1220,iia-item-series-switch-raw-products
+F51-1918-1938,hops,tonnes,1921,iia;juan,czech republic;czechoslovakia,,2260,2509,1.1100,
+F248-1920-1947,cotton lint,tonnes,1923,iia;juan,serbia;yugoslav sfr,,40,44.1,1.1025,iia-item-series-switch-raw-products
+F51-1918-1938,hempseed,ha,1923,iia;juan,czech republic;czechoslovakia,,1.107e+04,1.19e+04,1.0746,
+F248-1920-1947,cotton lint,tonnes,1932,iia;juan,serbia;yugoslav sfr,,110,117.6,1.0691,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,ha,1941,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.6e+04,1.0667,iia-item-series-switch-raw-products
 PAL-1920-1948,wine,tonnes,1922,iia;mitchell,israel;palestine,;page_38_table_1,2696,2871,1.0648,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1935,iia;mitchell,israel;palestine,;page_38_table_1,2425,2574,1.0614,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1921,iia;juan,czech republic;czechoslovakia,,1.134e+04,1.202e+04,1.0608,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1931,iia;juan,serbia;yugoslav sfr,,70,74.1,1.0586,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1925,iia;juan,czech republic;czechoslovakia,,1.101e+04,1.16e+04,1.0539,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1922,iia;juan,serbia;yugoslav sfr,,9391,9890,1.0531,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7627,8000,1.0489,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1925,iia;juan,serbia;yugoslav sfr,,120,125.8,1.0483,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hemp tow waste,ha,1921,iia;juan,czech republic;czechoslovakia,,1.134e+04,1.202e+04,1.0608,
+F248-1920-1947,cotton lint,tonnes,1931,iia;juan,serbia;yugoslav sfr,,70,74.1,1.0586,iia-item-series-switch-raw-products
+F51-1918-1938,hempseed,ha,1925,iia;juan,czech republic;czechoslovakia,,1.101e+04,1.16e+04,1.0539,
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1922,iia;juan,serbia;yugoslav sfr,,9391,9890,1.0531,iia-corrupted-country-labels
+F51-1918-1938,hempseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7627,8000,1.0489,
+F248-1920-1947,cotton lint,tonnes,1925,iia;juan,serbia;yugoslav sfr,,120,125.8,1.0483,iia-item-series-switch-raw-products
 PAL-1920-1948,wine,tonnes,1924,iia;mitchell,israel;palestine,;page_38_table_1,1420,1485,1.0456,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1920,iia;juan,czech republic;czechoslovakia,,1200,1254,1.0450,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1932,iia;juan,serbia;yugoslav sfr,,1400,1462,1.0443,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1921,iia;juan,czech republic;czechoslovakia,,1300,1357,1.0438,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1922,iia;mitchell,korea;south korea,;page_12_table_1,1.054e+04,1.1e+04,1.0433,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1924,iia;juan,serbia;yugoslav sfr,,80,83.4,1.0425,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1922,iia;juan,czech republic;czechoslovakia,,1600,1668,1.0425,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1909,iia;mitchell,korea;south korea,;page_12_table_1,1.151e+04,1.2e+04,1.0424,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1911,iia;mitchell,korea;south korea,;page_12_table_1,1.056e+04,1.1e+04,1.0416,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1925,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.489e+04,1.0414,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,210,218.4,1.0400,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1100,1144,1.0400,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2287,1.0395,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1930,iia;juan,serbia;yugoslav sfr,,130,134.9,1.0377,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.2e+04,1.0377,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1931,iia;juan,serbia;yugoslav sfr,,2200,2275,1.0341,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,1000,1034,1.0335,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1930,iia;juan,serbia;yugoslav sfr,,2800,2889,1.0318,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1933,iia;juan,czech republic;czechoslovakia,,970,1000,1.0309,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1922,iia;juan,serbia;yugoslav sfr,,3000,3089,1.0297,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1918,iia;mitchell,korea;south korea,;page_12_table_1,1.457e+04,1.5e+04,1.0297,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,7411,7627,1.0292,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.734e+04,1.784e+04,1.0287,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1912,iia;mitchell,korea;south korea,;page_12_table_1,1.264e+04,1.3e+04,1.0285,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1924,iia;mitchell,korea;south korea,;page_12_table_1,1.459e+04,1.5e+04,1.0278,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1924,iia;juan,serbia;yugoslav sfr,,3.523e+04,3.62e+04,1.0275,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1931,iia;mitchell,korea;south korea,;page_12_table_1,1.6e+04,1.644e+04,1.0275,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1933,iia;mitchell,korea;south korea,;page_12_table_1,1.655e+04,1.7e+04,1.0270,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1932,iia;juan,czech republic;czechoslovakia,,1500,1539,1.0260,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1919,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.434e+04,1.0241,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,60,61.4,1.0233,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1933,iia;juan,czech republic;czechoslovakia,,1.027e+04,1.05e+04,1.0227,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1923,iia;juan,czech republic;czechoslovakia,,2600,2654,1.0208,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1920,iia;juan,czech republic;czechoslovakia,,1200,1254,1.0450,iia-corrupted-country-labels
+F248-1920-1947,hops,ha,1932,iia;juan,serbia;yugoslav sfr,,1400,1462,1.0443,
+F51-1918-1938,"tobacco, unmanufactured",ha,1921,iia;juan,czech republic;czechoslovakia,,1300,1357,1.0438,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1922,iia;mitchell,korea;south korea,;page_12_table_1,1.054e+04,1.1e+04,1.0433,iia-corrupted-country-labels
+F248-1920-1947,cotton lint,tonnes,1924,iia;juan,serbia;yugoslav sfr,,80,83.4,1.0425,iia-item-series-switch-raw-products
+F51-1918-1938,"tobacco, unmanufactured",ha,1922,iia;juan,czech republic;czechoslovakia,,1600,1668,1.0425,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1909,iia;mitchell,korea;south korea,;page_12_table_1,1.151e+04,1.2e+04,1.0424,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1911,iia;mitchell,korea;south korea,;page_12_table_1,1.056e+04,1.1e+04,1.0416,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",ha,1925,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.489e+04,1.0414,iia-corrupted-country-labels
+F51-1918-1938,hempseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,210,218.4,1.0400,
+F51-1918-1938,rapeseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1100,1144,1.0400,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2287,1.0395,iia-attributable-single-cell-errors
+F248-1920-1947,cotton lint,tonnes,1930,iia;juan,serbia;yugoslav sfr,,130,134.9,1.0377,iia-item-series-switch-raw-products
+F51-1918-1938,flax fibre and tow,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.2e+04,1.0377,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hops,ha,1931,iia;juan,serbia;yugoslav sfr,,2200,2275,1.0341,
+F51-1918-1938,rapeseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,1000,1034,1.0335,iia-attributable-single-cell-errors
+F248-1920-1947,hops,ha,1930,iia;juan,serbia;yugoslav sfr,,2800,2889,1.0318,
+F51-1918-1938,rapeseed,ha,1933,iia;juan,czech republic;czechoslovakia,,970,1000,1.0309,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1922,iia;juan,serbia;yugoslav sfr,,3000,3089,1.0297,iia-attributable-single-cell-errors
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1918,iia;mitchell,korea;south korea,;page_12_table_1,1.457e+04,1.5e+04,1.0297,iia-corrupted-country-labels
+F51-1918-1938,linseed,tonnes,1921,iia;juan,czech republic;czechoslovakia,,7411,7627,1.0292,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.734e+04,1.784e+04,1.0287,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1912,iia;mitchell,korea;south korea,;page_12_table_1,1.264e+04,1.3e+04,1.0285,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1924,iia;mitchell,korea;south korea,;page_12_table_1,1.459e+04,1.5e+04,1.0278,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",ha,1924,iia;juan,serbia;yugoslav sfr,,3.523e+04,3.62e+04,1.0275,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1931,iia;mitchell,korea;south korea,;page_12_table_1,1.6e+04,1.644e+04,1.0275,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1933,iia;mitchell,korea;south korea,;page_12_table_1,1.655e+04,1.7e+04,1.0270,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,rapeseed,ha,1932,iia;juan,czech republic;czechoslovakia,,1500,1539,1.0260,iia-attributable-single-cell-errors
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1919,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.434e+04,1.0241,iia-corrupted-country-labels
+F248-1920-1947,sesame seed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,60,61.4,1.0233,
+F51-1918-1938,hops,ha,1933,iia;juan,czech republic;czechoslovakia,,1.027e+04,1.05e+04,1.0227,
+F51-1918-1938,"tobacco, unmanufactured",ha,1923,iia;juan,czech republic;czechoslovakia,,2600,2654,1.0208,iia-corrupted-country-labels
 PAL-1920-1948,wine,tonnes,1934,iia;mitchell,israel;palestine,;page_38_table_1,2328,2376,1.0206,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1936,iia;mitchell,israel;palestine,;page_38_table_1,2231,2277,1.0206,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1937,iia;mitchell,israel;palestine,;page_38_table_1,2425,2475,1.0206,layerb-nested-reporting-levels-one-polity
@@ -278,528 +278,528 @@ PAL-1920-1948,wine,tonnes,1941,iia;mitchell,israel;palestine,;page_38_table_1,35
 PAL-1920-1948,wine,tonnes,1942,iia;mitchell,israel;palestine,;page_38_table_1,3977,4059,1.0206,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1943,iia;mitchell,israel;palestine,;page_38_table_1,4171,4257,1.0206,layerb-nested-reporting-levels-one-polity
 PAL-1920-1948,wine,tonnes,1944,iia;mitchell,israel;palestine,;page_38_table_1,5335,5445,1.0206,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1924,iia;juan,czech republic;czechoslovakia,,3400,3464,1.0188,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.24e+04,1.0164,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,2032,1.0160,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1913,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.422e+04,1.0160,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1915,iia;mitchell,korea;south korea,;page_12_table_1,1.378e+04,1.4e+04,1.0158,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1931,iia;juan,czech republic;czechoslovakia,,2000,2031,1.0155,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,rapeseed,ha,1924,iia;juan,czech republic;czechoslovakia,,3400,3464,1.0188,iia-attributable-single-cell-errors
+F51-1938-1945,flax fibre and tow,tonnes,1943,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.24e+04,1.0164,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hops,ha,1925,iia;juan,serbia;yugoslav sfr,,2000,2032,1.0160,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1913,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.422e+04,1.0160,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1915,iia;mitchell,korea;south korea,;page_12_table_1,1.378e+04,1.4e+04,1.0158,iia-corrupted-country-labels
+F51-1918-1938,rapeseed,ha,1931,iia;juan,czech republic;czechoslovakia,,2000,2031,1.0155,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,linseed,ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7098,1.0140,iia-flax-fibre-item-is-mostly-linseed
 PAL-1920-1948,wine,tonnes,1923,iia;mitchell,israel;palestine,;page_38_table_1,2441,2475,1.0139,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1930,iia;juan,czech republic;czechoslovakia,,7400,7499,1.0134,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1925,iia;juan,serbia;yugoslav sfr,,2700,2736,1.0133,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.114e+04,1.0131,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1922,iia;juan,serbia;yugoslav sfr,,1800,1823,1.0128,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1914,iia;mitchell,korea;south korea,;page_12_table_1,9874,1e+04,1.0128,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2228,1.0127,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1921,iia;juan,czech republic;czechoslovakia,,4800,4860,1.0125,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.113e+04,1.0117,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1924,iia;juan,czech republic;czechoslovakia,,8100,8192,1.0114,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1924,iia;juan,czech republic;czechoslovakia,,4100,4146,1.0112,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8200,8290,1.0110,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1923,iia;mitchell,korea;south korea,;page_12_table_1,1.187e+04,1.2e+04,1.0109,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1923,iia;juan,serbia;yugoslav sfr,,1600,1616,1.0100,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1919,iia;juan,czech republic;czechoslovakia,,8500,8585,1.0100,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1932,iia;juan,czech republic;czechoslovakia,,9900,9997,1.0098,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8984,1.0094,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3469,3500,1.0089,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1910,iia;mitchell,korea;south korea,;page_12_table_1,8921,9000,1.0089,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2677,2700,1.0087,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rye,ha,1945,iia;juan,czech republic;czechoslovakia,,8.02e+05,8.09e+05,1.0087,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2777,2800,1.0084,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8970,1.0079,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1923,iia;juan,czech republic;czechoslovakia,,7700,7761,1.0079,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1922,iia;juan,czech republic;czechoslovakia,,3900,3931,1.0079,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1921,iia;juan,czech republic;czechoslovakia,,8300,8362,1.0075,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.259e+04,1.0075,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1920,iia;juan,czech republic;czechoslovakia,,8300,8361,1.0073,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1931,iia;juan,serbia;yugoslav sfr,,1.23e+04,1.239e+04,1.0071,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1000,1007,1.0071,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1920,iia;juan,czech republic;czechoslovakia,,6600,6647,1.0071,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1917,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.41e+04,1.0071,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1920,iia;juan,serbia;yugoslav sfr,,1.24e+04,1.249e+04,1.0070,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1922,iia;juan,czech republic;czechoslovakia,,7800,7854,1.0069,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1922,iia;juan,czech republic;czechoslovakia,,1.19e+04,1.198e+04,1.0068,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1924,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.168e+04,1.0068,layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1930,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.51e+04,1.0067,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1924,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.309e+04,1.0066,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1932,iia;juan,czech republic;czechoslovakia,,9500,9563,1.0066,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1916,iia;mitchell,korea;south korea,;page_12_table_1,1.3e+04,1.308e+04,1.0065,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1932,iia;juan,serbia;yugoslav sfr,,1.06e+04,1.067e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.258e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1932,iia;juan,czech republic;czechoslovakia,,7700,7749,1.0064,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1922,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.318e+04,1.0061,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1921,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.439e+04,1.0061,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,"tobacco, unmanufactured",ha,1930,iia;juan,czech republic;czechoslovakia,,7400,7499,1.0134,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,rapeseed,ha,1925,iia;juan,serbia;yugoslav sfr,,2700,2736,1.0133,iia-attributable-single-cell-errors
+F248-1920-1947,"tobacco, unmanufactured",ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.114e+04,1.0131,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,hops,ha,1922,iia;juan,serbia;yugoslav sfr,,1800,1823,1.0128,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1914,iia;mitchell,korea;south korea,;page_12_table_1,9874,1e+04,1.0128,iia-corrupted-country-labels
+F248-1920-1947,hops,ha,1924,iia;juan,serbia;yugoslav sfr,,2200,2228,1.0127,
+F51-1918-1938,rapeseed,ha,1921,iia;juan,czech republic;czechoslovakia,,4800,4860,1.0125,iia-attributable-single-cell-errors
+F248-1920-1947,flax fibre and tow,ha,1933,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.113e+04,1.0117,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1924,iia;juan,czech republic;czechoslovakia,,8100,8192,1.0114,
+F51-1918-1938,"tobacco, unmanufactured",ha,1924,iia;juan,czech republic;czechoslovakia,,4100,4146,1.0112,iia-corrupted-country-labels
+F51-1918-1938,hempseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8200,8290,1.0110,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1923,iia;mitchell,korea;south korea,;page_12_table_1,1.187e+04,1.2e+04,1.0109,iia-corrupted-country-labels
+F248-1920-1947,hops,ha,1923,iia;juan,serbia;yugoslav sfr,,1600,1616,1.0100,
+F51-1918-1938,hops,ha,1919,iia;juan,czech republic;czechoslovakia,,8500,8585,1.0100,
+F51-1918-1938,"tobacco, unmanufactured",ha,1932,iia;juan,czech republic;czechoslovakia,,9900,9997,1.0098,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,linseed,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8984,1.0094,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3469,3500,1.0089,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1910,iia;mitchell,korea;south korea,;page_12_table_1,8921,9000,1.0089,iia-corrupted-country-labels
+F51-1918-1938,linseed,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2677,2700,1.0087,iia-flax-fibre-item-is-mostly-linseed
+F51-1945-1947,rye,ha,1945,iia;juan,czech republic;czechoslovakia,,8.02e+05,8.09e+05,1.0087,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2777,2800,1.0084,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,ha,1931,iia;juan,czech republic;czechoslovakia,,8900,8970,1.0079,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1923,iia;juan,czech republic;czechoslovakia,,7700,7761,1.0079,
+F51-1918-1938,rapeseed,ha,1922,iia;juan,czech republic;czechoslovakia,,3900,3931,1.0079,iia-attributable-single-cell-errors
+F51-1918-1938,hops,ha,1921,iia;juan,czech republic;czechoslovakia,,8300,8362,1.0075,
+F51-1918-1938,linseed,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.259e+04,1.0075,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1920,iia;juan,czech republic;czechoslovakia,,8300,8361,1.0073,
+F248-1920-1947,flax fibre and tow,ha,1931,iia;juan,serbia;yugoslav sfr,,1.23e+04,1.239e+04,1.0071,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hempseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1000,1007,1.0071,
+F51-1918-1938,rapeseed,ha,1920,iia;juan,czech republic;czechoslovakia,,6600,6647,1.0071,iia-attributable-single-cell-errors
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1917,iia;mitchell,korea;south korea,;page_12_table_1,1.4e+04,1.41e+04,1.0071,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",ha,1920,iia;juan,serbia;yugoslav sfr,,1.24e+04,1.249e+04,1.0070,iia-corrupted-country-labels
+F51-1918-1938,hops,ha,1922,iia;juan,czech republic;czechoslovakia,,7800,7854,1.0069,
+F51-1918-1938,hempseed,ha,1922,iia;juan,czech republic;czechoslovakia,,1.19e+04,1.198e+04,1.0068,
+F51-1918-1938,hempseed,ha,1924,iia;juan,czech republic;czechoslovakia,,1.16e+04,1.168e+04,1.0068,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1930,iia;mitchell,korea;south korea,;page_12_table_1,1.5e+04,1.51e+04,1.0067,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,flax fibre and tow,ha,1924,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.309e+04,1.0066,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1932,iia;juan,czech republic;czechoslovakia,,9500,9563,1.0066,
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1916,iia;mitchell,korea;south korea,;page_12_table_1,1.3e+04,1.308e+04,1.0065,iia-corrupted-country-labels
+F248-1920-1947,flax fibre and tow,ha,1932,iia;juan,serbia;yugoslav sfr,,1.06e+04,1.067e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1930,iia;juan,czech republic;czechoslovakia,,1.25e+04,1.258e+04,1.0064,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,ha,1932,iia;juan,czech republic;czechoslovakia,,7700,7749,1.0064,
+F248-1920-1947,flax fibre and tow,ha,1922,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.318e+04,1.0061,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"tobacco, unmanufactured",ha,1921,iia;juan,serbia;yugoslav sfr,,1.43e+04,1.439e+04,1.0061,iia-corrupted-country-labels
 SER-1878-1913,flax fibre and tow,ha,1911,iia;juan,serbia;yugoslav sfr,,1800,1811,1.0061,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1932,iia;juan,serbia;yugoslav sfr,,820,824.9,1.0060,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1931,iia;juan,czech republic;czechoslovakia,,9000,9053,1.0059,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1100,1106,1.0055,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1920,iia;juan,czech republic;czechoslovakia,,1.86e+04,1.87e+04,1.0052,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1740,1749,1.0051,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1820,1829,1.0050,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1919,iia;juan,czech republic;czechoslovakia,,9000,9044,1.0049,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1930,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.316e+04,1.0048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1925,iia;juan,czech republic;czechoslovakia,,9000,9042,1.0047,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9039,9080,1.0046,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1580,1587,1.0045,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1930,iia;juan,serbia;yugoslav sfr,,1.53e+04,1.537e+04,1.0045,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1930,iia;juan,czech republic;czechoslovakia,,6200,6228,1.0045,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1923,iia;juan,serbia;yugoslav sfr,,2.16e+04,2.169e+04,1.0044,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-KOR-1800-1945,"tobacco, unmanufactured",tonnes,1932,iia;mitchell,korea;south korea,;page_12_table_1,1.991e+04,2e+04,1.0044,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1921,iia;juan,serbia;yugoslav sfr,,1.47e+04,1.476e+04,1.0041,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1750,1757,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1930,iia;juan,czech republic;czechoslovakia,,1.55e+04,1.556e+04,1.0039,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-CHN-1921-1932,soybeans,tonnes,1930,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.298e+06,5.317e+06,1.0037,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1933,iia;juan,serbia;yugoslav sfr,,1694,1700,1.0035,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1470,1475,1.0035,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
+F248-1920-1947,hops,tonnes,1932,iia;juan,serbia;yugoslav sfr,,820,824.9,1.0060,
+F51-1918-1938,"tobacco, unmanufactured",ha,1931,iia;juan,czech republic;czechoslovakia,,9000,9053,1.0059,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,hops,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1100,1106,1.0055,
+F51-1918-1938,grapes,ha,1920,iia;juan,czech republic;czechoslovakia,,1.86e+04,1.87e+04,1.0052,iia-item-series-switch-raw-products
+F51-1918-1938,rapeseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,1740,1749,1.0051,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1820,1829,1.0050,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,ha,1919,iia;juan,czech republic;czechoslovakia,,9000,9044,1.0049,
+F248-1920-1947,flax fibre and tow,ha,1930,iia;juan,serbia;yugoslav sfr,,1.31e+04,1.316e+04,1.0048,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1925,iia;juan,czech republic;czechoslovakia,,9000,9042,1.0047,
+F51-1918-1938,linseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9039,9080,1.0046,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hops,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1580,1587,1.0045,
+F248-1920-1947,"tobacco, unmanufactured",ha,1930,iia;juan,serbia;yugoslav sfr,,1.53e+04,1.537e+04,1.0045,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,hempseed,ha,1930,iia;juan,czech republic;czechoslovakia,,6200,6228,1.0045,
+F248-1920-1947,"tobacco, unmanufactured",ha,1923,iia;juan,serbia;yugoslav sfr,,2.16e+04,2.169e+04,1.0044,iia-corrupted-country-labels
+KOR-1800-1945,"tobacco, unmanufactured",tonnes,1932,iia;mitchell,korea;south korea,;page_12_table_1,1.991e+04,2e+04,1.0044,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,flax fibre and tow,ha,1921,iia;juan,serbia;yugoslav sfr,,1.47e+04,1.476e+04,1.0041,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hops,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1750,1757,1.0039,
+F51-1918-1938,flax fibre and tow,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1930,iia;juan,czech republic;czechoslovakia,,1.55e+04,1.556e+04,1.0039,
+F51-1918-1938,linseed,ha,1924,iia;juan,czech republic;czechoslovakia,,2.18e+04,2.189e+04,1.0039,iia-flax-fibre-item-is-mostly-linseed
+CHN-1921-1932,soybeans,tonnes,1930,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.298e+06,5.317e+06,1.0037,
+F248-1920-1947,hops,ha,1933,iia;juan,serbia;yugoslav sfr,,1694,1700,1.0035,
+F248-1920-1947,rapeseed,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1470,1475,1.0035,iia-attributable-single-cell-errors
 SER-1878-1913,hemp tow waste,ha,1910,iia;juan,serbia;yugoslav sfr,,1.54e+04,1.545e+04,1.0035,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hemp tow waste,ha,1920,iia;juan,czech republic;czechoslovakia,,9900,9934,1.0034,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.478e+04,1.0033,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-CHN-1921-1932,soybeans,tonnes,1931,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.227e+06,5.244e+06,1.0032,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1510,1515,1.0032,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1680,1685,1.0030,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1933,iia;juan,czech republic;czechoslovakia,,1e+04,1.003e+04,1.0030,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1933,iia;juan,serbia;yugoslav sfr,,9900,9928,1.0028,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1924,iia;juan,serbia;yugoslav sfr,,2180,2186,1.0026,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1923,iia;juan,czech republic;czechoslovakia,,3800,3810,1.0026,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1500,1504,1.0025,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,997.5,1000,1.0025,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1931,iia;juan,serbia;yugoslav sfr,,3960,3969,1.0024,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1931,iia;juan,czech republic;czechoslovakia,,3380,3388,1.0024,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1925,iia;juan,czech republic;czechoslovakia,,3000,3007,1.0023,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1920,iia;juan,serbia;yugoslav sfr,,2.87e+04,2.876e+04,1.0022,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1930,iia;juan,serbia;yugoslav sfr,,1.16e+04,1.162e+04,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1931,iia;juan,serbia;yugoslav sfr,,7700,7717,1.0022,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2760,2766,1.0021,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,3860,3868,1.0021,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1360,1363,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,2870,2876,1.0020,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2540,2545,1.0020,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
+F51-1918-1938,hemp tow waste,ha,1920,iia;juan,czech republic;czechoslovakia,,9900,9934,1.0034,
+F51-1918-1938,linseed,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.478e+04,1.0033,iia-flax-fibre-item-is-mostly-linseed
+CHN-1921-1932,soybeans,tonnes,1931,iia;mitchell,"china, mainland;china, manchuria province of",;page_14_table_1,5.227e+06,5.244e+06,1.0032,
+F248-1920-1947,hops,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1510,1515,1.0032,
+F51-1918-1938,rapeseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1680,1685,1.0030,iia-attributable-single-cell-errors
+F51-1918-1938,"tobacco, unmanufactured",ha,1933,iia;juan,czech republic;czechoslovakia,,1e+04,1.003e+04,1.0030,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,flax fibre and tow,tonnes,1933,iia;juan,serbia;yugoslav sfr,,9900,9928,1.0028,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hops,tonnes,1924,iia;juan,serbia;yugoslav sfr,,2180,2186,1.0026,
+F51-1918-1938,rapeseed,ha,1923,iia;juan,czech republic;czechoslovakia,,3800,3810,1.0026,iia-attributable-single-cell-errors
+F248-1920-1947,hempseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1500,1504,1.0025,
+F248-1920-1947,linseed,tonnes,1933,iia;juan,serbia;yugoslav sfr,,997.5,1000,1.0025,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"oil, olive, virgin",tonnes,1931,iia;juan,serbia;yugoslav sfr,,3960,3969,1.0024,
+F51-1918-1938,flax fibre and tow,tonnes,1931,iia;juan,czech republic;czechoslovakia,,3380,3388,1.0024,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rapeseed,ha,1925,iia;juan,czech republic;czechoslovakia,,3000,3007,1.0023,iia-attributable-single-cell-errors
+F248-1920-1947,hemp tow waste,ha,1920,iia;juan,serbia;yugoslav sfr,,2.87e+04,2.876e+04,1.0022,
+F248-1920-1947,rapeseed,ha,1930,iia;juan,serbia;yugoslav sfr,,1.16e+04,1.162e+04,1.0022,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1931,iia;juan,serbia;yugoslav sfr,,7700,7717,1.0022,iia-attributable-single-cell-errors
+F51-1918-1938,hempseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2760,2766,1.0021,
+F51-1918-1938,rapeseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,3860,3868,1.0021,iia-attributable-single-cell-errors
+F248-1920-1947,linseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1360,1363,1.0020,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,2870,2876,1.0020,
+F51-1918-1938,linseed,tonnes,1931,iia;juan,czech republic;czechoslovakia,,2540,2545,1.0020,iia-flax-fibre-item-is-mostly-linseed
 SER-1878-1913,hemp tow waste,ha,1911,iia;juan,serbia;yugoslav sfr,,1.57e+04,1.573e+04,1.0020,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1925,iia;juan,serbia;yugoslav sfr,,1.32e+04,1.322e+04,1.0017,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1480,1482,1.0017,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,5280,5289,1.0017,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1924,iia;juan,czech republic;czechoslovakia,,5760,5770,1.0017,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1923,iia;juan,serbia;yugoslav sfr,,1.34e+04,1.342e+04,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.422e+04,1.424e+04,1.0016,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3280,3285,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,ha,1931,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.222e+04,1.0016,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1931,iia;juan,serbia;yugoslav sfr,,1.93e+04,1.933e+04,1.0015,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,4210,4216,1.0015,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1923,iia;juan,czech republic;czechoslovakia,,2790,2794,1.0015,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,6440,6449,1.0014,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1922,iia;juan,czech republic;czechoslovakia,,2060,2063,1.0014,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1920,iia;juan,serbia;yugoslav sfr,,1.41e+04,1.412e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.473e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,6270,6278,1.0013,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,5620,5627,1.0013,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1922,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.272e+04,1.0012,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,4310,4315,1.0012,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7950,7959,1.0012,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,7070,7078,1.0011,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1920,iia;juan,czech republic;czechoslovakia,,5260,5266,1.0011,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1923,iia;juan,serbia;yugoslav sfr,,8690,8698,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9800,9810,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,840,840.8,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.122e+04,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,4280,4284,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2410,2412,1.0010,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,4780,4785,1.0010,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,920,920.8,1.0009,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1919,iia;juan,czech republic;czechoslovakia,,7650,7657,1.0009,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1923,iia;juan,czech republic;czechoslovakia,,3090,3093,1.0009,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1925,iia;juan,czech republic;czechoslovakia,,6870,6876,1.0009,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,2070,2072,1.0008,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1933,iia;juan,serbia;yugoslav sfr,,4250,4253,1.0008,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1933,iia;juan,serbia;yugoslav sfr,,2.56e+05,2.562e+05,1.0008,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1920,iia;juan,czech republic;czechoslovakia,,2.2e+04,2.202e+04,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3597,3600,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,3980,3983,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1932,iia;juan,serbia;yugoslav sfr,,2900,2902,1.0007,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.257e+04,1.258e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.226e+04,1.227e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.366e+04,1.367e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.033e+04,1.034e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1921,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.202e+04,1.0006,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1932,iia;juan,serbia;yugoslav sfr,,2.14e+04,2.141e+04,1.0006,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1920,iia;juan,czech republic;czechoslovakia,,1.307e+04,1.308e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1925,iia;juan,czech republic;czechoslovakia,,7030,7034,1.0006,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.232e+04,1.233e+04,1.0006,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1924,iia;juan,serbia;yugoslav sfr,,8470,8475,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1925,iia;juan,serbia;yugoslav sfr,,1.993e+05,1.994e+05,1.0005,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.691e+04,1.692e+04,1.0005,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1930,iia;juan,czech republic;czechoslovakia,,5810,5813,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,1.154e+04,1.155e+04,1.0005,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1920,iia;juan,serbia;yugoslav sfr,,8810,8814,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.021e+04,1.021e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.063e+04,1.063e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,linseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,710,710.3,1.0004,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1932,iia;juan,serbia;yugoslav sfr,,3750,3752,1.0004,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1921,iia;juan,serbia;yugoslav sfr,,1.904e+05,1.905e+05,1.0004,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.332e+04,1.333e+04,1.0004,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,5150,5152,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1919,iia;juan,czech republic;czechoslovakia,,4350,4352,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9960,9964,1.0004,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.472e+04,1.473e+04,1.0004,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1350,1350,1.0003,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1920,iia;juan,serbia;yugoslav sfr,,1.98e+05,1.981e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1921,iia;juan,czech republic;czechoslovakia,,2.39e+04,2.391e+04,1.0003,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1932,iia;juan,czech republic;czechoslovakia,,7520,7522,1.0003,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,7920,7922,1.0003,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1933,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1932,iia;juan,czech republic;czechoslovakia,,1.706e+04,1.707e+04,1.0003,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1941,iia;juan,czech republic;czechoslovakia,,9.81e+05,9.813e+05,1.0003,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1920,iia;juan,serbia;yugoslav sfr,,1.638e+05,1.638e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1921,iia;juan,serbia;yugoslav sfr,,1.708e+05,1.708e+05,1.0002,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1464,1464,1.0002,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1925,iia;juan,serbia;yugoslav sfr,,2250,2250,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2.453e+05,2.453e+05,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,9190,9191,1.0002,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1310,1310,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.002e+04,1.002e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.383e+04,1.383e+04,1.0002,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.729e+06,1.729e+06,1.0002,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1922,iia;juan,serbia;yugoslav sfr,,1.972e+05,1.972e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1922,iia;juan,serbia;yugoslav sfr,,1.149e+05,1.149e+05,1.0001,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1924,iia;juan,serbia;yugoslav sfr,,3.568e+04,3.569e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.206e+04,1.206e+04,1.0001,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1919,iia;juan,czech republic;czechoslovakia,,1.4e+04,1.4e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.287e+04,1.287e+04,1.0001,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3790,3790,1.0001,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,linseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.057e+04,1.057e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1919,iia;juan,czech republic;czechoslovakia,,7.329e+05,7.33e+05,1.0001,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,flax fibre and tow,ha,1925,iia;juan,serbia;yugoslav sfr,,1.32e+04,1.322e+04,1.0017,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,rapeseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1480,1482,1.0017,iia-attributable-single-cell-errors
+F51-1918-1938,hempseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,5280,5289,1.0017,
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1924,iia;juan,czech republic;czechoslovakia,,5760,5770,1.0017,iia-corrupted-country-labels
+F248-1920-1947,flax fibre and tow,ha,1923,iia;juan,serbia;yugoslav sfr,,1.34e+04,1.342e+04,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.422e+04,1.424e+04,1.0016,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,flax fibre and tow,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3280,3285,1.0016,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,ha,1931,iia;juan,czech republic;czechoslovakia,,1.22e+04,1.222e+04,1.0016,
+F248-1920-1947,"tobacco, unmanufactured",ha,1931,iia;juan,serbia;yugoslav sfr,,1.93e+04,1.933e+04,1.0015,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,rapeseed,tonnes,1924,iia;juan,czech republic;czechoslovakia,,4210,4216,1.0015,iia-attributable-single-cell-errors
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1923,iia;juan,czech republic;czechoslovakia,,2790,2794,1.0015,iia-corrupted-country-labels
+F51-1918-1938,flax fibre and tow,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,6440,6449,1.0014,
+F51-1918-1938,linseed,ha,1932,iia;juan,czech republic;czechoslovakia,,6600,6609,1.0014,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1922,iia;juan,czech republic;czechoslovakia,,2060,2063,1.0014,iia-corrupted-country-labels
+F248-1920-1947,flax fibre and tow,ha,1920,iia;juan,serbia;yugoslav sfr,,1.41e+04,1.412e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1925,iia;juan,czech republic;czechoslovakia,,2.47e+04,2.473e+04,1.0013,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,6270,6278,1.0013,
+F51-1918-1938,linseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,5620,5627,1.0013,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"tobacco, unmanufactured",ha,1922,iia;juan,serbia;yugoslav sfr,,1.27e+04,1.272e+04,1.0012,iia-corrupted-country-labels
+F51-1918-1938,hempseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,4310,4315,1.0012,
+F51-1918-1938,linseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7950,7959,1.0012,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,rapeseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,7070,7078,1.0011,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,tonnes,1920,iia;juan,czech republic;czechoslovakia,,5260,5266,1.0011,
+F51-1918-1938,linseed,ha,1922,iia;juan,czech republic;czechoslovakia,,2.27e+04,2.272e+04,1.0011,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1923,iia;juan,serbia;yugoslav sfr,,8690,8698,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1931,iia;juan,serbia;yugoslav sfr,,9800,9810,1.0010,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,linseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,840,840.8,1.0010,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,linseed,ha,1923,iia;juan,czech republic;czechoslovakia,,2.12e+04,2.122e+04,1.0010,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,linseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,4280,4284,1.0010,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,linseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2410,2412,1.0010,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rapeseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,4780,4785,1.0010,iia-attributable-single-cell-errors
+F248-1920-1947,hempseed,tonnes,1932,iia;juan,serbia;yugoslav sfr,,920,920.8,1.0009,
+F51-1918-1938,flax fibre and tow,tonnes,1919,iia;juan,czech republic;czechoslovakia,,7650,7657,1.0009,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,tonnes,1923,iia;juan,czech republic;czechoslovakia,,3090,3093,1.0009,
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1925,iia;juan,czech republic;czechoslovakia,,6870,6876,1.0009,iia-corrupted-country-labels
+F248-1920-1947,hempseed,tonnes,1930,iia;juan,serbia;yugoslav sfr,,2070,2072,1.0008,
+F248-1920-1947,"oil, olive, virgin",tonnes,1933,iia;juan,serbia;yugoslav sfr,,4250,4253,1.0008,
+F248-1920-1947,rye,ha,1933,iia;juan,serbia;yugoslav sfr,,2.56e+05,2.562e+05,1.0008,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,ha,1920,iia;juan,czech republic;czechoslovakia,,2.2e+04,2.202e+04,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1933,iia;juan,czech republic;czechoslovakia,,3597,3600,1.0008,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,rapeseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,3980,3983,1.0007,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1932,iia;juan,serbia;yugoslav sfr,,2900,2902,1.0007,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.257e+04,1.258e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.226e+04,1.227e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.366e+04,1.367e+04,1.0007,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.033e+04,1.034e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,hemp tow waste,ha,1921,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.202e+04,1.0006,
+F248-1920-1947,"tobacco, unmanufactured",ha,1932,iia;juan,serbia;yugoslav sfr,,2.14e+04,2.141e+04,1.0006,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,flax fibre and tow,tonnes,1920,iia;juan,czech republic;czechoslovakia,,1.307e+04,1.308e+04,1.0006,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,tonnes,1925,iia;juan,czech republic;czechoslovakia,,7030,7034,1.0006,
+F51-1918-1938,hops,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.232e+04,1.233e+04,1.0006,
+F248-1920-1947,flax fibre and tow,tonnes,1924,iia;juan,serbia;yugoslav sfr,,8470,8475,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,rye,ha,1925,iia;juan,serbia;yugoslav sfr,,1.993e+05,1.994e+05,1.0005,iia-attributable-single-cell-errors
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.691e+04,1.692e+04,1.0005,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,flax fibre and tow,tonnes,1930,iia;juan,czech republic;czechoslovakia,,5810,5813,1.0005,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rapeseed,tonnes,1919,iia;juan,czech republic;czechoslovakia,,1.154e+04,1.155e+04,1.0005,
+F248-1920-1947,flax fibre and tow,tonnes,1920,iia;juan,serbia;yugoslav sfr,,8810,8814,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.021e+04,1.021e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,tonnes,1932,iia;juan,serbia;yugoslav sfr,,1.063e+04,1.063e+04,1.0004,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,linseed,tonnes,1931,iia;juan,serbia;yugoslav sfr,,710,710.3,1.0004,iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,"oil, olive, virgin",tonnes,1932,iia;juan,serbia;yugoslav sfr,,3750,3752,1.0004,
+F248-1920-1947,rye,ha,1921,iia;juan,serbia;yugoslav sfr,,1.904e+05,1.905e+05,1.0004,iia-attributable-single-cell-errors
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.332e+04,1.333e+04,1.0004,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,hempseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,5150,5152,1.0004,
+F51-1918-1938,hops,tonnes,1919,iia;juan,czech republic;czechoslovakia,,4350,4352,1.0004,
+F51-1918-1938,hops,tonnes,1924,iia;juan,czech republic;czechoslovakia,,9960,9964,1.0004,
+F51-1918-1938,hops,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.472e+04,1.473e+04,1.0004,
+F248-1920-1947,"oil, olive, virgin",tonnes,1930,iia;juan,serbia;yugoslav sfr,,1350,1350,1.0003,
+F248-1920-1947,rye,ha,1920,iia;juan,serbia;yugoslav sfr,,1.98e+05,1.981e+05,1.0003,iia-attributable-single-cell-errors
+F51-1918-1938,flax fibre and tow,ha,1921,iia;juan,czech republic;czechoslovakia,,2.39e+04,2.391e+04,1.0003,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hops,tonnes,1932,iia;juan,czech republic;czechoslovakia,,7520,7522,1.0003,
+F51-1918-1938,linseed,tonnes,1922,iia;juan,czech republic;czechoslovakia,,7920,7922,1.0003,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rye,ha,1933,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0003,iia-attributable-single-cell-errors
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1932,iia;juan,czech republic;czechoslovakia,,1.706e+04,1.707e+04,1.0003,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,rye,tonnes,1941,iia;juan,czech republic;czechoslovakia,,9.81e+05,9.813e+05,1.0003,iia-attributable-single-cell-errors
+F248-1920-1947,grapes,ha,1920,iia;juan,serbia;yugoslav sfr,,1.638e+05,1.638e+05,1.0002,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1921,iia;juan,serbia;yugoslav sfr,,1.708e+05,1.708e+05,1.0002,iia-item-series-switch-raw-products
+F248-1920-1947,hops,tonnes,1933,iia;juan,serbia;yugoslav sfr,,1464,1464,1.0002,
+F248-1920-1947,rapeseed,tonnes,1925,iia;juan,serbia;yugoslav sfr,,2250,2250,1.0002,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1933,iia;juan,serbia;yugoslav sfr,,2.453e+05,2.453e+05,1.0002,iia-attributable-single-cell-errors
+F51-1918-1938,linseed,tonnes,1923,iia;juan,czech republic;czechoslovakia,,9190,9191,1.0002,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rapeseed,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1310,1310,1.0002,iia-attributable-single-cell-errors
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.002e+04,1.002e+04,1.0002,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.383e+04,1.383e+04,1.0002,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,rye,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.729e+06,1.729e+06,1.0002,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1922,iia;juan,serbia;yugoslav sfr,,1.972e+05,1.972e+05,1.0001,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1922,iia;juan,serbia;yugoslav sfr,,1.149e+05,1.149e+05,1.0001,iia-attributable-single-cell-errors
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1924,iia;juan,serbia;yugoslav sfr,,3.568e+04,3.569e+04,1.0001,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.206e+04,1.206e+04,1.0001,iia-corrupted-country-labels
+F51-1918-1938,flax fibre and tow,ha,1919,iia;juan,czech republic;czechoslovakia,,1.4e+04,1.4e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.287e+04,1.287e+04,1.0001,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,hempseed,tonnes,1932,iia;juan,czech republic;czechoslovakia,,3790,3790,1.0001,
+F51-1918-1938,linseed,tonnes,1925,iia;juan,czech republic;czechoslovakia,,1.057e+04,1.057e+04,1.0001,iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,rye,ha,1919,iia;juan,czech republic;czechoslovakia,,7.329e+05,7.33e+05,1.0001,
 ETH-1907-1936,"coffee, green",tonnes,1933,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.62e+04,1.62e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
 ETH-1907-1936,"coffee, green",tonnes,1934,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,2.24e+04,2.24e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
 ETH-1907-1936,"coffee, green",tonnes,1935,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.98e+04,1.98e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
 ETH-1941-1952,"coffee, green",tonnes,1942,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,8400,8400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
 ETH-1941-1952,"coffee, green",tonnes,1943,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.1e+04,1.1e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
 ETH-1941-1952,"coffee, green",tonnes,1944,iia;mitchell,ethiopia;ethiopia pdr,;page_11_table_1,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1933,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1934,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1935,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.2e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1936,iia;juan,serbia;yugoslav sfr,,3.1e+04,3.1e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1937,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1938,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"beans, dry",ha,1939,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,castor beans seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1936,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1200,1200,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,cotton lint,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1100,1100,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,tonnes,1921,iia;juan,serbia;yugoslav sfr,,8260,8260,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1934,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1936,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1937,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1938,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,flax fibre and tow,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1933,iia;juan,serbia;yugoslav sfr,,1.95e+05,1.95e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1934,iia;juan,serbia;yugoslav sfr,,1.99e+05,1.99e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1935,iia;juan,serbia;yugoslav sfr,,2.07e+05,2.07e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,9.156e+05,9.156e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1936,iia;juan,serbia;yugoslav sfr,,2.14e+05,2.14e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1936,iia;juan,serbia;yugoslav sfr,,6.571e+05,6.571e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1937,iia;juan,serbia;yugoslav sfr,,2.15e+05,2.15e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.826e+05,4.826e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1938,iia;juan,serbia;yugoslav sfr,,2.19e+05,2.19e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,7.94e+05,7.94e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,ha,1939,iia;juan,serbia;yugoslav sfr,,2.23e+05,2.23e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,grapes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7.778e+05,7.778e+05,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1939,iia;juan,serbia;yugoslav sfr,,5.7e+04,5.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,tonnes,1939,iia;juan,serbia;yugoslav sfr,,5.35e+04,5.35e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,ha,1940,iia;juan,serbia;yugoslav sfr,,6e+04,6e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hemp tow waste,tonnes,1940,iia;juan,serbia;yugoslav sfr,,4.5e+04,4.5e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,2100,2100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4500,4500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hempseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3100,3100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,hops,ha,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,lemons and limes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,ha,1939,iia;juan,serbia;yugoslav sfr,,3.57e+05,3.57e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.483e+05,3.483e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,ha,1940,iia;juan,serbia;yugoslav sfr,,3.52e+05,3.52e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oats,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.879e+05,2.879e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1922,iia;juan,serbia;yugoslav sfr,,5780,5780,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1923,iia;juan,serbia;yugoslav sfr,,3180,3180,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1924,iia;juan,serbia;yugoslav sfr,,5140,5140,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1370,1370,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1934,iia;juan,serbia;yugoslav sfr,,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1935,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1936,iia;juan,serbia;yugoslav sfr,,2000,2000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1937,iia;juan,serbia;yugoslav sfr,,7200,7200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1938,iia;juan,serbia;yugoslav sfr,,6100,6100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1939,iia;juan,serbia;yugoslav sfr,,5900,5900,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1940,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1941,iia;juan,serbia;yugoslav sfr,,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1942,iia;juan,serbia;yugoslav sfr,,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1943,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1944,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"oil, olive, virgin",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1800,1800,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.67e+04,1.67e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.83e+04,4.83e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3.07e+04,3.07e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,olives,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.84e+04,3.84e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1935,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1936,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1938,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,oranges,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,5400,5400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1935,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.01e+04,1.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1936,iia;juan,serbia;yugoslav sfr,,2.4e+04,2.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1937,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,8200,8200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1938,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2900,2900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rapeseed,tonnes,1941,iia;juan,serbia;yugoslav sfr,,3600,3600,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1.547e+05,1.547e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1921,iia;juan,serbia;yugoslav sfr,,1.466e+05,1.466e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1923,iia;juan,serbia;yugoslav sfr,,1.871e+05,1.871e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.5e+05,1.5e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1924,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.408e+05,1.408e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.998e+05,1.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1930,iia;juan,serbia;yugoslav sfr,,2.469e+05,2.469e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.988e+05,1.988e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.934e+05,1.934e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1932,iia;juan,serbia;yugoslav sfr,,2.115e+05,2.115e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1934,iia;juan,serbia;yugoslav sfr,,2.48e+05,2.48e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1935,iia;juan,serbia;yugoslav sfr,,2.52e+05,2.52e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.961e+05,1.961e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1936,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.033e+05,2.033e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1937,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.094e+05,2.094e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1938,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.271e+05,2.271e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1939,iia;juan,serbia;yugoslav sfr,,2.58e+05,2.58e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.435e+05,2.435e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,ha,1940,iia;juan,serbia;yugoslav sfr,,2.55e+05,2.55e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,rye,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.111e+05,2.111e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1934,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1936,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1937,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,ha,1938,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sesame seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1934,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1936,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1939,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,tonnes,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,soybeans,ha,1941,iia;juan,serbia;yugoslav sfr,,1.7e+04,1.7e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,sunflower seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.9e+04,1.9e+04,1.0000,layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1920,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1921,iia;juan,serbia;yugoslav sfr,,9327,9327,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",tonnes,1933,iia;juan,serbia;yugoslav sfr,,8751,8751,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1936,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1937,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1938,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1939,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F248-1920-1947,"tobacco, unmanufactured",ha,1945,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"beans, dry",tonnes,1933,iia;juan,czech republic;czechoslovakia,,6600,6600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.028e+04,1.028e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1935,iia;juan,czech republic;czechoslovakia,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1936,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,flax fibre and tow,ha,1937,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1930,iia;juan,czech republic;czechoslovakia,,7.324e+04,7.324e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,tonnes,1931,iia;juan,czech republic;czechoslovakia,,7.08e+04,7.08e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1934,iia;juan,czech republic;czechoslovakia,,2.1e+04,2.1e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1935,iia;juan,czech republic;czechoslovakia,,2.4e+04,2.4e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1936,iia;juan,czech republic;czechoslovakia,,2.5e+04,2.5e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,grapes,ha,1937,iia;juan,czech republic;czechoslovakia,,2.6e+04,2.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,ha,1935,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,3900,3900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hempseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,3400,3400,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,hops,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6268,6268,1.0000,iia-1933-x10-wrong-volume-cells;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7204,7204,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1934,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1500,1500,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1935,iia;juan,czech republic;czechoslovakia,,4000,4000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,4800,4800,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1936,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7400,7400,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rapeseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1919,iia;juan,czech republic;czechoslovakia,,8.315e+05,8.315e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1920,iia;juan,czech republic;czechoslovakia,,8.998e+05,8.998e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1920,iia;juan,czech republic;czechoslovakia,,8.368e+05,8.368e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1921,iia;juan,czech republic;czechoslovakia,,8.835e+05,8.835e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.381e+06,1.381e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1922,iia;juan,czech republic;czechoslovakia,,8.797e+05,8.797e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.298e+06,1.298e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1923,iia;juan,czech republic;czechoslovakia,,8.593e+05,8.593e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.355e+06,1.355e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1924,iia;juan,czech republic;czechoslovakia,,8.375e+05,8.375e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.136e+06,1.136e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1925,iia;juan,czech republic;czechoslovakia,,8.46e+05,8.46e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1930,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.788e+06,1.788e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1931,iia;juan,czech republic;czechoslovakia,,9.996e+05,9.996e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.388e+06,1.388e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1932,iia;juan,czech republic;czechoslovakia,,1.04e+06,1.04e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2.176e+06,2.176e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2.086e+06,2.086e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1934,iia;juan,czech republic;czechoslovakia,,9.88e+05,9.88e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.523e+06,1.523e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1935,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.638e+06,1.638e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1936,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.436e+06,1.436e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,ha,1937,iia;juan,czech republic;czechoslovakia,,9.67e+05,9.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,rye,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.485e+06,1.485e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1934,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1935,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1936,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,soybeans,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1920,iia;juan,czech republic;czechoslovakia,,1766,1766,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1921,iia;juan,czech republic;czechoslovakia,,1289,1289,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1925,iia;juan,czech republic;czechoslovakia,,5400,5400,1.0000,iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",tonnes,1933,iia;juan,czech republic;czechoslovakia,,1.178e+04,1.178e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1935,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1936,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1918-1938,"tobacco, unmanufactured",ha,1937,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1938,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1939,iia;juan,czech republic;czechoslovakia,,2e+04,2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1940,iia;juan,czech republic;czechoslovakia,,4.6e+04,4.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1941,iia;juan,czech republic;czechoslovakia,,4.7e+04,4.7e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1943,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,flax fibre and tow,ha,1944,iia;juan,czech republic;czechoslovakia,,3.4e+04,3.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1938,iia;juan,czech republic;czechoslovakia,,2.7e+04,2.7e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1940,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1943,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,grapes,ha,1944,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1941,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1943,iia;juan,czech republic;czechoslovakia,,4900,4900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hemp tow waste,tonnes,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2600,2600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2400,2400,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2700,2700,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2500,2500,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hempseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1939,iia;juan,czech republic;czechoslovakia,,1.05e+04,1.05e+04,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1940,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1941,iia;juan,czech republic;czechoslovakia,,7500,7500,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1942,iia;juan,czech republic;czechoslovakia,,7300,7300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1943,iia;juan,czech republic;czechoslovakia,,6300,6300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,hops,ha,1944,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1939,iia;juan,czech republic;czechoslovakia,,7.06e+05,7.06e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.265e+06,1.265e+06,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1940,iia;juan,czech republic;czechoslovakia,,7.99e+05,7.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.277e+06,1.277e+06,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1941,iia;juan,czech republic;czechoslovakia,,6.55e+05,6.55e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1941,iia;juan,czech republic;czechoslovakia,,8.443e+05,8.443e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1942,iia;juan,czech republic;czechoslovakia,,6.36e+05,6.36e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1942,iia;juan,czech republic;czechoslovakia,,9.863e+05,9.863e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1943,iia;juan,czech republic;czechoslovakia,,6.02e+05,6.02e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1943,iia;juan,czech republic;czechoslovakia,,9.65e+05,9.65e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,ha,1944,iia;juan,czech republic;czechoslovakia,,5.72e+05,5.72e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,oats,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.44e+05,7.44e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.32e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7200,7200,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1940,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3700,3700,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1941,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.01e+04,2.01e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.5e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.85e+04,1.85e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,3.6e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.72e+04,3.72e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,ha,1944,iia;juan,czech republic;czechoslovakia,,6.1e+04,6.1e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rapeseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.28e+04,7.28e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1938,iia;juan,czech republic;czechoslovakia,,1.016e+06,1.016e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.906e+06,1.906e+06,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,tonnes,1940,iia;juan,czech republic;czechoslovakia,,8.67e+05,8.67e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1942,iia;juan,czech republic;czechoslovakia,,8.61e+05,8.61e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,rye,ha,1944,iia;juan,czech republic;czechoslovakia,,9.15e+05,9.15e+05,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1939,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1939,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1940,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1100,1100,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1942,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1200,1200,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1943,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1943,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,ha,1944,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,soybeans,tonnes,1944,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-1933-x10-wrong-volume-cells;iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1939,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1940,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1943,iia;juan,czech republic;czechoslovakia,,2000,2000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1938-1945,"tobacco, unmanufactured",ha,1944,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,flax fibre and tow,ha,1945,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,grapes,ha,1945,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hemp tow waste,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hemp tow waste,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hempseed,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hempseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1900,1900,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,hops,ha,1945,iia;juan,czech republic;czechoslovakia,,8300,8300,1.0000,iia-hops-x100;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,oats,ha,1945,iia;juan,czech republic;czechoslovakia,,5.99e+05,5.99e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,oats,tonnes,1945,iia;juan,czech republic;czechoslovakia,,7.242e+05,7.242e+05,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rapeseed,ha,1945,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,rapeseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.48e+04,2.48e+04,1.0000,iia-attributable-single-cell-errors;layerb-nested-reporting-levels-one-polity
-F51-1945-1947,soybeans,ha,1945,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,layerb-nested-reporting-levels-one-polity
-F51-1945-1947,soybeans,tonnes,1945,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,layerb-nested-reporting-levels-one-polity
+F248-1920-1947,"beans, dry",ha,1933,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1934,iia;juan,serbia;yugoslav sfr,,3.5e+04,3.5e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1935,iia;juan,serbia;yugoslav sfr,,3.2e+04,3.2e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1936,iia;juan,serbia;yugoslav sfr,,3.1e+04,3.1e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1937,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1938,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,
+F248-1920-1947,"beans, dry",ha,1939,iia;juan,serbia;yugoslav sfr,,3e+04,3e+04,1.0000,
+F248-1920-1947,castor beans seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,
+F248-1920-1947,cotton lint,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,cotton lint,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,cotton lint,tonnes,1936,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,cotton lint,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,cotton lint,tonnes,1938,iia;juan,serbia;yugoslav sfr,,1200,1200,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,cotton lint,tonnes,1939,iia;juan,serbia;yugoslav sfr,,1100,1100,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,flax fibre and tow,tonnes,1921,iia;juan,serbia;yugoslav sfr,,8260,8260,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1934,iia;juan,serbia;yugoslav sfr,,1.1e+04,1.1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1936,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1937,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1938,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,flax fibre and tow,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F248-1920-1947,grapes,ha,1933,iia;juan,serbia;yugoslav sfr,,1.95e+05,1.95e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1934,iia;juan,serbia;yugoslav sfr,,1.99e+05,1.99e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1935,iia;juan,serbia;yugoslav sfr,,2.07e+05,2.07e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,9.156e+05,9.156e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1936,iia;juan,serbia;yugoslav sfr,,2.14e+05,2.14e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,tonnes,1936,iia;juan,serbia;yugoslav sfr,,6.571e+05,6.571e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1937,iia;juan,serbia;yugoslav sfr,,2.15e+05,2.15e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.826e+05,4.826e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1938,iia;juan,serbia;yugoslav sfr,,2.19e+05,2.19e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,7.94e+05,7.94e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,ha,1939,iia;juan,serbia;yugoslav sfr,,2.23e+05,2.23e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,grapes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7.778e+05,7.778e+05,1.0000,iia-item-series-switch-raw-products
+F248-1920-1947,hemp tow waste,ha,1939,iia;juan,serbia;yugoslav sfr,,5.7e+04,5.7e+04,1.0000,
+F248-1920-1947,hemp tow waste,tonnes,1939,iia;juan,serbia;yugoslav sfr,,5.35e+04,5.35e+04,1.0000,
+F248-1920-1947,hemp tow waste,ha,1940,iia;juan,serbia;yugoslav sfr,,6e+04,6e+04,1.0000,
+F248-1920-1947,hemp tow waste,tonnes,1940,iia;juan,serbia;yugoslav sfr,,4.5e+04,4.5e+04,1.0000,
+F248-1920-1947,hempseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1900,1900,1.0000,
+F248-1920-1947,hempseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,2100,2100,1.0000,
+F248-1920-1947,hempseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2400,2400,1.0000,
+F248-1920-1947,hempseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4500,4500,1.0000,
+F248-1920-1947,hempseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,
+F248-1920-1947,hempseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3100,3100,1.0000,
+F248-1920-1947,hops,ha,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,iia-hops-x100
+F248-1920-1947,lemons and limes,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,lemons and limes,tonnes,1935,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,lemons and limes,tonnes,1937,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,lemons and limes,tonnes,1938,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,lemons and limes,tonnes,1939,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,oats,ha,1939,iia;juan,serbia;yugoslav sfr,,3.57e+05,3.57e+05,1.0000,
+F248-1920-1947,oats,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.483e+05,3.483e+05,1.0000,
+F248-1920-1947,oats,ha,1940,iia;juan,serbia;yugoslav sfr,,3.52e+05,3.52e+05,1.0000,
+F248-1920-1947,oats,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.879e+05,2.879e+05,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1922,iia;juan,serbia;yugoslav sfr,,5780,5780,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1923,iia;juan,serbia;yugoslav sfr,,3180,3180,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1924,iia;juan,serbia;yugoslav sfr,,5140,5140,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1925,iia;juan,serbia;yugoslav sfr,,1370,1370,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1934,iia;juan,serbia;yugoslav sfr,,3900,3900,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1935,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1936,iia;juan,serbia;yugoslav sfr,,2000,2000,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1937,iia;juan,serbia;yugoslav sfr,,7200,7200,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1938,iia;juan,serbia;yugoslav sfr,,6100,6100,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1939,iia;juan,serbia;yugoslav sfr,,5900,5900,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1940,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1941,iia;juan,serbia;yugoslav sfr,,2500,2500,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1942,iia;juan,serbia;yugoslav sfr,,2700,2700,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1943,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1944,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,
+F248-1920-1947,"oil, olive, virgin",tonnes,1945,iia;juan,serbia;yugoslav sfr,,1800,1800,1.0000,
+F248-1920-1947,olives,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.67e+04,1.67e+04,1.0000,
+F248-1920-1947,olives,tonnes,1936,iia;juan,serbia;yugoslav sfr,,1.3e+04,1.3e+04,1.0000,
+F248-1920-1947,olives,tonnes,1937,iia;juan,serbia;yugoslav sfr,,4.83e+04,4.83e+04,1.0000,
+F248-1920-1947,olives,tonnes,1938,iia;juan,serbia;yugoslav sfr,,3.07e+04,3.07e+04,1.0000,
+F248-1920-1947,olives,tonnes,1939,iia;juan,serbia;yugoslav sfr,,3.84e+04,3.84e+04,1.0000,
+F248-1920-1947,oranges,tonnes,1934,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,oranges,tonnes,1935,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,
+F248-1920-1947,oranges,tonnes,1936,iia;juan,serbia;yugoslav sfr,,100,100,1.0000,
+F248-1920-1947,oranges,tonnes,1937,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,
+F248-1920-1947,oranges,tonnes,1938,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,
+F248-1920-1947,oranges,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,
+F248-1920-1947,rapeseed,ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,5400,5400,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1935,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.01e+04,1.01e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1936,iia;juan,serbia;yugoslav sfr,,2.4e+04,2.4e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1937,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,8200,8200,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1938,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,9000,9000,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2900,2900,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rapeseed,tonnes,1941,iia;juan,serbia;yugoslav sfr,,3600,3600,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1920,iia;juan,serbia;yugoslav sfr,,1.547e+05,1.547e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1921,iia;juan,serbia;yugoslav sfr,,1.466e+05,1.466e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1923,iia;juan,serbia;yugoslav sfr,,1.871e+05,1.871e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1923,iia;juan,serbia;yugoslav sfr,,1.5e+05,1.5e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1924,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1924,iia;juan,serbia;yugoslav sfr,,1.408e+05,1.408e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1925,iia;juan,serbia;yugoslav sfr,,1.998e+05,1.998e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1930,iia;juan,serbia;yugoslav sfr,,2.469e+05,2.469e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1930,iia;juan,serbia;yugoslav sfr,,1.988e+05,1.988e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1931,iia;juan,serbia;yugoslav sfr,,1.934e+05,1.934e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1932,iia;juan,serbia;yugoslav sfr,,2.115e+05,2.115e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1934,iia;juan,serbia;yugoslav sfr,,2.48e+05,2.48e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1934,iia;juan,serbia;yugoslav sfr,,1.953e+05,1.953e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1935,iia;juan,serbia;yugoslav sfr,,2.52e+05,2.52e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1.961e+05,1.961e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1936,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1936,iia;juan,serbia;yugoslav sfr,,2.033e+05,2.033e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1937,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1937,iia;juan,serbia;yugoslav sfr,,2.094e+05,2.094e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1938,iia;juan,serbia;yugoslav sfr,,2.54e+05,2.54e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1938,iia;juan,serbia;yugoslav sfr,,2.271e+05,2.271e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1939,iia;juan,serbia;yugoslav sfr,,2.58e+05,2.58e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2.435e+05,2.435e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,ha,1940,iia;juan,serbia;yugoslav sfr,,2.55e+05,2.55e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,rye,tonnes,1940,iia;juan,serbia;yugoslav sfr,,2.111e+05,2.111e+05,1.0000,iia-attributable-single-cell-errors
+F248-1920-1947,sesame seed,ha,1934,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,sesame seed,tonnes,1934,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,
+F248-1920-1947,sesame seed,ha,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,sesame seed,tonnes,1935,iia;juan,serbia;yugoslav sfr,,200,200,1.0000,
+F248-1920-1947,sesame seed,ha,1936,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,sesame seed,tonnes,1936,iia;juan,serbia;yugoslav sfr,,300,300,1.0000,
+F248-1920-1947,sesame seed,ha,1937,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,sesame seed,tonnes,1937,iia;juan,serbia;yugoslav sfr,,400,400,1.0000,
+F248-1920-1947,sesame seed,ha,1938,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,sesame seed,tonnes,1938,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,
+F248-1920-1947,sesame seed,tonnes,1939,iia;juan,serbia;yugoslav sfr,,500,500,1.0000,
+F248-1920-1947,soybeans,tonnes,1934,iia;juan,serbia;yugoslav sfr,,700,700,1.0000,
+F248-1920-1947,soybeans,tonnes,1935,iia;juan,serbia;yugoslav sfr,,1000,1000,1.0000,
+F248-1920-1947,soybeans,tonnes,1936,iia;juan,serbia;yugoslav sfr,,600,600,1.0000,
+F248-1920-1947,soybeans,tonnes,1937,iia;juan,serbia;yugoslav sfr,,1500,1500,1.0000,
+F248-1920-1947,soybeans,ha,1939,iia;juan,serbia;yugoslav sfr,,3000,3000,1.0000,
+F248-1920-1947,soybeans,tonnes,1939,iia;juan,serbia;yugoslav sfr,,2800,2800,1.0000,
+F248-1920-1947,soybeans,ha,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,
+F248-1920-1947,soybeans,tonnes,1940,iia;juan,serbia;yugoslav sfr,,8000,8000,1.0000,
+F248-1920-1947,soybeans,ha,1941,iia;juan,serbia;yugoslav sfr,,1.7e+04,1.7e+04,1.0000,
+F248-1920-1947,sunflower seed,ha,1939,iia;juan,serbia;yugoslav sfr,,1.9e+04,1.9e+04,1.0000,iia-yugoslavia-sunflower-production-x10
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1920,iia;juan,serbia;yugoslav sfr,,7800,7800,1.0000,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1921,iia;juan,serbia;yugoslav sfr,,9327,9327,1.0000,iia-corrupted-country-labels
+F248-1920-1947,"tobacco, unmanufactured",tonnes,1933,iia;juan,serbia;yugoslav sfr,,8751,8751,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1934,iia;juan,serbia;yugoslav sfr,,7000,7000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1935,iia;juan,serbia;yugoslav sfr,,1.2e+04,1.2e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1936,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1937,iia;juan,serbia;yugoslav sfr,,2.1e+04,2.1e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1938,iia;juan,serbia;yugoslav sfr,,1.6e+04,1.6e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1939,iia;juan,serbia;yugoslav sfr,,1.8e+04,1.8e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F248-1920-1947,"tobacco, unmanufactured",ha,1945,iia;juan,serbia;yugoslav sfr,,1.4e+04,1.4e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"beans, dry",ha,1933,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,
+F51-1918-1938,"beans, dry",tonnes,1933,iia;juan,czech republic;czechoslovakia,,6600,6600,1.0000,
+F51-1918-1938,flax fibre and tow,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.028e+04,1.028e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1935,iia;juan,czech republic;czechoslovakia,,1.3e+04,1.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1936,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,flax fibre and tow,ha,1937,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1918-1938,grapes,tonnes,1930,iia;juan,czech republic;czechoslovakia,,7.324e+04,7.324e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,tonnes,1931,iia;juan,czech republic;czechoslovakia,,7.08e+04,7.08e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,ha,1934,iia;juan,czech republic;czechoslovakia,,2.1e+04,2.1e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,ha,1935,iia;juan,czech republic;czechoslovakia,,2.4e+04,2.4e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,ha,1936,iia;juan,czech republic;czechoslovakia,,2.5e+04,2.5e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,grapes,ha,1937,iia;juan,czech republic;czechoslovakia,,2.6e+04,2.6e+04,1.0000,iia-item-series-switch-raw-products
+F51-1918-1938,hempseed,ha,1934,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,
+F51-1918-1938,hempseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,
+F51-1918-1938,hempseed,ha,1935,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,
+F51-1918-1938,hempseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,3900,3900,1.0000,
+F51-1918-1938,hempseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,
+F51-1918-1938,hempseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,3400,3400,1.0000,
+F51-1918-1938,hops,tonnes,1933,iia;juan,czech republic;czechoslovakia,,6268,6268,1.0000,
+F51-1918-1938,rapeseed,tonnes,1920,iia;juan,czech republic;czechoslovakia,,7204,7204,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,ha,1934,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1500,1500,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,ha,1935,iia;juan,czech republic;czechoslovakia,,4000,4000,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,tonnes,1935,iia;juan,czech republic;czechoslovakia,,4800,4800,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,ha,1936,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,tonnes,1936,iia;juan,czech republic;czechoslovakia,,7400,7400,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,ha,1937,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rapeseed,tonnes,1937,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1919,iia;juan,czech republic;czechoslovakia,,8.315e+05,8.315e+05,1.0000,
+F51-1918-1938,rye,ha,1920,iia;juan,czech republic;czechoslovakia,,8.998e+05,8.998e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1920,iia;juan,czech republic;czechoslovakia,,8.368e+05,8.368e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1921,iia;juan,czech republic;czechoslovakia,,8.835e+05,8.835e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1921,iia;juan,czech republic;czechoslovakia,,1.381e+06,1.381e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1922,iia;juan,czech republic;czechoslovakia,,8.797e+05,8.797e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1922,iia;juan,czech republic;czechoslovakia,,1.298e+06,1.298e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1923,iia;juan,czech republic;czechoslovakia,,8.593e+05,8.593e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1923,iia;juan,czech republic;czechoslovakia,,1.355e+06,1.355e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1924,iia;juan,czech republic;czechoslovakia,,8.375e+05,8.375e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1924,iia;juan,czech republic;czechoslovakia,,1.136e+06,1.136e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1925,iia;juan,czech republic;czechoslovakia,,8.46e+05,8.46e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1930,iia;juan,czech republic;czechoslovakia,,1.046e+06,1.046e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1930,iia;juan,czech republic;czechoslovakia,,1.788e+06,1.788e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1931,iia;juan,czech republic;czechoslovakia,,9.996e+05,9.996e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1931,iia;juan,czech republic;czechoslovakia,,1.388e+06,1.388e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1932,iia;juan,czech republic;czechoslovakia,,1.04e+06,1.04e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1932,iia;juan,czech republic;czechoslovakia,,2.176e+06,2.176e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1933,iia;juan,czech republic;czechoslovakia,,2.086e+06,2.086e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1934,iia;juan,czech republic;czechoslovakia,,9.88e+05,9.88e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1934,iia;juan,czech republic;czechoslovakia,,1.523e+06,1.523e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1935,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1935,iia;juan,czech republic;czechoslovakia,,1.638e+06,1.638e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1936,iia;juan,czech republic;czechoslovakia,,1.009e+06,1.009e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1936,iia;juan,czech republic;czechoslovakia,,1.436e+06,1.436e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,ha,1937,iia;juan,czech republic;czechoslovakia,,9.67e+05,9.67e+05,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,rye,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1.485e+06,1.485e+06,1.0000,iia-attributable-single-cell-errors
+F51-1918-1938,soybeans,tonnes,1934,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,
+F51-1918-1938,soybeans,tonnes,1935,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,
+F51-1918-1938,soybeans,tonnes,1936,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,
+F51-1918-1938,soybeans,tonnes,1937,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1920,iia;juan,czech republic;czechoslovakia,,1766,1766,1.0000,iia-corrupted-country-labels
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1921,iia;juan,czech republic;czechoslovakia,,1289,1289,1.0000,iia-corrupted-country-labels
+F51-1918-1938,"tobacco, unmanufactured",ha,1925,iia;juan,czech republic;czechoslovakia,,5400,5400,1.0000,iia-corrupted-country-labels
+F51-1918-1938,"tobacco, unmanufactured",tonnes,1933,iia;juan,czech republic;czechoslovakia,,1.178e+04,1.178e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",ha,1934,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",ha,1935,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",ha,1936,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1918-1938,"tobacco, unmanufactured",ha,1937,iia;juan,czech republic;czechoslovakia,,1e+04,1e+04,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,flax fibre and tow,ha,1938,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,ha,1939,iia;juan,czech republic;czechoslovakia,,2e+04,2e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,ha,1940,iia;juan,czech republic;czechoslovakia,,4.6e+04,4.6e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,ha,1941,iia;juan,czech republic;czechoslovakia,,4.7e+04,4.7e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,ha,1943,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,flax fibre and tow,ha,1944,iia;juan,czech republic;czechoslovakia,,3.4e+04,3.4e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1938-1945,grapes,ha,1938,iia;juan,czech republic;czechoslovakia,,2.7e+04,2.7e+04,1.0000,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,ha,1940,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,ha,1943,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products
+F51-1938-1945,grapes,ha,1944,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products
+F51-1938-1945,hemp tow waste,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1939,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,
+F51-1938-1945,hemp tow waste,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3800,3800,1.0000,
+F51-1938-1945,hemp tow waste,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1941,iia;juan,czech republic;czechoslovakia,,4100,4100,1.0000,
+F51-1938-1945,hemp tow waste,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1942,iia;juan,czech republic;czechoslovakia,,3500,3500,1.0000,
+F51-1938-1945,hemp tow waste,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1943,iia;juan,czech republic;czechoslovakia,,4900,4900,1.0000,
+F51-1938-1945,hemp tow waste,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hemp tow waste,tonnes,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,2600,2600,1.0000,
+F51-1938-1945,hempseed,ha,1940,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,2400,2400,1.0000,
+F51-1938-1945,hempseed,ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2700,2700,1.0000,
+F51-1938-1945,hempseed,ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,2500,2500,1.0000,
+F51-1938-1945,hempseed,ha,1943,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,
+F51-1938-1945,hempseed,ha,1944,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,
+F51-1938-1945,hempseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,
+F51-1938-1945,hops,ha,1939,iia;juan,czech republic;czechoslovakia,,1.05e+04,1.05e+04,1.0000,iia-hops-x100
+F51-1938-1945,hops,ha,1940,iia;juan,czech republic;czechoslovakia,,8900,8900,1.0000,iia-hops-x100
+F51-1938-1945,hops,ha,1941,iia;juan,czech republic;czechoslovakia,,7500,7500,1.0000,iia-hops-x100
+F51-1938-1945,hops,ha,1942,iia;juan,czech republic;czechoslovakia,,7300,7300,1.0000,iia-hops-x100
+F51-1938-1945,hops,ha,1943,iia;juan,czech republic;czechoslovakia,,6300,6300,1.0000,iia-hops-x100
+F51-1938-1945,hops,ha,1944,iia;juan,czech republic;czechoslovakia,,7000,7000,1.0000,iia-hops-x100
+F51-1938-1945,oats,ha,1939,iia;juan,czech republic;czechoslovakia,,7.06e+05,7.06e+05,1.0000,
+F51-1938-1945,oats,tonnes,1939,iia;juan,czech republic;czechoslovakia,,1.265e+06,1.265e+06,1.0000,
+F51-1938-1945,oats,ha,1940,iia;juan,czech republic;czechoslovakia,,7.99e+05,7.99e+05,1.0000,
+F51-1938-1945,oats,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1.277e+06,1.277e+06,1.0000,
+F51-1938-1945,oats,ha,1941,iia;juan,czech republic;czechoslovakia,,6.55e+05,6.55e+05,1.0000,
+F51-1938-1945,oats,tonnes,1941,iia;juan,czech republic;czechoslovakia,,8.443e+05,8.443e+05,1.0000,
+F51-1938-1945,oats,ha,1942,iia;juan,czech republic;czechoslovakia,,6.36e+05,6.36e+05,1.0000,
+F51-1938-1945,oats,tonnes,1942,iia;juan,czech republic;czechoslovakia,,9.863e+05,9.863e+05,1.0000,
+F51-1938-1945,oats,ha,1943,iia;juan,czech republic;czechoslovakia,,6.02e+05,6.02e+05,1.0000,
+F51-1938-1945,oats,tonnes,1943,iia;juan,czech republic;czechoslovakia,,9.65e+05,9.65e+05,1.0000,
+F51-1938-1945,oats,ha,1944,iia;juan,czech republic;czechoslovakia,,5.72e+05,5.72e+05,1.0000,
+F51-1938-1945,oats,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.44e+05,7.44e+05,1.0000,
+F51-1938-1945,rapeseed,ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.32e+04,1.32e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1939,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1939,iia;juan,czech republic;czechoslovakia,,7200,7200,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1940,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1940,iia;juan,czech republic;czechoslovakia,,3700,3700,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1941,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1941,iia;juan,czech republic;czechoslovakia,,2.01e+04,2.01e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1942,iia;juan,czech republic;czechoslovakia,,1.5e+04,1.5e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1.85e+04,1.85e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1943,iia;juan,czech republic;czechoslovakia,,3.6e+04,3.6e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1943,iia;juan,czech republic;czechoslovakia,,3.72e+04,3.72e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,ha,1944,iia;juan,czech republic;czechoslovakia,,6.1e+04,6.1e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rapeseed,tonnes,1944,iia;juan,czech republic;czechoslovakia,,7.28e+04,7.28e+04,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rye,ha,1938,iia;juan,czech republic;czechoslovakia,,1.016e+06,1.016e+06,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rye,tonnes,1938,iia;juan,czech republic;czechoslovakia,,1.906e+06,1.906e+06,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rye,tonnes,1940,iia;juan,czech republic;czechoslovakia,,8.67e+05,8.67e+05,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rye,ha,1942,iia;juan,czech republic;czechoslovakia,,8.61e+05,8.61e+05,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,rye,ha,1944,iia;juan,czech republic;czechoslovakia,,9.15e+05,9.15e+05,1.0000,iia-attributable-single-cell-errors
+F51-1938-1945,soybeans,ha,1939,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1939,iia;juan,czech republic;czechoslovakia,,900,900,1.0000,
+F51-1938-1945,soybeans,ha,1940,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1940,iia;juan,czech republic;czechoslovakia,,1100,1100,1.0000,
+F51-1938-1945,soybeans,ha,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1941,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,ha,1942,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1942,iia;juan,czech republic;czechoslovakia,,1200,1200,1.0000,
+F51-1938-1945,soybeans,ha,1943,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1943,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,
+F51-1938-1945,soybeans,ha,1944,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1938-1945,soybeans,tonnes,1944,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,
+F51-1938-1945,"tobacco, unmanufactured",ha,1938,iia;juan,czech republic;czechoslovakia,,9000,9000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1939,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1940,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1941,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1942,iia;juan,czech republic;czechoslovakia,,5000,5000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1943,iia;juan,czech republic;czechoslovakia,,2000,2000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1938-1945,"tobacco, unmanufactured",ha,1944,iia;juan,czech republic;czechoslovakia,,3000,3000,1.0000,iia-corrupted-country-labels;iia-tobacco-implausible-magnitudes
+F51-1945-1947,flax fibre and tow,ha,1945,iia;juan,czech republic;czechoslovakia,,1.9e+04,1.9e+04,1.0000,iia-attributable-single-cell-errors;iia-flax-fibre-item-is-mostly-linseed
+F51-1945-1947,grapes,ha,1945,iia;juan,czech republic;czechoslovakia,,1.6e+04,1.6e+04,1.0000,iia-item-series-switch-raw-products
+F51-1945-1947,hemp tow waste,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,
+F51-1945-1947,hemp tow waste,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2300,2300,1.0000,
+F51-1945-1947,hempseed,ha,1945,iia;juan,czech republic;czechoslovakia,,6000,6000,1.0000,
+F51-1945-1947,hempseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,1900,1900,1.0000,
+F51-1945-1947,hops,ha,1945,iia;juan,czech republic;czechoslovakia,,8300,8300,1.0000,iia-hops-x100
+F51-1945-1947,oats,ha,1945,iia;juan,czech republic;czechoslovakia,,5.99e+05,5.99e+05,1.0000,
+F51-1945-1947,oats,tonnes,1945,iia;juan,czech republic;czechoslovakia,,7.242e+05,7.242e+05,1.0000,
+F51-1945-1947,rapeseed,ha,1945,iia;juan,czech republic;czechoslovakia,,3.3e+04,3.3e+04,1.0000,iia-attributable-single-cell-errors
+F51-1945-1947,rapeseed,tonnes,1945,iia;juan,czech republic;czechoslovakia,,2.48e+04,2.48e+04,1.0000,iia-attributable-single-cell-errors
+F51-1945-1947,soybeans,ha,1945,iia;juan,czech republic;czechoslovakia,,1000,1000,1.0000,
+F51-1945-1947,soybeans,tonnes,1945,iia;juan,czech republic;czechoslovakia,,600,600,1.0000,
 SER-1878-1913,hemp tow waste,ha,1909,iia;juan,serbia;yugoslav sfr,,1.5e+04,1.5e+04,1.0000,layerb-nested-reporting-levels-one-polity

--- a/scripts/selftest_gates.py
+++ b/scripts/selftest_gates.py
@@ -5051,6 +5051,40 @@ def mutate_data_errors_entry_uncovered(root, gpd, make_valid, affinity):
         w.writerows(rows)
     return "data_errors.csv now carries an entry that no re-test in 35_retest_data_errors.py covers"
 
+def mutate_crosssource_one_entry_absorbs_all(root, gpd, make_valid, affinity):
+    """Attribute every cross-source cell to one registry entry, making the zero ceiling unreachable.
+
+    `BASELINE_UNEXPLAINED = 0` is only a check if some cell CAN be unexplained. Until issue 635 none
+    could: `coverage()` ignored the registry's `polity_code` column, so an entry declaring 17 codes
+    with `commodity = (all)` and a placeholder label matched 804 of 804 cells. The arm had never
+    convicted anything, and it was masking 8 real disagreements at 10-14x -- czech `beans, dry` x7
+    (the yearbooks print two series and layer B keeps one) and yugoslav `sunflower seed` (production
+    x10 on an area both sources agree on), both since registered.
+
+    The mutation rewrites only `known_defect`, setting every cell to that one entry. Every other
+    column is untouched, every citation still resolves, every ratio still matches its own values,
+    and no cell becomes unexplained -- so arms A-E stay green and the table looks better attributed,
+    not worse. That is the shape of the original defect: each individual attribution was defensible
+    and the aggregate made the gate blind.
+    """
+    import csv as _csv
+
+    path = os.path.join(root, "pipelines/polity-autoimprove/state/cross_source_agreement.csv")
+    with open(path, newline="", encoding="utf-8") as fh:
+        rows = list(_csv.DictReader(fh))
+    if not rows:
+        raise AssertionError("cross_source_agreement.csv is empty, so this mutation would do nothing")
+    ids = sorted({i for r in rows for i in r["known_defect"].split(";") if i})
+    if not ids:
+        raise AssertionError("no cell carries a known_defect, so there is no entry to widen")
+    for r in rows:
+        r["known_defect"] = ids[0]
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    return f"every cross-source cell is now attributed to {ids[0]!r}, so nothing can be unexplained"
+
 CASES = (
     (
         "validate_composition_sums.py",
@@ -6111,6 +6145,14 @@ CASES = (
         "a defect-registry entry covered by no re-test, so the adjudication it records is a claim "
         "with nothing behind it -- invisible to CI, because the suite that would re-measure it "
         "needs the gitignored layer-B panel and runs by hand",
+    ),
+    (
+        "validate_cross_source_agreement.py",
+        mutate_crosssource_one_entry_absorbs_all,
+        "attributed to ALL",
+        "one registry entry attributed to every cross-source cell, so the zero ceiling on "
+        "unexplained disagreements cannot be exceeded by anything -- the gate reads as fully "
+        "explained while being unable to convict, which is how it hid 8 real defects",
     ),
 )
 

--- a/scripts/validate_cross_source_agreement.py
+++ b/scripts/validate_cross_source_agreement.py
@@ -20,9 +20,25 @@ any of them -- every other check compares a series against itself, its neighbour
 
 NO REGENERATION CHECK, deliberately: the table is built from layer B, which is absent in CI, so a
 `--check` could only compare nothing and report OK (issue 573). This gate reads the committed table.
+
+AND THE CEILING ABOVE IS ONLY A CHECK IF SOME CELL CAN BE UNEXPLAINED (arm F, issue 635). Until
+2026-09-01 none could. `coverage()` in 39_cross_source_agreement.py ignored the registry's
+`polity_code` column, so `layerb-nested-reporting-levels-one-polity` -- seventeen declared codes,
+`commodity = (all)`, a placeholder label, all four sources, years 1909-1960 -- was attributed to 804
+of 804 cells. The zero ceiling could not be exceeded by anything, and it was masking eight real
+disagreements at 10-14x on polities absent from that entry's own list. Both are registered now
+(#636): czech `beans, dry` x7, where the yearbooks print TWO series per year and layer B keeps the
+smaller while juan carries their sum; and yugoslav `sunflower seed`, where both sources carry the
+same 19,000 ha and iia's production implies 0.10 t/ha against juan's 0.63-1.44.
+
+`coverage()` now honours `polity_code` -- attribution narrowed from 804 to 570 of 804 cells, widest
+entry 227 -- and arm F forbids any entry being attributed to ALL cells. That arm exists because the
+failure is invisible per-cell: every individual attribution looked defensible, and only the aggregate
+blinded the gate. An entry that should cover broadly leaves `polity_code` blank.
 """
 from __future__ import annotations
 
+import collections
 import csv
 import os
 import sys
@@ -100,6 +116,30 @@ def main() -> int:
             f"because several labels route to one polity, so it SHRINKS when a reroute separates "
             f"them -- which may be correct, but it removes the only place two publishers are "
             f"comparable and should be a deliberate act")
+    # ARM F -- THE CEILING MUST BE REACHABLE (issue 635). BASELINE_UNEXPLAINED = 0 above is only a
+    # check if some cell CAN be unexplained. It could not be: `coverage()` ignored the registry's
+    # `polity_code` column, so one entry with 17 declared codes, `commodity = (all)` and a
+    # placeholder label matched 804 of 804 cells and pre-absorbed everything. The arm had never been
+    # able to convict, and it was masking 8 real disagreements at 10-14x (both since registered,
+    # #636). Fixed in 39_cross_source_agreement.py by honouring polity_code; this arm is what stops
+    # it coming back, because the failure is invisible from any per-cell test -- every individual
+    # attribution looked defensible.
+    absorbed = collections.Counter()
+    for r in rows:
+        for issue_id in filter(None, r["known_defect"].split(";")):
+            absorbed[issue_id] += 1
+    universal = sorted(i for i, n in absorbed.items() if n == len(rows))
+    if rows and universal:
+        problems.append(
+            f"entry/entries {universal} are attributed to ALL {len(rows)} cells, so no cell can ever "
+            f"appear as unexplained and the ceiling of {BASELINE_UNEXPLAINED} above cannot be "
+            f"exceeded by anything. An entry that covers everything explains nothing. Scope it with "
+            f"`polity_code`, `commodity` or `label` in data_errors.csv -- see issue 635, where this "
+            f"state hid 8 disagreements at 10-14x.")
+    print(f"  attribution: {sum(1 for r in rows if r['known_defect'])} of {len(rows)} cells carry a "
+          f"recorded defect; widest entry covers "
+          f"{max(absorbed.values()) if absorbed else 0} of {len(rows)}")
+
     if len(unexplained) > BASELINE_UNEXPLAINED:
         for r in unexplained[:8]:
             print(f"   UNEXPLAINED {r['polity_code']:16}{r['item'][:22]:24}{r['unit'][:8]:10}"


### PR DESCRIPTION
Fixes #635. Lands green because #636 registered the eight cells this was masking.

## The defect

`BASELINE_UNEXPLAINED = 0`, commented *"reachable today; a new one is a finding"*, was not reachable. `coverage()` matched an entry to a cell on **source, year, commodity and label** — and never read `polity_code`. So `layerb-nested-reporting-levels-one-polity`, which **declares seventeen codes** but carries `commodity = (all)`, a placeholder label, all four sources and years 1909–1960, was attributed to **804 of 804** cells.

The arm could never convict anything, and it absorbed 8 real disagreements at 10–14× on polities absent from that entry's own list.

## The fix

The entries already carry the right data; only the matcher ignored it. Declaring codes is what opts an entry into being scoped — an entry that should cover broadly leaves `polity_code` blank.

Regenerated, and only one column moved:

```
rows                        804 -> 804
columns changed             ['known_defect']
cells with an attribution   804 -> 570
>=10x with no attribution     0 ->   0      the gate still passes
widest single entry                227 of 804
```

## Arm F, and why it is needed

The fix alone would not stop this recurring, so arm F pins the reachability directly: **no entry may be attributed to all cells.**

That arm earns its place because the failure is invisible from every per-cell test. Each individual attribution looked defensible, every citation resolved, every ratio matched its own two values, and no cell was unexplained. Only the aggregate was wrong. Its selftest case mutates the table so one entry absorbs everything — which leaves arms A–E green and makes the table look *better* attributed, not worse:

```
mutation: every cross-source cell attributed to one entry
result:   exit=1, names "attributed to ALL 804 cells"
```

## What the whole exercise showed about the arm

It earns its keep. Two genuine defects sat in that table for as long as the arm has existed, and neither is reachable by any other check here — one needed the raw extract to see that the yearbooks print two Czechoslovak bean series and layer B keeps the smaller, the other needed a paired axis plus an agronomic bound to show a ×10 in Yugoslav sunflower production. That is exactly what the docstring claims the arm is for, and it had never been able to say it.

91 gates pass, selftest case 148 passes, `35_retest_data_errors.py` and `11_retest_conventions.py` both exit 0.

Created by Claude.